### PR TITLE
remove undefined variable of LLAMAINDEX_INSTALLED

### DIFF
--- a/src/honeyhive/utils/llamaindex_tracer.py
+++ b/src/honeyhive/utils/llamaindex_tracer.py
@@ -55,9 +55,6 @@ class HoneyHiveLlamaIndexTracer(BaseCallbackHandler):
         verbose: bool = False,
         base_url: Optional[str] = None,
     ) -> None:
-        if not LLAMAINDEX_INSTALLED:
-            raise ImportError("Please install our llama_index tracer. You can install it with `pip install honeyhive[llama_index]`")
-        
         self.verbose = verbose
         if self._env_api_key:
             api_key = self._env_api_key


### PR DESCRIPTION
The issue is that `LLAMAINDEX_INSTALLED` is not defined. Since that it was primarily set to check if there is llamaindex package installed based on https://github.com/honeyhiveai/python-sdk/commit/c1ccddb15e9b4b4c9a9d394820693c94aca0cb0b#diff-a75e354e6c693b88e3727ae20d945c6fe87a45c42fee4ea0fa5b565f7bc22d98R58 and there already a lazy import checker here https://github.com/honeyhiveai/python-sdk/commit/c1ccddb15e9b4b4c9a9d394820693c94aca0cb0b#diff-a75e354e6c693b88e3727ae20d945c6fe87a45c42fee4ea0fa5b565f7bc22d98R21 . We can safely remove this broken variable. 