### PR TITLE
span enrichment

### DIFF
--- a/src/honeyhive/tracer/__init__.py
+++ b/src/honeyhive/tracer/__init__.py
@@ -31,6 +31,7 @@ class HoneyHiveTracer:
                 HoneyHiveTracer._is_traceloop_initialized = True
             Traceloop.set_association_properties({"session_id": session_id})
             HoneyHiveTracer.session_id = session_id
+            HoneyHiveTracer.api_key = api_key
         except:
             pass
 

--- a/src/honeyhive/tracer/__init__.py
+++ b/src/honeyhive/tracer/__init__.py
@@ -7,6 +7,8 @@ from traceloop.sdk import Traceloop
 
 class HoneyHiveTracer:
     _is_traceloop_initialized = False
+    session_id = None
+    api_key = None
 
     @staticmethod
     def init(
@@ -28,6 +30,7 @@ class HoneyHiveTracer:
                 )
                 HoneyHiveTracer._is_traceloop_initialized = True
             Traceloop.set_association_properties({"session_id": session_id})
+            HoneyHiveTracer.session_id = session_id
         except:
             pass
 
@@ -45,3 +48,51 @@ class HoneyHiveTracer:
         )
         assert res.object.session_id is not None
         return res.object.session_id
+
+    @staticmethod
+    def set_feedback(feedback):
+        if HoneyHiveTracer.session_id is None:
+            raise Exception("HoneyHiveTracer is not initialized")
+        session_id = HoneyHiveTracer.session_id
+        try:
+            sdk = honeyhive.HoneyHive(HoneyHiveTracer.api_key)
+            sdk.events.update_event(
+                request=operations.UpdateEventRequestBody(
+                    event_id=session_id,
+                    feedback=feedback
+                )
+            )
+        except:
+            pass
+
+    @staticmethod
+    def set_evaluator(metrics):
+        if HoneyHiveTracer.session_id is None:
+            raise Exception("HoneyHiveTracer is not initialized")
+        session_id = HoneyHiveTracer.session_id
+        try:
+            sdk = honeyhive.HoneyHive(HoneyHiveTracer.api_key)
+            sdk.events.update_event(
+                request=operations.UpdateEventRequestBody(
+                    event_id=session_id,
+                    metrics=metrics
+                )
+            )
+        except:
+            pass
+
+    @staticmethod
+    def set_metadata(metadata):
+        if HoneyHiveTracer.session_id is None:
+            raise Exception("HoneyHiveTracer is not initialized")
+        session_id = HoneyHiveTracer.session_id
+        try:
+            sdk = honeyhive.HoneyHive(HoneyHiveTracer.api_key)
+            sdk.events.update_event(
+                request=operations.UpdateEventRequestBody(
+                    event_id=session_id,
+                    metadata=metadata
+                )
+            )
+        except:
+            pass


### PR DESCRIPTION
### Description

- added basic functionality to track session id and api key on the Tracer Singleton
- created the necessary functions for `metadata`, `feedback` and `metrics`

### Testing

Ran `tracer.set_feedback({ "liked": True })` after an auto-instrumented OpenAI call.

