### PR TITLE
Simple logging functionality

### DIFF
--- a/src/honeyhive/__init__.py
+++ b/src/honeyhive/__init__.py
@@ -2,7 +2,7 @@
 
 from .sdk import *
 from .sdkconfiguration import *
-from .tracer import HoneyHiveTracer, enrich_session
+from .tracer import HoneyHiveTracer, enrich_session, start_session, log
 from .tracer.custom import trace, atrace, enrich_span
 from .evaluation import evaluate, evaluator, aevaluator
 from .utils.dotdict import dotdict
@@ -14,6 +14,8 @@ __all__ = [
     "trace",
     "atrace",
     "enrich_span",
+    "start_session",
+    "log",
     "evaluate",
     "evaluator",
     "aevaluator",

--- a/src/honeyhive/tracer/__init__.py
+++ b/src/honeyhive/tracer/__init__.py
@@ -642,6 +642,8 @@ def start_session(
         if capture_git_info:
             git_info = HoneyHiveTracer._get_git_info()
             if "error" not in git_info:
+                if metadata is None:
+                    metadata = {}
                 metadata = {**metadata, **git_info}
         
         # Validate session_id if provided

--- a/src/honeyhive/tracer/__init__.py
+++ b/src/honeyhive/tracer/__init__.py
@@ -259,6 +259,46 @@ class HoneyHiveTracer:
     def _validate_server_url(server_url):
         return server_url and type(server_url) == str
     
+    @staticmethod
+    def _validate_project(project):
+        return project and type(project) == str
+    
+    @staticmethod
+    def _validate_source(source):
+        return source and type(source) == str
+    
+    @staticmethod
+    def _get_validated_api_key(api_key=None):
+        if api_key is None:
+            api_key = os.getenv("HH_API_KEY")
+        if not HoneyHiveTracer._validate_api_key(api_key):
+            raise Exception("api_key must be specified or set in environment variable HH_API_KEY.")
+        return api_key
+    
+    @staticmethod
+    def _get_validated_server_url(server_url=None):
+        if server_url is None or server_url == 'https://api.honeyhive.ai':
+            server_url = os.getenv("HH_API_URL", 'https://api.honeyhive.ai')
+        if not HoneyHiveTracer._validate_server_url(server_url):
+            raise Exception("server_url must be a valid URL string.")
+        return server_url
+    
+    @staticmethod
+    def _get_validated_project(project=None):
+        if project is None:
+            project = os.getenv("HH_PROJECT")
+        if not HoneyHiveTracer._validate_project(project):
+            raise Exception("project must be specified or set in environment variable HH_PROJECT.")
+        return project
+    
+    @staticmethod
+    def _get_validated_source(source=None):
+        if source is None:
+            source = os.getenv("HH_SOURCE", "dev")
+        if not HoneyHiveTracer._validate_source(source):
+            raise Exception("source must be a non-empty string.")
+        return source
+    
     def session_start(self) -> str:
         """Start a session using the tracer's parameters"""
         self.session_id = HoneyHiveTracer.__start_session(
@@ -620,24 +660,11 @@ def start_session(
         '123e4567-e89b-12d3-a456-426614174000'
     """
     try:
-        # Get server URL from env if not provided
-        if server_url == 'https://api.honeyhive.ai':
-            server_url = os.getenv("HH_API_URL", server_url)
-        
-        if api_key is None:
-            api_key = os.getenv("HH_API_KEY")
-            if api_key is None:
-                raise Exception("api_key must be specified or set in environment variable HH_API_KEY.")
-        
-        # Get project from env if not provided
-        if project is None:
-            project = os.getenv("HH_PROJECT")
-            if project is None:
-                raise Exception("project must be specified or set in environment variable HH_PROJECT.")
-        
-        # Get source from env if not provided
-        if source is None:
-            source = os.getenv("HH_SOURCE", "dev")   
+        # Validate and get required parameters
+        api_key = HoneyHiveTracer._get_validated_api_key(api_key)
+        server_url = HoneyHiveTracer._get_validated_server_url(server_url)
+        project = HoneyHiveTracer._get_validated_project(project)
+        source = HoneyHiveTracer._get_validated_source(source)
 
         if capture_git_info:
             git_info = HoneyHiveTracer._get_git_info()
@@ -730,21 +757,11 @@ def log(
         '123e4567-e89b-12d3-a456-426614174000'
     """
     try:
-        # Get server URL from env if not provided
-        if server_url == 'https://api.honeyhive.ai':
-            server_url = os.getenv("HH_API_URL", server_url)
-        
-        # Get API key from env if not provided
-        if api_key is None:
-            api_key = os.getenv("HH_API_KEY")
-            if api_key is None:
-                raise Exception("api_key must be specified or set in environment variable HH_API_KEY.")
-        
-        # Get project from env if not provided
-        if project is None:
-            project = os.getenv("HH_PROJECT")
-            if project is None:
-                raise Exception("project must be specified or set in environment variable HH_PROJECT.")
+        # Validate and get required parameters
+        api_key = HoneyHiveTracer._get_validated_api_key(api_key)
+        server_url = HoneyHiveTracer._get_validated_server_url(server_url)
+        project = HoneyHiveTracer._get_validated_project(project)
+        source = HoneyHiveTracer._get_validated_source(source)
         
         # Validate session_id
         if session_id is not None:
@@ -759,9 +776,6 @@ def log(
         if event_type not in ["tool", "model", "chain"]:
             raise Exception("event_type must be one of: tool, model, chain")
         
-        if not source:
-            source = os.getenv("HH_SOURCE", "dev")
-
         if not duration:
             duration = 10
         

--- a/src/honeyhive/tracer/__init__.py
+++ b/src/honeyhive/tracer/__init__.py
@@ -688,6 +688,7 @@ def log(
     config: dict = None,
     inputs: dict = None,
     outputs: dict = None,
+    duration: int = None,
     metadata: dict = None,
     feedback: dict = None,
     metrics: dict = None,
@@ -708,6 +709,7 @@ def log(
         config (dict, optional): Configuration for the event.
         inputs (dict, optional): Input parameters for the event.
         outputs (dict, optional): Output results from the event.
+        duration (int, optional): Duration of the event in milliseconds.
         metadata (dict, optional): Additional metadata for the event.
         feedback (dict, optional): Feedback data for the event.
         metrics (dict, optional): Metrics data for the event.
@@ -757,6 +759,9 @@ def log(
         
         if not source:
             source = os.getenv("HH_SOURCE", "dev")
+
+        if not duration:
+            duration = 10
         
         # Create the event using the SDK
         sdk = HoneyHive(bearer_auth=api_key, server_url=server_url)
@@ -771,6 +776,7 @@ def log(
                     config=config or {},
                     inputs=inputs or {},
                     outputs=outputs or {},
+                    duration=duration,
                     metadata=metadata or {},
                     feedback=feedback or {},
                     metrics=metrics or {},

--- a/src/honeyhive/tracer/__init__.py
+++ b/src/honeyhive/tracer/__init__.py
@@ -552,3 +552,238 @@ def enrich_session(
             print_exc()
         else:
             pass
+
+def validate_uuidv4(guid: str) -> str:
+    """
+    Validate if the input is a valid UUIDv4.
+    
+    Args:
+        guid (str): A string representing a UUID to validate
+        
+    Returns:
+        str: The lowercase UUID string if valid
+        
+    Raises:
+        ValueError: If the input is not a valid UUIDv4
+        
+    Examples:
+        >>> validate_uuidv4("123e4567-e89b-12d3-a456-426614174000")
+        '123e4567-e89b-12d3-a456-426614174000'
+    """
+    try:
+        uuid_obj = uuid.UUID(guid)
+        # Check if it's version 4
+        if uuid_obj.version != 4:
+            raise ValueError("UUID must be version 4")
+        # Return lowercase string
+        return str(uuid_obj).lower()
+    except ValueError as e:
+        raise ValueError(f"Invalid UUIDv4: {str(e)}. Please provide a valid UUIDv4.")
+
+def start_session(
+    api_key: str = None,
+    project: str = None,
+    source: str = None,
+    config: dict = None,
+    inputs: dict = None,
+    metadata: dict = None,
+    user_properties: dict = None,
+    session_id: str = None,
+    capture_git_info: bool = False,
+    session_name: str = "unknown",
+    server_url: str = 'https://api.honeyhive.ai',
+    verbose: bool = False
+) -> str:
+    """
+    Start a new session with HoneyHive.
+    
+    Args:
+        api_key (str, optional): Your HoneyHive API key. Must be provided or set via HH_API_KEY env var.
+        project (str, optional): The project name. Must be provided or set via HH_PROJECT env var.
+        session_name (str, optional): Name for this session. Defaults to script name.
+        source (str, optional): Source of the session. Defaults to "dev" or HH_SOURCE env var.
+        config (dict, optional): Configuration for the session.
+        inputs (dict, optional): Input parameters for the session.
+        metadata (dict, optional): Additional metadata for the session.
+        user_properties (dict, optional): User-defined properties for the session.
+        session_id (str, optional): A valid UUIDv4 for the session. If not provided, one will be generated.
+        server_url (str, optional): HoneyHive API server URL. Defaults to "https://api.honeyhive.ai" or HH_API_URL env var.
+        
+    Returns:
+        str: The session ID (UUIDv4)
+        
+    Raises:
+        Exception: If required parameters are missing or invalid
+        
+    Examples:
+        >>> start_session(api_key="your-api-key", project="my-project")
+        '123e4567-e89b-12d3-a456-426614174000'
+    """
+    try:
+        # Get server URL from env if not provided
+        if server_url == 'https://api.honeyhive.ai':
+            server_url = os.getenv("HH_API_URL", server_url)
+        
+        if api_key is None:
+            api_key = os.getenv("HH_API_KEY")
+            if api_key is None:
+                raise Exception("api_key must be specified or set in environment variable HH_API_KEY.")
+        
+        # Get project from env if not provided
+        if project is None:
+            project = os.getenv("HH_PROJECT")
+            if project is None:
+                raise Exception("project must be specified or set in environment variable HH_PROJECT.")
+        
+        # Get source from env if not provided
+        if source is None:
+            source = os.getenv("HH_SOURCE", "dev")   
+
+        if capture_git_info:
+            git_info = HoneyHiveTracer._get_git_info()
+            if "error" not in git_info:
+                metadata = {**metadata, **git_info}
+        
+        # Validate session_id if provided
+        if session_id is not None:
+            try:
+                session_id = validate_uuidv4(session_id)
+            except ValueError as e:
+                raise Exception(f"Invalid session_id: {str(e)}")
+        
+        # Start the session using the SDK
+        sdk = HoneyHive(bearer_auth=api_key, server_url=server_url)
+        res = sdk.session.start_session(
+            request=operations.StartSessionRequestBody(
+                session=components.SessionStartRequest(
+                    project=project,
+                    session_name=session_name,
+                    session_id=session_id,
+                    source=source,
+                    inputs=inputs or {},
+                    metadata=metadata or {},
+                    config=config or {},
+                    user_properties=user_properties or {}
+                )
+            )
+        )
+        
+        if res.status_code != 200:
+            raise Exception(f"Failed to start session: {res.raw_response.text}")
+        if res.object.session_id is None:
+            raise Exception("Failure initializing session")
+            
+        return res.object.session_id
+    except Exception as e:
+        print(f"Error starting session: {str(e)}")
+        if verbose:
+            print_exc()
+
+def log(
+    api_key: str = None,
+    project: str = None,
+    session_id: str = None,
+    event_name: str = None,
+    source: str = None,
+    config: dict = None,
+    inputs: dict = None,
+    outputs: dict = None,
+    metadata: dict = None,
+    feedback: dict = None,
+    metrics: dict = None,
+    user_properties: dict = None,
+    event_type: str = "tool",
+    server_url: str = 'https://api.honeyhive.ai',
+    verbose: bool = False
+) -> str:
+    """
+    Log an event to HoneyHive.
+    
+    Args:
+        event_name (str): Name of the event to log.
+        api_key (str, optional): Your HoneyHive API key. Must be provided or set via HH_API_KEY env var.
+        project (str, optional): The project name. Must be provided or set via HH_PROJECT env var.
+        session_id (str, optional): A valid UUIDv4 for the session.
+        source (str, optional): Source of the event. Defaults to "dev" or HH_SOURCE env var.
+        config (dict, optional): Configuration for the event.
+        inputs (dict, optional): Input parameters for the event.
+        outputs (dict, optional): Output results from the event.
+        metadata (dict, optional): Additional metadata for the event.
+        feedback (dict, optional): Feedback data for the event.
+        metrics (dict, optional): Metrics data for the event.
+        user_properties (dict, optional): User-defined properties for the event.
+        event_type (str, optional): Type of event. Must be one of: "tool", "model", "chain". Defaults to "tool".
+        server_url (str, optional): HoneyHive API server URL. Defaults to "https://api.honeyhive.ai" or HH_API_URL env var.
+        
+    Returns:
+        str: The event ID
+        
+    Raises:
+        Exception: If required parameters are missing or invalid
+        
+    Examples:
+        >>> log(session_id="123e4567-e89b-12d3-a456-426614174000", event_name="my-event")
+        '123e4567-e89b-12d3-a456-426614174000'
+    """
+    try:
+        # Get server URL from env if not provided
+        if server_url == 'https://api.honeyhive.ai':
+            server_url = os.getenv("HH_API_URL", server_url)
+        
+        # Get API key from env if not provided
+        if api_key is None:
+            api_key = os.getenv("HH_API_KEY")
+            if api_key is None:
+                raise Exception("api_key must be specified or set in environment variable HH_API_KEY.")
+        
+        # Get project from env if not provided
+        if project is None:
+            project = os.getenv("HH_PROJECT")
+            if project is None:
+                raise Exception("project must be specified or set in environment variable HH_PROJECT.")
+        
+        # Validate session_id
+        if session_id is not None:
+            try:
+                session_id = validate_uuidv4(session_id)
+            except ValueError as e:
+                raise Exception(f"Invalid session_id: {str(e)}")
+        
+        if not event_name:
+            raise Exception("event_name is required")
+        
+        if event_type not in ["tool", "model", "chain"]:
+            raise Exception("event_type must be one of: tool, model, chain")
+        
+        if not source:
+            source = os.getenv("HH_SOURCE", "dev")
+        
+        # Create the event using the SDK
+        sdk = HoneyHive(bearer_auth=api_key, server_url=server_url)
+        res = sdk.events.create_event(
+            request=operations.CreateEventRequestBody(
+                event=components.CreateEventRequest(
+                    session_id=session_id,
+                    project=project,
+                    source=source,
+                    event_name=event_name,
+                    event_type=event_type,
+                    config=config or {},
+                    inputs=inputs or {},
+                    outputs=outputs or {},
+                    metadata=metadata or {},
+                    feedback=feedback or {},
+                    metrics=metrics or {},
+                    user_properties=user_properties or {}
+                )
+            )
+        )
+        
+        if res.status_code != 200:
+            raise Exception(f"Failed to log event: {res.raw_response.text}")
+            
+        return res.object.event_id
+    except Exception as e:
+        print(f"Error logging event: {str(e)}")
+        if verbose:
+            print_exc()

--- a/tests/logger/test_logger.py
+++ b/tests/logger/test_logger.py
@@ -28,7 +28,7 @@ def test_start_session():
     res = sdk.session.get_session(session_id=session_id)
     assert res.event is not None
     assert res.event.session_id == session_id
-    assert res.event.project == os.environ["HH_PROJECT"]
+    assert res.event.project_id is not None
     assert res.event.source == "sdk_test"
 
 def test_start_session_with_metadata():
@@ -51,7 +51,9 @@ def test_start_session_with_metadata():
     sdk = honeyhive.HoneyHive(bearer_auth=os.environ["HH_API_KEY"], server_url=os.environ["HH_API_URL"])
     res = sdk.session.get_session(session_id=session_id)
     assert res.event is not None
-    assert res.event.metadata == metadata
+    assert res.event.metadata is not None
+    assert res.event.metadata.get("test_key") == "test_value"
+    assert res.event.metadata.get("version") == "1.0.0"
 
 def test_log_event():
     # First start a session
@@ -76,11 +78,12 @@ def test_log_event():
         inputs=inputs,
         outputs=outputs,
         metadata=metadata,
-        server_url=os.environ["HH_API_URL"]
+        server_url=os.environ["HH_API_URL"],
+        verbose=True
     )
     
     # Wait for event to be processed
-    time.sleep(5)
+    time.sleep(10)
     
     # Verify event was logged correctly
     sdk = honeyhive.HoneyHive(bearer_auth=os.environ["HH_API_KEY"], server_url=os.environ["HH_API_URL"])
@@ -100,9 +103,9 @@ def test_log_event():
     assert len(res.object.events) == 1
     event = res.object.events[0]
     assert event.event_name == event_name
-    assert event.inputs == inputs
-    assert event.outputs == outputs
-    assert event.metadata == metadata
+    assert event.inputs.get("query") == inputs["query"]
+    assert event.outputs.get("result") == outputs["result"]
+    assert event.metadata.get("test_meta") == metadata["test_meta"]
     assert event.session_id == session_id
 
 def test_log_event_with_feedback():
@@ -148,7 +151,9 @@ def test_log_event_with_feedback():
     assert res.status_code == 200
     assert res.object is not None
     assert len(res.object.events) == 1
-    assert res.object.events[0].feedback == feedback
+    assert res.object.events[0].feedback is not None
+    assert res.object.events[0].feedback.get("rating") == feedback["rating"]
+    assert res.object.events[0].feedback.get("comment") == feedback["comment"]
 
 def test_log_event_with_metrics():
     # Start a session
@@ -193,7 +198,9 @@ def test_log_event_with_metrics():
     assert res.status_code == 200
     assert res.object is not None
     assert len(res.object.events) == 1
-    assert res.object.events[0].metrics == metrics
+    assert res.object.events[0].metrics is not None
+    assert res.object.events[0].metrics.get("latency") == metrics["latency"]
+    assert res.object.events[0].metrics.get("tokens_used") == metrics["tokens_used"]
 
 if __name__ == "__main__":
     test_start_session()

--- a/tests/logger/test_logger.py
+++ b/tests/logger/test_logger.py
@@ -1,0 +1,203 @@
+import os
+import honeyhive
+from honeyhive.tracer import start_session, log
+import uuid
+from honeyhive.models import components, operations
+import time
+
+def test_start_session():
+    # Start a new session
+    session_id = start_session(
+        api_key=os.environ["HH_API_KEY"],
+        project=os.environ["HH_PROJECT"],
+        source="sdk_test",
+        session_name="test_session",
+        server_url=os.environ["HH_API_URL"],
+        verbose=True
+    )
+    
+    # Verify session_id is a valid UUID
+    assert session_id is not None
+    try:
+        uuid.UUID(session_id)
+    except ValueError:
+        assert False, "session_id is not a valid UUID"
+    
+    # Verify session exists in API
+    sdk = honeyhive.HoneyHive(bearer_auth=os.environ["HH_API_KEY"], server_url=os.environ["HH_API_URL"])
+    res = sdk.session.get_session(session_id=session_id)
+    assert res.event is not None
+    assert res.event.session_id == session_id
+    assert res.event.project == os.environ["HH_PROJECT"]
+    assert res.event.source == "sdk_test"
+
+def test_start_session_with_metadata():
+    # Test starting session with additional metadata
+    metadata = {
+        "test_key": "test_value",
+        "version": "1.0.0"
+    }
+    
+    session_id = start_session(
+        api_key=os.environ["HH_API_KEY"],
+        project=os.environ["HH_PROJECT"],
+        source="sdk_test",
+        session_name="test_session_with_metadata",
+        metadata=metadata,
+        server_url=os.environ["HH_API_URL"]
+    )
+    
+    # Verify session exists and metadata is correct
+    sdk = honeyhive.HoneyHive(bearer_auth=os.environ["HH_API_KEY"], server_url=os.environ["HH_API_URL"])
+    res = sdk.session.get_session(session_id=session_id)
+    assert res.event is not None
+    assert res.event.metadata == metadata
+
+def test_log_event():
+    # First start a session
+    session_id = start_session(
+        api_key=os.environ["HH_API_KEY"],
+        project=os.environ["HH_PROJECT"],
+        source="sdk_test",
+        session_name="test_log_event"
+    )
+    
+    # Log an event
+    event_name = "test_event"
+    inputs = {"query": "test query"}
+    outputs = {"result": "test result"}
+    metadata = {"test_meta": "test_value"}
+    
+    event_id = log(
+        api_key=os.environ["HH_API_KEY"],
+        project=os.environ["HH_PROJECT"],
+        session_id=session_id,
+        event_name=event_name,
+        inputs=inputs,
+        outputs=outputs,
+        metadata=metadata,
+        server_url=os.environ["HH_API_URL"]
+    )
+    
+    # Wait for event to be processed
+    time.sleep(5)
+    
+    # Verify event was logged correctly
+    sdk = honeyhive.HoneyHive(bearer_auth=os.environ["HH_API_KEY"], server_url=os.environ["HH_API_URL"])
+    req = operations.GetEventsRequestBody(
+        project=os.environ["HH_PROJECT"],
+        filters=[
+            components.EventFilter(
+                field="event_id",
+                value=event_id,
+                operator=components.Operator.IS,
+            )
+        ],
+    )
+    res = sdk.events.get_events(request=req)
+    assert res.status_code == 200
+    assert res.object is not None
+    assert len(res.object.events) == 1
+    event = res.object.events[0]
+    assert event.event_name == event_name
+    assert event.inputs == inputs
+    assert event.outputs == outputs
+    assert event.metadata == metadata
+    assert event.session_id == session_id
+
+def test_log_event_with_feedback():
+    # Start a session
+    session_id = start_session(
+        api_key=os.environ["HH_API_KEY"],
+        project=os.environ["HH_PROJECT"],
+        source="sdk_test",
+        session_name="test_log_event_with_feedback"
+    )
+    
+    # Log an event with feedback
+    feedback = {
+        "rating": 5,
+        "comment": "Great result!"
+    }
+    
+    event_id = log(
+        api_key=os.environ["HH_API_KEY"],
+        project=os.environ["HH_PROJECT"],
+        session_id=session_id,
+        event_name="test_event_with_feedback",
+        feedback=feedback,
+        server_url=os.environ["HH_API_URL"]
+    )
+    
+    # Wait for event to be processed
+    time.sleep(5)
+    
+    # Verify event and feedback were logged correctly
+    sdk = honeyhive.HoneyHive(bearer_auth=os.environ["HH_API_KEY"], server_url=os.environ["HH_API_URL"])
+    req = operations.GetEventsRequestBody(
+        project=os.environ["HH_PROJECT"],
+        filters=[
+            components.EventFilter(
+                field="event_id",
+                value=event_id,
+                operator=components.Operator.IS,
+            )
+        ],
+    )
+    res = sdk.events.get_events(request=req)
+    assert res.status_code == 200
+    assert res.object is not None
+    assert len(res.object.events) == 1
+    assert res.object.events[0].feedback == feedback
+
+def test_log_event_with_metrics():
+    # Start a session
+    session_id = start_session(
+        api_key=os.environ["HH_API_KEY"],
+        project=os.environ["HH_PROJECT"],
+        source="sdk_test",
+        session_name="test_log_event_with_metrics"
+    )
+    
+    # Log an event with metrics
+    metrics = {
+        "latency": 0.5,
+        "tokens_used": 100
+    }
+    
+    event_id = log(
+        api_key=os.environ["HH_API_KEY"],
+        project=os.environ["HH_PROJECT"],
+        session_id=session_id,
+        event_name="test_event_with_metrics",
+        metrics=metrics,
+        server_url=os.environ["HH_API_URL"]
+    )
+    
+    # Wait for event to be processed
+    time.sleep(5)
+    
+    # Verify event and metrics were logged correctly
+    sdk = honeyhive.HoneyHive(bearer_auth=os.environ["HH_API_KEY"], server_url=os.environ["HH_API_URL"])
+    req = operations.GetEventsRequestBody(
+        project=os.environ["HH_PROJECT"],
+        filters=[
+            components.EventFilter(
+                field="event_id",
+                value=event_id,
+                operator=components.Operator.IS,
+            )
+        ],
+    )
+    res = sdk.events.get_events(request=req)
+    assert res.status_code == 200
+    assert res.object is not None
+    assert len(res.object.events) == 1
+    assert res.object.events[0].metrics == metrics
+
+if __name__ == "__main__":
+    test_start_session()
+    test_start_session_with_metadata()
+    test_log_event()
+    test_log_event_with_feedback()
+    test_log_event_with_metrics()


### PR DESCRIPTION
Added two functions - `start_session` and `log` - that wrap our APIs directly.

1. `start_session` - accepts minimal info about the session and provides the `session_id` that'll be used by `log` to link events to a session.
2. `log` - accepts event logging data with `session_id` optional, so can be used standalone for simplicity.

All code exceptions are non-blocking.

Tests cover usage examples. Here's the simple one:

```
    session_id = start_session(
        api_key=os.environ["HH_API_KEY"],
        project=os.environ["HH_PROJECT"],
        source="sdk_test",
        session_name="test_log_event"
    )
    
    # Log an event
    event_name = "test_event"
    inputs = {"query": "test query"}
    outputs = {"result": "test result"}
    metadata = {"test_meta": "test_value"}
    
    event_id = log(
        api_key=os.environ["HH_API_KEY"],
        project=os.environ["HH_PROJECT"],
        session_id=session_id,
        event_name=event_name,
        inputs=inputs,
        outputs=outputs,
        metadata=metadata,
        server_url=os.environ["HH_API_URL"],
        verbose=True
    )
```

Tests are passing. 
