### PR TITLE
fix(deps): Fix convenience groups package references in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,9 +79,9 @@ openinference-anthropic = [
     "anthropic>=0.18.0",
 ]
 
-# Google Generative AI (openinference-google-generativeai)
+# Google Generative AI (openinference-google-genai)
 openinference-google-ai = [
-    "openinference-instrumentation-google-generativeai>=0.1.0",
+    "openinference-instrumentation-google-genai>=0.1.0",
     "google-generativeai>=0.3.0",
 ]
 
@@ -154,41 +154,81 @@ traceloop-mcp = [
 
 # Convenience Groups (OpenInference Instrumentors)
 # All Available OpenInference Integrations (documented only)
+# Note: Must list actual packages, not extra names (pyproject.toml doesn't support extra references)
 all-openinference = [
-    "openinference-openai",
-    "openinference-anthropic",
-    "openinference-google-ai",
-    "openinference-google-adk",
-    "openinference-aws-bedrock",
-    "openinference-azure-openai",
-    "openinference-mcp",
+    # openinference-openai
+    "openinference-instrumentation-openai>=0.1.0",
+    "openai>=1.0.0",
+    # openinference-anthropic
+    "openinference-instrumentation-anthropic>=0.1.0",
+    "anthropic>=0.18.0",
+    # openinference-google-ai
+    "openinference-instrumentation-google-genai>=0.1.0",
+    "google-generativeai>=0.3.0",
+    # openinference-google-adk
+    "openinference-instrumentation-google-adk>=0.1.0",
+    "google-adk>=0.1.0",
+    # openinference-aws-bedrock
+    "openinference-instrumentation-bedrock>=0.1.0",
+    "boto3>=1.26.0",
+    # openinference-azure-openai (openai already included above)
+    "azure-identity>=1.12.0",
+    # openinference-mcp
+    "openinference-instrumentation-mcp>=1.3.0",
 ]
 
 # Common LLM Providers (OpenInference Ecosystem)
 openinference-llm-providers = [
-    "openinference-openai",
-    "openinference-anthropic",
-    "openinference-google-ai",
-    "openinference-aws-bedrock",
+    # openinference-openai
+    "openinference-instrumentation-openai>=0.1.0",
+    "openai>=1.0.0",
+    # openinference-anthropic
+    "openinference-instrumentation-anthropic>=0.1.0",
+    "anthropic>=0.18.0",
+    # openinference-google-ai
+    "openinference-instrumentation-google-genai>=0.1.0",
+    "google-generativeai>=0.3.0",
+    # openinference-aws-bedrock
+    "openinference-instrumentation-bedrock>=0.1.0",
+    "boto3>=1.26.0",
 ]
 
 # OpenLLMetry (Traceloop) Convenience Groups
 # All Available Traceloop Integrations (documented only)
+# Note: Must list actual packages, not extra names (pyproject.toml doesn't support extra references)
 all-traceloop = [
-    "traceloop-openai",
-    "traceloop-anthropic",
-    "traceloop-google-ai",
-    "traceloop-aws-bedrock",
-    "traceloop-azure-openai",
-    "traceloop-mcp",
+    # traceloop-openai
+    "opentelemetry-instrumentation-openai>=0.46.0,<1.0.0",
+    "openai>=1.0.0",
+    # traceloop-anthropic
+    "opentelemetry-instrumentation-anthropic>=0.46.0,<1.0.0",
+    "anthropic>=0.17.0",
+    # traceloop-google-ai
+    "opentelemetry-instrumentation-google-generativeai>=0.46.0,<1.0.0",
+    "google-generativeai>=0.3.0",
+    # traceloop-aws-bedrock
+    "opentelemetry-instrumentation-bedrock>=0.46.0,<1.0.0",
+    "boto3>=1.26.0",
+    # traceloop-azure-openai (openai already included above)
+    "azure-identity>=1.12.0",
+    # traceloop-mcp
+    "opentelemetry-instrumentation-mcp>=0.46.0,<1.0.0",
 ]
 
 # Common LLM Providers (Traceloop Ecosystem)
 traceloop-llm-providers = [
-    "traceloop-openai",
-    "traceloop-anthropic", 
-    "traceloop-google-ai",
-    "traceloop-aws-bedrock",
+    # traceloop-openai
+    "opentelemetry-instrumentation-openai>=0.46.0,<1.0.0",
+    "openai>=1.0.0",
+    # traceloop-anthropic
+    "opentelemetry-instrumentation-anthropic>=0.46.0,<1.0.0",
+    "anthropic>=0.17.0",
+    # traceloop-google-ai
+    "opentelemetry-instrumentation-google-generativeai>=0.46.0,<1.0.0",
+    "google-generativeai>=0.3.0",
+    # traceloop-aws-bedrock
+    "opentelemetry-instrumentation-bedrock>=0.46.0,<1.0.0",
+    "boto3>=1.26.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

Fixes critical bug in `pyproject.toml` where convenience groups were referencing extra names instead of actual PyPI packages, causing installation failures.

## Problem

The convenience groups (`all-openinference`, `openinference-llm-providers`, `all-traceloop`, `traceloop-llm-providers`) were using extra names like `"openinference-anthropic"` which don't exist on PyPI. This caused errors:

```
ERROR: No matching distribution found for openinference-anthropic
```

**Root cause:** pyproject.toml does not support referencing one extra from within another. Each entry must be a valid PyPI package name.

## Changes

1. **Fixed convenience groups** - replaced all extra name references with actual package specifiers
2. **Fixed wrong package name** - `openinference-instrumentation-google-generativeai` → `openinference-instrumentation-google-genai`  
3. **Added explanatory comments** - documenting why packages must be listed directly

## Affected Extras

- ✅ `all-openinference` (7 providers)
- ✅ `openinference-llm-providers` (4 providers)
- ✅ `all-traceloop` (6 providers)  
- ✅ `traceloop-llm-providers` (4 providers)
- ✅ `openinference-google-ai` (package name fix)

## Testing

All convenience groups now install successfully:

```bash
uv pip install -e ".[all-openinference]"           # ✅ 135 packages
uv pip install -e ".[openinference-llm-providers]" # ✅ 72 packages
uv pip install -e ".[all-traceloop]"               # ✅ 86 packages
uv pip install -e ".[traceloop-llm-providers]"     # ✅ 77 packages
```

Verified all instrumentor imports work correctly:
- ✅ OpenAIInstrumentor
- ✅ AnthropicInstrumentor
- ✅ BedrockInstrumentor
- ✅ GoogleGenAIInstrumentor

## Impact

- **User-facing:** No breaking changes - users still use same extra names
- **Documentation:** No updates needed - docs already show correct usage
- **Backwards compatible:** Individual extras unchanged

## Related

- Fixes installation errors in README examples
- Unblocks users trying to use convenience groups

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace extra-name references in convenience groups with actual package specifiers and fix the Google GenAI instrumentation package name.
> 
> - **pyproject.toml**:
>   - **Convenience groups**: Update `all-openinference`, `openinference-llm-providers`, `all-traceloop`, `traceloop-llm-providers` to list actual PyPI packages (instrumentors + SDKs) instead of referencing other extras; add clarifying comments.
>   - **Google GenAI**: Rename instrumentation package to `openinference-instrumentation-google-genai` and adjust section heading/comment.
>   - **Versions/specs**: Ensure explicit specs for MCP (`openinference-instrumentation-mcp>=1.3.0`) and Traceloop instrumentations where included.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51e969b5b87e94b461f8307972b0eacb93e48a66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->