### PR TITLE
docs: improve reference navigation and add missing API docs

### DIFF
--- a/docs/reference/api/client-apis.rst
+++ b/docs/reference/api/client-apis.rst
@@ -3,6 +3,9 @@ API Client Classes
 
 This section documents all API client classes for interacting with the HoneyHive platform.
 
+.. note::
+   **For tracing and observability**, use :doc:`tracer` (``HoneyHiveTracer``). This page documents the ``HoneyHive`` API client for managing platform resources (datasets, projects, etc.) - typically used in scripts and automation.
+
 .. contents:: Table of Contents
    :local:
    :depth: 2
@@ -149,6 +152,51 @@ Example
    
    # Get specific dataset
    dataset = client.datasets.get_dataset(dataset_id="dataset-id")
+
+DatapointsAPI
+-------------
+
+API client for datapoint operations. Datapoints are individual records within datasets.
+
+.. autoclass:: honeyhive.api.datapoints.DatapointsAPI
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Example
+~~~~~~~
+
+.. code-block:: python
+
+   from honeyhive import HoneyHive as Client
+   from honeyhive.models import CreateDatapointRequest
+   
+   client = honeyhive.HoneyHive(api_key="your-api-key")
+   
+   # Create a datapoint
+   datapoint = client.datapoints.create_datapoint(
+       CreateDatapointRequest(
+           inputs={"query": "What is machine learning?"},
+           ground_truth="Machine learning is a subset of AI...",
+           linked_datasets=["dataset-id"]
+       )
+   )
+   
+   # List datapoints for a dataset
+   datapoints = client.datapoints.list_datapoints(dataset_id="dataset-id")
+   
+   # Get specific datapoint
+   datapoint = client.datapoints.get_datapoint(datapoint_id="datapoint-id")
+
+ConfigurationsAPI
+-----------------
+
+API client for configuration operations.
+
+.. autoclass:: honeyhive.api.configurations.ConfigurationsAPI
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 MetricsAPI
 ----------

--- a/docs/reference/experiments/results.rst
+++ b/docs/reference/experiments/results.rst
@@ -3,6 +3,9 @@ Results Retrieval
 
 Functions for retrieving and comparing experiment results from the backend.
 
+.. note::
+   These functions require a ``HoneyHive`` API client (not ``HoneyHiveTracer``). The client manages platform resources while the tracer handles observability.
+
 get_run_result()
 ----------------
 

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -111,24 +111,39 @@ Main Components
 Core API
 --------
 
-Client Classes
-~~~~~~~~~~~~~~
+Tracing
+~~~~~~~
 
 .. toctree::
    :maxdepth: 1
 
-   api/client
    api/tracer
+   api/decorators
    api/tracer-architecture
    api/config-models
 
-Decorators & Functions
-~~~~~~~~~~~~~~~~~~~~~~
+Data & Platform APIs
+~~~~~~~~~~~~~~~~~~~~
+
+APIs for managing datasets, datapoints, projects, and other platform resources.
 
 .. toctree::
    :maxdepth: 1
 
-   api/decorators
+   api/client-apis
+   api/client
+
+Models & Errors
+~~~~~~~~~~~~~~~
+
+Data models, request/response classes, and error handling.
+
+.. toctree::
+   :maxdepth: 1
+
+   api/models-complete
+   api/errors
+   api/evaluators-complete
 
 Configuration
 ~~~~~~~~~~~~~
@@ -193,6 +208,16 @@ Command Line Interface
    cli/index
    cli/commands
    cli/options
+
+Utilities
+~~~~~~~~~
+
+Helper classes for caching, connection pooling, and logging.
+
+.. toctree::
+   :maxdepth: 1
+
+   api/utilities
 
 Feature Specifications
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/tutorials/05-run-first-experiment.rst
+++ b/docs/tutorials/05-run-first-experiment.rst
@@ -511,6 +511,8 @@ Now you have TWO runs to compare!
 
 **Compare in the Dashboard OR via API:**
 
+.. note::
+   **HoneyHive vs HoneyHiveTracer**: ``HoneyHiveTracer`` (used in previous tutorials) handles tracing and observability. ``HoneyHive`` is the API client for managing HoneyHive resources like experiment results, datasets, and projects.
 
 .. code-block:: python
 


### PR DESCRIPTION
## Summary

- Reorganize toctree structure for better discoverability
- Add 5 orphaned RST files to navigation (were inaccessible)
- Add autodoc for DatapointsAPI and ConfigurationsAPI
- **Clarify HoneyHive vs HoneyHiveTracer distinction (HHAI-3216)**

## Problem

Users couldn't find Datasets SDK reference documentation because:
1. `client-apis.rst` was orphaned from navigation (not in any toctree)
2. DatapointsAPI and ConfigurationsAPI had no documentation
3. Section names were misleading - "Client Classes" didn't hint at Datasets
4. 5 RST files existed but weren't linked from anywhere
5. **Users were confused about when to use HoneyHive vs HoneyHiveTracer** (HHAI-3216)

## Changes

### New Navigation Structure

| Old | New |
|-----|-----|
| Client Classes | Split into **Tracing** + **Data & Platform APIs** |
| (missing) | **Models & Errors** section |
| (missing) | **Utilities** section |

### Files Now Discoverable

- `api/client-apis` - DatasetsAPI, DatapointsAPI, ProjectsAPI, MetricsAPI, SessionAPI, ToolsAPI, EvaluationsAPI, EventsAPI, ConfigurationsAPI
- `api/models-complete` - Data models reference
- `api/errors` - Error handling classes
- `api/evaluators-complete` - Evaluator classes
- `api/utilities` - Helper utilities + distributed tracing context functions

### Not Added (Intentional)

- `api/tracer-internals` - Left orphaned as it's explicitly marked for "SDK maintainers and advanced use cases"

### Clarifying Notes Added (HHAI-3216)

Added brief notes at 3 strategic entry points explaining the difference between `HoneyHive` (API client for managing resources) and `HoneyHiveTracer` (for tracing/observability):

1. **Tutorial 05** (`docs/tutorials/05-run-first-experiment.rst`) - Where users first encounter `HoneyHive` after learning `HoneyHiveTracer` in tutorials 1-4
2. **client-apis.rst** (`docs/reference/api/client-apis.rst`) - For users who land directly on API client reference via search
3. **experiments/results.rst** (`docs/reference/experiments/results.rst`) - Where `HoneyHive` client is functionally required for result retrieval functions

Each note is 2-3 sentences, providing just enough context without cluttering the documentation.

## Verification

All RST file references cross-checked against actual Python code:
- ✅ errors.rst - 11 classes verified
- ✅ models-complete.rst - 7 classes verified  
- ✅ evaluators-complete.rst - 8 classes verified
- ✅ utilities.rst - 10 classes + 3 functions verified
- ✅ client-apis.rst - All APIs verified

## Test plan

- [x] Build docs locally with `uvx --from sphinx sphinx-build -b html docs docs/_build/html`
- [x] Verify new navigation structure in browser
- [x] Confirm DatasetsAPI is now findable within 2 clicks
- [x] Cross-check all autodoc references against source code
- [x] Verify clarifying notes appear correctly in rendered docs