### PR TITLE
feat: Add create_session() for multi-session handling with baggage-based isolation

### DIFF
--- a/docs/how-to/deployment/tracer-initialization-patterns.rst
+++ b/docs/how-to/deployment/tracer-initialization-patterns.rst
@@ -292,7 +292,21 @@ Pattern 4: Long-Running Server (FastAPI / Flask / Django)
 - Need to trace each user request separately
 - Want distributed tracing across services
 
-**Pattern: Global Tracer + Per-Request Session Context**
+**Pattern: Global Tracer + Per-Request Session via Baggage**
+
+.. important::
+   **How Multi-Session Handling Works:**
+   
+   The ``create_session()`` method stores the session_id in OpenTelemetry **baggage**,
+   which uses Python's ``ContextVar`` internally. This means:
+   
+   - Each async task/thread gets its own isolated session context
+   - The span processor reads session_id from baggage first
+   - No race conditions between concurrent requests
+   - The tracer instance is safely shared across all requests
+   
+   **Do NOT use** ``session_start()`` for concurrent requests - it stores session_id
+   on the tracer instance, which causes race conditions.
 
 .. code-block:: python
 
@@ -300,9 +314,9 @@ Pattern 4: Long-Running Server (FastAPI / Flask / Django)
    from fastapi import FastAPI, Request
    from honeyhive import HoneyHiveTracer, trace
    import os
-   import uuid
 
    # Initialize tracer ONCE at application startup
+   # This instance is shared across ALL requests
    tracer = HoneyHiveTracer.init(
        api_key=os.getenv("HH_API_KEY"),
        project="my-api",
@@ -312,58 +326,40 @@ Pattern 4: Long-Running Server (FastAPI / Flask / Django)
    app = FastAPI()
 
    @app.middleware("http")
-   async def tracing_middleware(request: Request, call_next):
-       """Create new session for each request."""
-       # Check if session ID exists in request (e.g., from upstream service)
-       incoming_session_id = request.headers.get("X-Session-ID")
-       
-       if incoming_session_id:
-           # Validate and use existing session ID
-           session_id = validate_session_id(incoming_session_id)
-       else:
-           # Generate new UUID v4 session ID
-           session_id = str(uuid.uuid4())
-       
-       # Create session for this request
-       tracer.create_session(
-           session_name=f"request-{session_id}",
+   async def session_middleware(request: Request, call_next):
+       """Create isolated session for each request using baggage."""
+       # acreate_session() is the async version - use for async middleware
+       # It creates a session via API and stores session_id in baggage
+       # (NOT on the tracer instance - that would cause race conditions)
+       session_id = await tracer.acreate_session(
+           session_name=f"api-{request.url.path}",
            inputs={
                "method": request.method,
-               "path": request.url.path,
+               "path": str(request.url),
                "user_id": request.headers.get("X-User-ID")
            }
        )
        
-       # Process request
+       # Process request - all spans will use this session_id from baggage
        response = await call_next(request)
        
-       # Update session with response
+       # enrich_session reads session_id from baggage automatically
        tracer.enrich_session(
-           outputs={"status_code": response.status_code},
-           metadata={"session_id": session_id}
+           outputs={"status_code": response.status_code}
        )
        
-       # Add session ID to response headers for downstream services
-       response.headers["X-Session-ID"] = session_id
+       # Optionally return session_id to client
+       if session_id:
+           response.headers["X-Session-ID"] = session_id
        
        return response
-   
-   def validate_session_id(session_id: str) -> str:
-       """Validate and convert session ID to UUID v4 format."""
-       try:
-           # Check if it's already a valid UUID
-           uuid.UUID(session_id, version=4)
-           return session_id
-       except (ValueError, AttributeError):
-           # Convert non-UUID identifier deterministically
-           namespace = uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
-           return str(uuid.uuid5(namespace, session_id))
 
    @app.post("/api/chat")
    @trace(event_type="chain", tracer=tracer)
    async def chat_endpoint(message: str):
        """Each request traced to its own session."""
-       # This span goes to the request's session
+       # The span processor reads session_id from baggage (set by middleware)
+       # This span automatically uses the correct session for this request
        tracer.enrich_span(metadata={"message_length": len(message)})
        
        response = await process_message(message)
@@ -375,6 +371,45 @@ Pattern 4: Long-Running Server (FastAPI / Flask / Django)
        result = await llm_call(message)
        tracer.enrich_span(metadata={"tokens": len(result.split())})
        return result
+
+**Sync Version (Flask / Django):**
+
+For synchronous frameworks, use ``create_session()`` instead of ``acreate_session()``:
+
+.. code-block:: python
+
+   # Flask example
+   from flask import Flask, request, g
+   from honeyhive import HoneyHiveTracer, trace
+   
+   app = Flask(__name__)
+   tracer = HoneyHiveTracer.init(api_key="...", project="my-api")
+   
+   @app.before_request
+   def create_session_for_request():
+       """Create session before each request."""
+       g.session_id = tracer.create_session(
+           session_name=f"flask-{request.path}",
+           inputs={"method": request.method}
+       )
+   
+   @app.after_request
+   def enrich_session_after_request(response):
+       """Enrich session with response data."""
+       tracer.enrich_session(outputs={"status_code": response.status_code})
+       return response
+
+**Using with_session Context Manager:**
+
+For scoped session management, use the ``with_session`` context manager:
+
+.. code-block:: python
+
+   # Synchronous usage
+   with tracer.with_session("batch-job", inputs={"batch_id": batch_id}) as session_id:
+       # All spans created here use this session
+       process_batch(items)
+       tracer.enrich_session(outputs={"processed": len(items)})
 
 **With Distributed Tracing:**
 
@@ -392,15 +427,15 @@ Pattern 4: Long-Running Server (FastAPI / Flask / Django)
        token = context.attach(ctx)
        
        try:
-           # Create session with parent context
-           session_id = tracer.create_session(
-               session_name=f"api-request-{uuid.uuid4()}",
-               link_carrier=ctx  # Link to parent trace
+           # Create session - will be in the attached context
+           session_id = await tracer.acreate_session(
+               session_name=f"api-request",
+               inputs={"path": str(request.url)}
            )
            
            response = await call_next(request)
            
-           # Inject trace context into response
+           # Inject trace context into response for downstream
            propagate.inject(response.headers)
            
            return response
@@ -410,30 +445,35 @@ Pattern 4: Long-Running Server (FastAPI / Flask / Django)
 **Characteristics:**
 
 ✅ **Efficient** - Single tracer instance shared across requests
-✅ **Isolated** - Each request gets own session
-✅ **Concurrent** - Handles multiple requests safely (OpenTelemetry context is thread-safe)
+✅ **Isolated** - Each request gets own session via baggage (ContextVar)
+✅ **Concurrent** - Handles multiple requests safely
 ✅ **Distributed** - Traces span multiple services
-⚠️ **Session management** - Must manage session lifecycle per request
+✅ **No race conditions** - Session stored in baggage, not on tracer instance
 
 .. note::
    **Thread & Process Safety:**
    
    The global tracer pattern is safe for multi-threaded servers (FastAPI, Flask with threads) because:
    
-   - OpenTelemetry Context is **thread-local** by design
-   - Each thread/request has isolated context
-   - Session creation uses thread-safe operations
+   - ``create_session()`` stores session_id in OpenTelemetry baggage
+   - Baggage uses Python's ``ContextVar`` (inherently request-scoped)
+   - Each thread/async task has isolated context
    
    For **multi-process** deployments (Gunicorn with workers, uWSGI):
    
    - ✅ **Safe** - Each process gets its own tracer instance
    - ✅ **Safe** - Processes don't share state
    - ⚠️ **Note** - Tracer initialization happens per-process (acceptable overhead)
+
+.. warning::
+   **Common Mistake: Using session_start() for Web Servers**
    
-   **Not recommended for:**
+   ``session_start()`` stores session_id on the tracer instance (``tracer._session_id``).
+   In concurrent environments, this causes race conditions where requests overwrite
+   each other's session_id.
    
-   - High-concurrency async workloads where tracer init overhead is critical (use singleton pattern)
-   - Edge functions with aggressive cold start constraints (use lazy init pattern)
+   **Always use** ``create_session()`` or ``acreate_session()`` for web servers.
+   These methods store session_id in baggage, which is request-scoped.
 
 Pattern 5: Testing / Multi-Session Scenarios
 ---------------------------------------------
@@ -618,16 +658,21 @@ Troubleshooting
 "My traces are getting mixed up between requests"
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**Cause:** Using global tracer without creating separate sessions per request.
+**Cause:** Using ``session_start()`` or not creating sessions per request.
+``session_start()`` stores session_id on the tracer instance, causing race conditions.
 
-**Solution:** Create a new session for each request:
+**Solution:** Use ``create_session()`` or ``acreate_session()`` which store session_id in baggage:
 
 .. code-block:: python
 
    @app.middleware("http")
-   async def create_session_per_request(request, call_next):
-       tracer.create_session(session_name=f"request-{uuid.uuid4()}")
+   async def session_middleware(request, call_next):
+       # ✅ CORRECT: Uses baggage (request-scoped)
+       await tracer.acreate_session(session_name=f"request-{request.url.path}")
        return await call_next(request)
+   
+   # ❌ WRONG: session_start() stores on tracer instance (race condition)
+   # tracer.session_start()  # Don't use this for web servers!
 
 "evaluate() is using the wrong tracer"
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/how-to/deployment/tracer-initialization-patterns.rst
+++ b/docs/how-to/deployment/tracer-initialization-patterns.rst
@@ -399,6 +399,91 @@ For synchronous frameworks, use ``create_session()`` instead of ``acreate_sessio
        tracer.enrich_session(outputs={"status_code": response.status_code})
        return response
 
+**Custom Session IDs and the ``skip_api_call`` Parameter:**
+
+The ``create_session()`` method supports two different session ID scenarios:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 35 40
+
+   * - Scenario
+     - Code
+     - When to Use
+   * - Auto-generate ID
+     - ``create_session(session_name="request")``
+     - Default - HoneyHive creates and returns a new session ID
+   * - Custom ID (API creates session)
+     - ``create_session(session_id="my-id")``
+     - You want to use your own ID scheme (e.g., ``user-{user_id}-{timestamp}``)
+   * - Link to existing session
+     - ``create_session(session_id="existing", skip_api_call=True)``
+     - Session already exists - just set context for tracing
+
+.. important::
+   **When to use ``skip_api_call=True``:**
+   
+   Set ``skip_api_call=True`` ONLY when linking to a session that **already exists** 
+   in HoneyHive (created by a previous request or external system).
+   
+   **Examples where ``skip_api_call=True`` makes sense:**
+   
+   - Multi-turn conversations: First request creates session, subsequent requests link to it
+   - Webhook handlers: Parent service created session, webhook links to same session
+   - Background jobs: Job receives session_id from queue message
+   
+   **Examples where ``skip_api_call=False`` (default) is correct:**
+   
+   - New user request: Create a new session in HoneyHive
+   - Custom ID scheme: Create session with your own ID format
+   - Any case where the session doesn't exist yet
+
+.. code-block:: python
+
+   # SCENARIO 1: Multi-turn conversation (first request creates, others link)
+   @app.middleware("http")
+   async def session_middleware(request: Request, call_next):
+       existing_session = request.headers.get("X-Session-ID")
+       
+       if existing_session:
+           # Link to existing session - NO API call needed
+           await tracer.acreate_session(
+               session_id=existing_session,
+               skip_api_call=True  # Session already exists
+           )
+       else:
+           # Create NEW session with auto-generated ID
+           session_id = await tracer.acreate_session(
+               session_name=f"conversation-{request.url.path}"
+           )
+           # Return session_id to client for future requests
+           request.state.new_session_id = session_id
+       
+       response = await call_next(request)
+       
+       if hasattr(request.state, "new_session_id"):
+           response.headers["X-Session-ID"] = request.state.new_session_id
+       
+       return response
+
+.. code-block:: python
+
+   # SCENARIO 2: Custom ID scheme (API creates session with YOUR ID)
+   @app.middleware("http")
+   async def session_middleware(request: Request, call_next):
+       user_id = request.headers.get("X-User-ID", "anonymous")
+       timestamp = int(time.time())
+       
+       # Create session with custom ID format
+       # skip_api_call=False (default) - API creates session with this ID
+       session_id = await tracer.acreate_session(
+           session_id=f"user-{user_id}-{timestamp}",  # Your custom ID
+           session_name=f"api-{request.url.path}",
+           inputs={"user_id": user_id}
+       )
+       
+       return await call_next(request)
+
 **Using with_session Context Manager:**
 
 For scoped session management, use the ``with_session`` context manager:

--- a/docs/reference/api/tracer.rst
+++ b/docs/reference/api/tracer.rst
@@ -1218,45 +1218,106 @@ Framework Integration Examples
            span.set_attribute("user.found", user_data is not None)
            return {"user": user_data}
 
-**FastAPI Integration:**
+**FastAPI Integration (Multi-Session Pattern):**
+
+This pattern creates isolated sessions for each request, enabling safe concurrent request handling:
 
 .. code-block:: python
 
-   from fastapi import FastAPI, Request, Response
-   import time
+   from fastapi import FastAPI, Request
+   from honeyhive import HoneyHiveTracer, trace
+   import os
    
    app = FastAPI()
-   # Requires HH_API_KEY environment variable
-   tracer = HoneyHiveTracer.init(project="fastapi-app")
+   
+   # Initialize tracer ONCE at app startup (shared across all requests)
+   tracer = HoneyHiveTracer.init(
+       api_key=os.getenv("HH_API_KEY"),
+       project="fastapi-app",
+       source="production"
+   )
    
    @app.middleware("http")
-   async def trace_requests(request: Request, call_next):
-       start_time = time.time()
+   async def session_middleware(request: Request, call_next):
+       """Create isolated session for each request using baggage.
        
-       with tracer.trace(f"{request.method} {request.url.path}") as span:
-           span.set_attribute("http.method", request.method)
-           span.set_attribute("http.url", str(request.url))
-           span.set_attribute("http.user_agent", request.headers.get("user-agent", ""))
-           
-           response = await call_next(request)
-           
-           duration = time.time() - start_time
-           span.set_attribute("http.status_code", response.status_code)
-           span.set_attribute("http.duration", duration)
-           
-           return response
+       acreate_session() stores session_id in OpenTelemetry baggage,
+       which is ContextVar-based and therefore request-scoped.
+       This enables safe concurrent request handling.
+       """
+       session_id = await tracer.acreate_session(
+           session_name=f"api-{request.url.path}",
+           inputs={
+               "method": request.method,
+               "path": str(request.url),
+               "user_id": request.headers.get("X-User-ID"),
+           }
+       )
+       
+       response = await call_next(request)
+       
+       # enrich_session reads session_id from baggage automatically
+       tracer.enrich_session(
+           outputs={"status_code": response.status_code}
+       )
+       
+       # Optionally return session_id to client
+       if session_id:
+           response.headers["X-Session-ID"] = session_id
+       
+       return response
    
-   @app.get("/users/{user_id}")
-   async def get_user(user_id: str):
-       with tracer.trace("get_user_async") as span:
-           span.set_attribute("user.id", user_id)
-           
-           # Simulate async database call
-           await asyncio.sleep(0.1)
-           user_data = {"id": user_id, "name": "User Name"}
-           
-           span.set_attribute("user.found", True)
-           return user_data
+   @app.post("/chat")
+   @trace(event_type="chain", tracer=tracer)
+   async def chat_endpoint(message: str):
+       """Endpoint with automatic session association.
+       
+       The span processor reads session_id from baggage (set by middleware).
+       """
+       tracer.enrich_span(metadata={"message_length": len(message)})
+       result = await process_message(message)
+       return {"response": result}
+   
+   @trace(event_type="tool", tracer=tracer)
+   async def process_message(message: str) -> str:
+       """Nested spans automatically use request's session context."""
+       # Simulate LLM call
+       response = f"Response to: {message}"
+       tracer.enrich_span(
+           inputs={"message": message},
+           outputs={"response": response}
+       )
+       return response
+
+.. note::
+   **Why acreate_session() instead of session_start()?**
+   
+   ``acreate_session()`` stores session_id in OpenTelemetry baggage (ContextVar-based),
+   which provides request-scoped isolation. ``session_start()`` stores on the tracer
+   instance, which causes race conditions in concurrent environments.
+
+**Bring-Your-Own Session ID:**
+
+If you already have a session ID (e.g., from a database or external system):
+
+.. code-block:: python
+
+   @app.middleware("http")
+   async def session_middleware(request: Request, call_next):
+       # Use existing session ID from headers or generate new one
+       existing_session_id = request.headers.get("X-Session-ID")
+       
+       if existing_session_id:
+           # Just set it in baggage - no API call needed
+           await tracer.acreate_session(session_id=existing_session_id)
+       else:
+           # Create new session via API
+           await tracer.acreate_session(
+               session_name=f"api-{request.url.path}",
+               inputs={"method": request.method}
+           )
+       
+       return await call_next(request)
 
 **Django Integration:**
 

--- a/docs/reference/api/tracer.rst
+++ b/docs/reference/api/tracer.rst
@@ -705,6 +705,245 @@ close()
       
       atexit.register(cleanup_tracer)
 
+Session Management Methods
+--------------------------
+
+create_session()
+~~~~~~~~~~~~~~~~
+
+.. py:method:: create_session(session_name: Optional[str] = None, session_id: Optional[str] = None, inputs: Optional[Dict[str, Any]] = None, metadata: Optional[Dict[str, Any]] = None, user_properties: Optional[Dict[str, Any]] = None, source: Optional[str] = None) -> Optional[str]
+
+   Create a new session and set it in the current request context using OpenTelemetry baggage.
+   
+   **🆕 Recommended for Web Servers:** This method stores the session_id in OpenTelemetry baggage
+   (which uses Python's ``ContextVar`` internally), providing proper request-scoped isolation.
+   It does NOT modify the tracer instance's session_id, making it safe for concurrent requests.
+   
+   **Parameters:**
+   
+   :param session_name: Human-readable name for the session. Auto-generated if not provided.
+   :type session_name: Optional[str]
+   
+   :param session_id: Custom session ID (bring-your-own-session-id pattern). If provided, 
+                      sets this ID in baggage WITHOUT making an API call. Useful when session
+                      was created externally or when linking multiple requests to the same session.
+   :type session_id: Optional[str]
+   
+   :param inputs: Input data for the session (e.g., user query, request data).
+   :type inputs: Optional[Dict[str, Any]]
+   
+   :param metadata: Additional metadata for the session.
+   :type metadata: Optional[Dict[str, Any]]
+   
+   :param user_properties: User-specific properties (user_id, plan, etc.).
+   :type user_properties: Optional[Dict[str, Any]]
+   
+   :param source: Source environment override. Uses tracer's source if not provided.
+   :type source: Optional[str]
+   
+   **Returns:**
+   
+   :rtype: Optional[str]
+   :returns: Session ID if successful, None otherwise
+   
+   **Basic Usage (Flask/Django):**
+   
+   .. code-block:: python
+   
+      from flask import Flask, request, g
+      from honeyhive import HoneyHiveTracer, trace
+      
+      app = Flask(__name__)
+      tracer = HoneyHiveTracer.init(api_key="...", project="my-api")
+      
+      @app.before_request
+      def create_session_for_request():
+          """Create session before each request."""
+          g.session_id = tracer.create_session(
+              session_name=f"flask-{request.path}",
+              inputs={"method": request.method, "path": request.path},
+              user_properties={"user_id": request.headers.get("X-User-ID")}
+          )
+      
+      @app.after_request
+      def enrich_session_after_request(response):
+          """Enrich session with response data."""
+          tracer.enrich_session(outputs={"status_code": response.status_code})
+          return response
+   
+   **Bring-Your-Own Session ID:**
+   
+   .. code-block:: python
+   
+      # Use existing session ID without making API call
+      existing_session_id = request.headers.get("X-Session-ID")
+      if existing_session_id:
+          tracer.create_session(session_id=existing_session_id)
+      else:
+          tracer.create_session(session_name="new-session")
+   
+   **See Also:**
+   
+   - :meth:`acreate_session` - Async version for FastAPI and async frameworks
+   - :meth:`enrich_session` - Add data to existing session
+   
+   .. versionadded:: 1.0.0rc8
+
+acreate_session()
+~~~~~~~~~~~~~~~~~
+
+.. py:method:: acreate_session(session_name: Optional[str] = None, session_id: Optional[str] = None, inputs: Optional[Dict[str, Any]] = None, metadata: Optional[Dict[str, Any]] = None, user_properties: Optional[Dict[str, Any]] = None, source: Optional[str] = None) -> Optional[str]
+   :async:
+
+   Async version of ``create_session()`` for async frameworks like FastAPI.
+   
+   Creates a session via async API call and stores session_id in baggage.
+   This is the recommended method for async web servers.
+   
+   **Parameters:**
+   
+   Same as :meth:`create_session`.
+   
+   **Returns:**
+   
+   :rtype: Optional[str]
+   :returns: Session ID if successful, None otherwise
+   
+   **FastAPI Middleware Example:**
+   
+   .. code-block:: python
+   
+      from fastapi import FastAPI, Request
+      from honeyhive import HoneyHiveTracer, trace
+      
+      app = FastAPI()
+      tracer = HoneyHiveTracer.init(api_key="...", project="my-api")
+      
+      @app.middleware("http")
+      async def session_middleware(request: Request, call_next):
+          """Create isolated session for each request."""
+          session_id = await tracer.acreate_session(
+              session_name=f"api-{request.url.path}",
+              inputs={
+                  "method": request.method,
+                  "path": str(request.url),
+                  "user_id": request.headers.get("X-User-ID"),
+              }
+          )
+          
+          response = await call_next(request)
+          
+          # enrich_session reads session_id from baggage automatically
+          tracer.enrich_session(outputs={"status_code": response.status_code})
+          
+          if session_id:
+              response.headers["X-Session-ID"] = session_id
+          
+          return response
+      
+      @app.post("/chat")
+      @trace(event_type="chain", tracer=tracer)
+      async def chat(message: str):
+          # Span automatically uses session_id from baggage
+          tracer.enrich_span(inputs={"message": message})
+          return await process_message(message)
+   
+   **See Also:**
+   
+   - :meth:`create_session` - Sync version for Flask/Django
+   
+   .. versionadded:: 1.0.0rc8
+
+with_session()
+~~~~~~~~~~~~~~
+
+.. py:method:: with_session(session_name: Optional[str] = None, inputs: Optional[Dict[str, Any]] = None, metadata: Optional[Dict[str, Any]] = None, user_properties: Optional[Dict[str, Any]] = None, **kwargs) -> ContextManager[Optional[str]]
+
+   Context manager that creates a session and ensures proper context cleanup.
+   
+   **Parameters:**
+   
+   :param session_name: Human-readable name for the session.
+   :type session_name: Optional[str]
+   
+   :param inputs: Input data for the session.
+   :type inputs: Optional[Dict[str, Any]]
+   
+   :param metadata: Additional metadata for the session.
+   :type metadata: Optional[Dict[str, Any]]
+   
+   :param user_properties: User-specific properties.
+   :type user_properties: Optional[Dict[str, Any]]
+   
+   **Yields:**
+   
+   :rtype: Optional[str]
+   :yields: The newly created session ID
+   
+   **Usage:**
+   
+   .. code-block:: python
+   
+      # Scoped session management
+      with tracer.with_session("batch-job", inputs={"batch_id": batch_id}) as session_id:
+          # All spans created here use this session
+          process_batch(items)
+          tracer.enrich_session(outputs={"processed": len(items)})
+      # Context automatically cleaned up
+   
+   .. versionadded:: 1.0.0rc8
+
+enrich_session()
+~~~~~~~~~~~~~~~~
+
+.. py:method:: enrich_session(inputs: Optional[Dict[str, Any]] = None, outputs: Optional[Dict[str, Any]] = None, metadata: Optional[Dict[str, Any]] = None, feedback: Optional[Dict[str, Any]] = None, metrics: Optional[Dict[str, Any]] = None, user_properties: Optional[Dict[str, Any]] = None, session_id: Optional[str] = None) -> None
+
+   Update the current session with additional data.
+   
+   Automatically reads session_id from OpenTelemetry baggage if not explicitly provided,
+   making it compatible with the ``create_session()`` pattern for web servers.
+   
+   **Parameters:**
+   
+   :param inputs: Additional input data to add to session.
+   :type inputs: Optional[Dict[str, Any]]
+   
+   :param outputs: Output/response data to add to session.
+   :type outputs: Optional[Dict[str, Any]]
+   
+   :param metadata: Additional metadata to add to session.
+   :type metadata: Optional[Dict[str, Any]]
+   
+   :param feedback: User feedback data.
+   :type feedback: Optional[Dict[str, Any]]
+   
+   :param metrics: Metrics data.
+   :type metrics: Optional[Dict[str, Any]]
+   
+   :param user_properties: User properties to add.
+   :type user_properties: Optional[Dict[str, Any]]
+   
+   :param session_id: Explicit session ID override. If not provided, reads from baggage.
+   :type session_id: Optional[str]
+   
+   **Usage with create_session():**
+   
+   .. code-block:: python
+   
+      @app.middleware("http")
+      async def session_middleware(request: Request, call_next):
+          # Create session - stores in baggage
+          await tracer.acreate_session(session_name="api-request")
+          
+          response = await call_next(request)
+          
+          # enrich_session automatically reads session_id from baggage
+          tracer.enrich_session(
+              outputs={"status_code": response.status_code},
+              metadata={"response_time_ms": response_time}
+          )
+          return response
+
 Context Propagation Methods (Backwards Compatibility)
 -----------------------------------------------------
 

--- a/docs/reference/api/tracer.rst
+++ b/docs/reference/api/tracer.rst
@@ -711,7 +711,7 @@ Session Management Methods
 create_session()
 ~~~~~~~~~~~~~~~~
 
-.. py:method:: create_session(session_name: Optional[str] = None, session_id: Optional[str] = None, inputs: Optional[Dict[str, Any]] = None, metadata: Optional[Dict[str, Any]] = None, user_properties: Optional[Dict[str, Any]] = None, source: Optional[str] = None) -> Optional[str]
+.. py:method:: create_session(session_name: Optional[str] = None, session_id: Optional[str] = None, inputs: Optional[Dict[str, Any]] = None, metadata: Optional[Dict[str, Any]] = None, user_properties: Optional[Dict[str, Any]] = None, source: Optional[str] = None, skip_api_call: bool = False) -> Optional[str]
 
    Create a new session and set it in the current request context using OpenTelemetry baggage.
    
@@ -724,9 +724,9 @@ create_session()
    :param session_name: Human-readable name for the session. Auto-generated if not provided.
    :type session_name: Optional[str]
    
-   :param session_id: Custom session ID (bring-your-own-session-id pattern). If provided, 
-                      sets this ID in baggage WITHOUT making an API call. Useful when session
-                      was created externally or when linking multiple requests to the same session.
+   :param session_id: Custom session ID. By default, the API is called with this ID to create
+                      the session in the backend. If ``skip_api_call=True``, just sets this ID
+                      in baggage without making an API call (for linking to existing sessions).
    :type session_id: Optional[str]
    
    :param inputs: Input data for the session (e.g., user query, request data).
@@ -740,6 +740,11 @@ create_session()
    
    :param source: Source environment override. Uses tracer's source if not provided.
    :type source: Optional[str]
+   
+   :param skip_api_call: If True and session_id is provided, skip the API call and just
+                         set session_id in baggage. Useful for linking to sessions that
+                         were already created externally. Defaults to False.
+   :type skip_api_call: bool
    
    **Returns:**
    
@@ -771,14 +776,29 @@ create_session()
           tracer.enrich_session(outputs={"status_code": response.status_code})
           return response
    
-   **Bring-Your-Own Session ID:**
+   **Custom Session ID (API creates session with your ID):**
    
    .. code-block:: python
    
-      # Use existing session ID without making API call
+      # Create session with your own ID via API
+      my_session_id = f"user-{user_id}-{timestamp}"
+      tracer.create_session(
+          session_id=my_session_id,  # API creates session with this ID
+          session_name="user-session",
+          inputs={"user_id": user_id}
+      )
+   
+   **Link to Existing Session (no API call):**
+   
+   .. code-block:: python
+   
+      # Link to session that was already created (skip API call)
       existing_session_id = request.headers.get("X-Session-ID")
       if existing_session_id:
-          tracer.create_session(session_id=existing_session_id)
+          tracer.create_session(
+              session_id=existing_session_id,
+              skip_api_call=True  # Just set in baggage, no API call
+          )
       else:
           tracer.create_session(session_name="new-session")
    

--- a/examples/fastapi_multi_session_example.py
+++ b/examples/fastapi_multi_session_example.py
@@ -1,0 +1,260 @@
+"""
+FastAPI Multi-Session Tracing Example
+=====================================
+
+This example demonstrates the recommended pattern for tracing multiple
+concurrent requests in a FastAPI server with HoneyHive.
+
+Key Pattern:
+- Initialize tracer ONCE at app startup (shared across all requests)
+- Use create_session() or acreate_session() in middleware per request
+- Session IDs are stored in OpenTelemetry baggage (ContextVar-based)
+- Each request is automatically isolated to its own session
+
+Installation:
+    pip install honeyhive fastapi uvicorn
+
+Usage:
+    # Set your API key
+    export HH_API_KEY="your-api-key"
+    export HH_PROJECT="your-project"
+    
+    # Run the server
+    uvicorn fastapi_multi_session_example:app --reload
+    
+    # Test with concurrent requests
+    curl -X POST http://localhost:8000/chat -H "Content-Type: application/json" \
+         -H "X-User-ID: user-123" -d '{"message": "Hello!"}'
+"""
+
+import os
+from typing import Optional
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from honeyhive import HoneyHiveTracer, trace
+
+# =============================================================================
+# TRACER INITIALIZATION (ONCE AT APP STARTUP)
+# =============================================================================
+# The tracer is initialized ONCE and shared across all requests.
+# Session isolation is achieved through OpenTelemetry baggage (ContextVar),
+# NOT by creating multiple tracer instances.
+
+tracer = HoneyHiveTracer.init(
+    api_key=os.getenv("HH_API_KEY"),
+    project=os.getenv("HH_PROJECT", "fastapi-example"),
+    source=os.getenv("HH_SOURCE", "development"),
+)
+
+app = FastAPI(
+    title="HoneyHive Multi-Session Example",
+    description="Demonstrates per-request session isolation with a global tracer",
+)
+
+
+# =============================================================================
+# SESSION MIDDLEWARE
+# =============================================================================
+# This middleware creates a new session for each request.
+# The session_id is stored in OpenTelemetry baggage, which is:
+# - ContextVar-based (automatically request-scoped)
+# - Propagated to all spans within the request
+# - Safe for concurrent requests (no race conditions)
+
+
+@app.middleware("http")
+async def session_middleware(request: Request, call_next):
+    """Create isolated session for each request.
+    
+    acreate_session() creates a session via the HoneyHive API and stores
+    the session_id in OpenTelemetry baggage. This enables:
+    
+    1. Request-scoped isolation (each request has its own session)
+    2. No race conditions (session_id is NOT stored on tracer instance)
+    3. Automatic span association (span processor reads from baggage)
+    """
+    # Extract user info from headers (example)
+    user_id = request.headers.get("X-User-ID")
+    
+    # Create session via API (async version for async middleware)
+    # If you have an existing session_id, you can pass it directly:
+    #   await tracer.acreate_session(session_id=existing_session_id)
+    session_id = await tracer.acreate_session(
+        session_name=f"api-{request.method}-{request.url.path}",
+        inputs={
+            "method": request.method,
+            "path": str(request.url.path),
+            "query_params": dict(request.query_params),
+        },
+        user_properties={
+            "user_id": user_id,
+        } if user_id else None,
+    )
+    
+    # Process the request
+    response = await call_next(request)
+    
+    # Enrich session with response data
+    # enrich_session reads session_id from baggage automatically
+    tracer.enrich_session(
+        outputs={"status_code": response.status_code},
+        metadata={"completed": True},
+    )
+    
+    # Optionally return session_id to client for debugging/linking
+    if session_id:
+        response.headers["X-Session-ID"] = session_id
+    
+    return response
+
+
+# =============================================================================
+# REQUEST MODELS
+# =============================================================================
+
+
+class ChatRequest(BaseModel):
+    message: str
+    context: Optional[str] = None
+
+
+class ChatResponse(BaseModel):
+    response: str
+    session_id: Optional[str] = None
+
+
+# =============================================================================
+# ENDPOINTS (Traced)
+# =============================================================================
+# All endpoints use @trace decorator with explicit tracer reference.
+# Spans are automatically associated with the session from middleware.
+
+
+@app.post("/chat", response_model=ChatResponse)
+@trace(event_type="chain", tracer=tracer)
+async def chat_endpoint(request: Request, body: ChatRequest) -> ChatResponse:
+    """Chat endpoint with automatic session association.
+    
+    The @trace decorator creates a span that automatically picks up
+    the session_id from baggage (set by middleware).
+    """
+    # Enrich span with input data
+    tracer.enrich_span(
+        inputs={"message": body.message, "context": body.context},
+        metadata={"message_length": len(body.message)},
+    )
+    
+    # Process the message (traced as nested span)
+    response = await process_message(body.message, body.context)
+    
+    # Enrich span with output
+    tracer.enrich_span(outputs={"response": response})
+    
+    # Get session_id from request state (set by middleware)
+    # Note: In production, you might want to read this from baggage
+    session_id = request.headers.get("X-Session-ID")
+    
+    return ChatResponse(response=response, session_id=session_id)
+
+
+@trace(event_type="tool", tracer=tracer)
+async def process_message(message: str, context: Optional[str] = None) -> str:
+    """Process message - span automatically uses parent's session context.
+    
+    Nested functions decorated with @trace automatically inherit the
+    session context from the parent span.
+    """
+    tracer.enrich_span(
+        inputs={"message": message, "context": context},
+        metadata={"step": "message_processing"},
+    )
+    
+    # Simulate LLM call (in real app, this would call OpenAI, Anthropic, etc.)
+    response = await generate_response(message)
+    
+    tracer.enrich_span(outputs={"response": response})
+    
+    return response
+
+
+@trace(event_type="model", tracer=tracer)
+async def generate_response(message: str) -> str:
+    """Simulate LLM response generation.
+    
+    In a real application, this would call an LLM provider.
+    The span is automatically associated with the correct session.
+    """
+    tracer.enrich_span(
+        inputs={"prompt": message},
+        metadata={"model": "simulated"},
+    )
+    
+    # Simulate LLM response
+    response = f"Response to: {message}"
+    
+    tracer.enrich_span(
+        outputs={"completion": response},
+        metadata={"tokens": len(response.split())},
+    )
+    
+    return response
+
+
+# =============================================================================
+# BRING-YOUR-OWN SESSION ID EXAMPLE
+# =============================================================================
+
+
+@app.post("/chat/with-session/{session_id}")
+@trace(event_type="chain", tracer=tracer)
+async def chat_with_existing_session(
+    request: Request, session_id: str, body: ChatRequest
+) -> ChatResponse:
+    """Chat endpoint that uses an existing session ID.
+    
+    Use this pattern when you want to link multiple requests to
+    the same session (e.g., multi-turn conversations).
+    """
+    # Set the provided session_id in baggage (no API call)
+    tracer.create_session(session_id=session_id)
+    
+    # Now all spans will use this session_id
+    tracer.enrich_span(inputs={"message": body.message})
+    
+    response = await process_message(body.message, body.context)
+    
+    return ChatResponse(response=response, session_id=session_id)
+
+
+# =============================================================================
+# HEALTH CHECK
+# =============================================================================
+
+
+@app.get("/health")
+async def health_check():
+    """Health check endpoint (not traced)."""
+    return {"status": "healthy"}
+
+
+# =============================================================================
+# MAIN
+# =============================================================================
+
+if __name__ == "__main__":
+    import uvicorn
+    
+    print("Starting FastAPI server with HoneyHive tracing...")
+    print(f"Project: {os.getenv('HH_PROJECT', 'fastapi-example')}")
+    print(f"Source: {os.getenv('HH_SOURCE', 'development')}")
+    print()
+    print("Test with:")
+    print('  curl -X POST http://localhost:8000/chat \\')
+    print('       -H "Content-Type: application/json" \\')
+    print('       -H "X-User-ID: user-123" \\')
+    print("       -d '{\"message\": \"Hello!\"}'")
+    
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/src/honeyhive/__init__.py
+++ b/src/honeyhive/__init__.py
@@ -3,7 +3,7 @@ HoneyHive Python SDK - LLM Observability and Evaluation Platform
 """
 
 # Version must be defined BEFORE imports to avoid circular import issues
-__version__ = "1.0.0rc6"
+__version__ = "1.0.0rc7"
 
 from .api.client import HoneyHive
 

--- a/src/honeyhive/tracer/core/context.py
+++ b/src/honeyhive/tracer/core/context.py
@@ -10,8 +10,10 @@ context handling and robust state management.
 # Duplicate code represents common session enrichment and parameter building
 # patterns shared across core mixin classes for consistent behavior.
 
+import uuid
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Dict, Optional, cast
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, cast
 
 from opentelemetry import baggage, context, trace
 from opentelemetry.context import Context
@@ -266,6 +268,11 @@ class TracerContextMixin(TracerContextInterface):
         the session ID. This provides backward compatibility with the original
         SDK's session_start() method.
 
+        .. note::
+            This method stores session_id on the tracer instance, which is NOT
+            safe for concurrent requests. For multi-session handling in web
+            servers, use :meth:`create_session` instead.
+
         Returns:
             Session ID if successful, None otherwise
 
@@ -296,6 +303,330 @@ class TracerContextMixin(TracerContextInterface):
             )
             return None
 
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    # Justification: Session creation supports multiple optional parameters
+    # for flexibility in different use cases.
+    def create_session(
+        self,
+        session_name: Optional[str] = None,
+        session_id: Optional[str] = None,
+        inputs: Optional[Dict[str, Any]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        user_properties: Optional[Dict[str, Any]] = None,
+        source: Optional[str] = None,
+    ) -> Optional[str]:
+        """Create a new session and set it in the current request context.
+
+        **RECOMMENDED FOR WEB SERVERS:** This method creates a session via the
+        API and stores the session_id in OpenTelemetry baggage (ContextVar-based),
+        enabling proper request-scoped session isolation. It does NOT modify
+        the tracer instance's session_id, making it safe for concurrent requests.
+
+        The session_id is stored in baggage, which means:
+        - Each async task/thread gets its own isolated session context
+        - The span processor reads from baggage first (priority over instance)
+        - No race conditions between concurrent requests
+
+        Args:
+            session_name: Name for the session. Auto-generated if not provided.
+            session_id: Custom session ID. If provided, sets this ID in baggage
+                       WITHOUT making an API call (bring-your-own-session-id pattern).
+                       Useful when session was created externally or you want to
+                       use your own ID scheme.
+            inputs: Input data for the session (e.g., user query, request data)
+            metadata: Additional metadata for the session
+            user_properties: User-specific properties (user_id, plan, etc.)
+            source: Source environment override. Uses tracer's source if not provided.
+
+        Returns:
+            Session ID if successful, None otherwise
+
+        Example:
+            FastAPI middleware for per-request sessions::
+
+                from fastapi import FastAPI, Request
+                from honeyhive import HoneyHiveTracer, trace
+
+                tracer = HoneyHiveTracer.init(api_key="...", project="my-api")
+                app = FastAPI()
+
+                @app.middleware("http")
+                async def session_middleware(request: Request, call_next):
+                    # Creates session, sets session_id in baggage (not on tracer)
+                    session_id = tracer.create_session(
+                        session_name=f"api-{request.url.path}",
+                        inputs={"method": request.method, "path": str(request.url)}
+                    )
+
+                    response = await call_next(request)
+
+                    # enrich_session reads session_id from baggage
+                    tracer.enrich_session(outputs={"status_code": response.status_code})
+                    return response
+
+                @app.post("/chat")
+                @trace(tracer=tracer, event_type="chain")
+                async def chat(message: str):
+                    # Span automatically uses session_id from baggage
+                    return await process_message(message)
+
+        See Also:
+            - :meth:`acreate_session` - Async version for async frameworks
+            - :meth:`with_session` - Context manager for automatic cleanup
+            - :meth:`session_start` - Legacy method (stores on instance, not baggage)
+
+        .. versionadded:: 1.0.0rc8
+            Added for multi-session handling with global tracer pattern.
+        """
+        try:
+            # If session_id is provided, just set it in baggage (no API call)
+            if session_id:
+                current_ctx = context.get_current()
+                new_ctx = baggage.set_baggage("session_id", session_id, current_ctx)
+                context.attach(new_ctx)
+
+                safe_log(
+                    self,
+                    "info",
+                    f"Set provided session_id in baggage: {session_id}",
+                    honeyhive_data={
+                        "session_id": session_id,
+                        "storage": "baggage",
+                        "source": "provided",
+                    },
+                )
+                return session_id
+
+            # Create session via API
+            if not self.session_api:
+                safe_log(
+                    self, "warning", "No session API available for session creation"
+                )
+                return None
+
+            # Build session parameters
+            effective_session_name = session_name or f"session-{uuid.uuid4().hex[:8]}"
+            effective_source = source or getattr(self, "source_environment", "dev")
+
+            session_params: Dict[str, Any] = {
+                "project": getattr(self, "project_name", None),
+                "source": effective_source,
+                "session_name": effective_session_name,
+            }
+
+            if inputs:
+                session_params["inputs"] = inputs
+            if metadata:
+                session_params["metadata"] = metadata
+            if user_properties:
+                session_params["user_properties"] = user_properties
+
+            # Create session via API
+            response = self.session_api.create_session_from_dict(session_params)
+            new_session_id = response.session_id
+
+            # Set session_id in baggage (ContextVar-based, request-scoped)
+            # CRITICAL: Do NOT set self._session_id - that would break concurrency
+            current_ctx = context.get_current()
+            new_ctx = baggage.set_baggage("session_id", new_session_id, current_ctx)
+            context.attach(new_ctx)
+
+            safe_log(
+                self,
+                "info",
+                f"Created session in baggage: {new_session_id}",
+                honeyhive_data={
+                    "session_id": new_session_id,
+                    "session_name": effective_session_name,
+                    "storage": "baggage",
+                },
+            )
+
+            return new_session_id
+
+        except Exception as e:
+            safe_log(
+                self,
+                "error",
+                f"Failed to create session: {e}",
+                honeyhive_data={"error_type": type(e).__name__},
+            )
+            return None
+
+    async def acreate_session(
+        self,
+        session_name: Optional[str] = None,
+        session_id: Optional[str] = None,
+        inputs: Optional[Dict[str, Any]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        user_properties: Optional[Dict[str, Any]] = None,
+        source: Optional[str] = None,
+    ) -> Optional[str]:
+        """Async version of create_session for async frameworks like FastAPI.
+
+        Creates a session via async API call and stores session_id in baggage.
+        This is the recommended method for async web servers.
+
+        Args:
+            session_name: Name for the session. Auto-generated if not provided.
+            session_id: Custom session ID. If provided, sets this ID in baggage
+                       WITHOUT making an API call (bring-your-own-session-id pattern).
+            inputs: Input data for the session
+            metadata: Additional metadata for the session
+            user_properties: User-specific properties
+            source: Source environment override
+
+        Returns:
+            Session ID if successful, None otherwise
+
+        Example:
+            FastAPI async middleware::
+
+                @app.middleware("http")
+                async def session_middleware(request: Request, call_next):
+                    session_id = await tracer.acreate_session(
+                        session_name=f"api-{request.url.path}",
+                        inputs={"method": request.method}
+                    )
+                    response = await call_next(request)
+                    tracer.enrich_session(outputs={"status_code": response.status_code})
+                    return response
+
+        See Also:
+            - :meth:`create_session` - Sync version
+
+        .. versionadded:: 1.0.0rc8
+        """
+        try:
+            # If session_id is provided, just set it in baggage (no API call)
+            if session_id:
+                current_ctx = context.get_current()
+                new_ctx = baggage.set_baggage("session_id", session_id, current_ctx)
+                context.attach(new_ctx)
+
+                safe_log(
+                    self,
+                    "info",
+                    f"Set provided session_id in baggage (async): {session_id}",
+                    honeyhive_data={
+                        "session_id": session_id,
+                        "storage": "baggage",
+                        "source": "provided",
+                    },
+                )
+                return session_id
+
+            # Create session via API
+            if not self.session_api:
+                safe_log(
+                    self, "warning", "No session API available for session creation"
+                )
+                return None
+
+            # Build session parameters
+            effective_session_name = session_name or f"session-{uuid.uuid4().hex[:8]}"
+            effective_source = source or getattr(self, "source_environment", "dev")
+
+            session_params: Dict[str, Any] = {
+                "project": getattr(self, "project_name", None),
+                "source": effective_source,
+                "session_name": effective_session_name,
+            }
+
+            if inputs:
+                session_params["inputs"] = inputs
+            if metadata:
+                session_params["metadata"] = metadata
+            if user_properties:
+                session_params["user_properties"] = user_properties
+
+            # Create session via async API
+            response = await self.session_api.create_session_from_dict_async(
+                session_params
+            )
+            new_session_id = response.session_id
+
+            # Set session_id in baggage (ContextVar-based, request-scoped)
+            current_ctx = context.get_current()
+            new_ctx = baggage.set_baggage("session_id", new_session_id, current_ctx)
+            context.attach(new_ctx)
+
+            safe_log(
+                self,
+                "info",
+                f"Created session in baggage (async): {new_session_id}",
+                honeyhive_data={
+                    "session_id": new_session_id,
+                    "session_name": effective_session_name,
+                    "storage": "baggage",
+                },
+            )
+
+            return new_session_id
+
+        except Exception as e:
+            safe_log(
+                self,
+                "error",
+                f"Failed to create session (async): {e}",
+                honeyhive_data={"error_type": type(e).__name__},
+            )
+            return None
+
+    @contextmanager
+    def with_session(
+        self,
+        session_name: Optional[str] = None,
+        inputs: Optional[Dict[str, Any]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        user_properties: Optional[Dict[str, Any]] = None,
+        source: Optional[str] = None,
+    ) -> Iterator[Optional[str]]:
+        """Context manager that creates a session for the enclosed scope.
+
+        Creates a session and yields the session_id. All spans created within
+        the context will use this session. The session context is automatically
+        managed via OpenTelemetry baggage.
+
+        Args:
+            session_name: Name for the session
+            inputs: Input data for the session
+            metadata: Additional metadata
+            user_properties: User-specific properties
+            source: Source environment override
+
+        Yields:
+            Session ID if successful, None otherwise
+
+        Example:
+            Using with_session for scoped tracing::
+
+                tracer = HoneyHiveTracer.init(api_key="...", project="my-app")
+
+                with tracer.with_session("user-req", inputs={"q": query}) as sid:
+                    # All spans here use this session
+                    result = process_query(query)
+                    tracer.enrich_session(outputs={"result": result})
+
+        See Also:
+            - :meth:`create_session` - Direct session creation
+
+        .. versionadded:: 1.0.0rc8
+        """
+        session_id = self.create_session(
+            session_name=session_name,
+            inputs=inputs,
+            metadata=metadata,
+            user_properties=user_properties,
+            source=source,
+        )
+        try:
+            yield session_id
+        finally:
+            # Context cleanup happens automatically when ContextVar scope ends
+            # No explicit detach needed - baggage is scoped to this context
+            pass
+
     def _can_enrich_session_dynamically(self) -> bool:
         """Dynamically check if session enrichment is possible."""
         # Check if client with events API is available (for session updates)
@@ -310,14 +641,17 @@ class TracerContextMixin(TracerContextInterface):
         return True
 
     def _get_session_id_for_enrichment_dynamically(self) -> Optional[str]:
-        """Dynamically get session ID for enrichment operations."""
-        # Priority: explicit session_id, baggage session_id
-        if self._session_id:
-            return str(self._session_id)
+        """Dynamically get session ID for enrichment operations.
 
-        # Check baggage dynamically
+        Priority order (matches span processor behavior):
+        1. Baggage session_id (request-scoped, from create_session())
+        2. Instance session_id (tracer._session_id, from session_start())
+
+        This order ensures multi-session handling works correctly with
+        a global tracer, while maintaining backwards compatibility.
+        """
+        # Priority 1: Check baggage first (for multi-session / concurrent requests)
         try:
-            # Use dynamic baggage access
             current_baggage = get_current_baggage()
             baggage_session = current_baggage.get("session_id")
             if baggage_session:
@@ -330,6 +664,10 @@ class TracerContextMixin(TracerContextInterface):
                 "Failed to get session from baggage",
                 honeyhive_data={"error_type": type(e).__name__},
             )
+
+        # Priority 2: Fallback to instance session_id (for single-session scripts)
+        if self._session_id:
+            return str(self._session_id)
 
         return None
 

--- a/src/honeyhive/tracer/core/context.py
+++ b/src/honeyhive/tracer/core/context.py
@@ -314,6 +314,7 @@ class TracerContextMixin(TracerContextInterface):
         metadata: Optional[Dict[str, Any]] = None,
         user_properties: Optional[Dict[str, Any]] = None,
         source: Optional[str] = None,
+        skip_api_call: bool = False,
     ) -> Optional[str]:
         """Create a new session and set it in the current request context.
 
@@ -329,14 +330,18 @@ class TracerContextMixin(TracerContextInterface):
 
         Args:
             session_name: Name for the session. Auto-generated if not provided.
-            session_id: Custom session ID. If provided, sets this ID in baggage
-                       WITHOUT making an API call (bring-your-own-session-id pattern).
-                       Useful when session was created externally or you want to
-                       use your own ID scheme.
+            session_id: Custom session ID. If provided along with skip_api_call=True,
+                       sets this ID in baggage WITHOUT making an API call
+                       (bring-your-own-session-id pattern for linking to existing
+                       sessions). If skip_api_call=False (default), creates the
+                       session via API with this ID.
             inputs: Input data for the session (e.g., user query, request data)
             metadata: Additional metadata for the session
             user_properties: User-specific properties (user_id, plan, etc.)
             source: Source environment override. Uses tracer's source if not provided.
+            skip_api_call: If True and session_id is provided, skip API call and just
+                          set session_id in baggage. Useful for linking to sessions
+                          that were already created. Defaults to False.
 
         Returns:
             Session ID if successful, None otherwise
@@ -379,8 +384,8 @@ class TracerContextMixin(TracerContextInterface):
             Added for multi-session handling with global tracer pattern.
         """
         try:
-            # If session_id is provided, just set it in baggage (no API call)
-            if session_id:
+            # If session_id provided with skip_api_call, just set in baggage
+            if session_id and skip_api_call:
                 current_ctx = context.get_current()
                 new_ctx = baggage.set_baggage("session_id", session_id, current_ctx)
                 context.attach(new_ctx)
@@ -388,11 +393,12 @@ class TracerContextMixin(TracerContextInterface):
                 safe_log(
                     self,
                     "info",
-                    f"Set provided session_id in baggage: {session_id}",
+                    f"Set provided session_id in baggage (no API call): {session_id}",
                     honeyhive_data={
                         "session_id": session_id,
                         "storage": "baggage",
                         "source": "provided",
+                        "api_call": False,
                     },
                 )
                 return session_id
@@ -413,6 +419,10 @@ class TracerContextMixin(TracerContextInterface):
                 "source": effective_source,
                 "session_name": effective_session_name,
             }
+
+            # Include customer-provided session_id if specified
+            if session_id:
+                session_params["session_id"] = session_id
 
             if inputs:
                 session_params["inputs"] = inputs
@@ -461,6 +471,7 @@ class TracerContextMixin(TracerContextInterface):
         metadata: Optional[Dict[str, Any]] = None,
         user_properties: Optional[Dict[str, Any]] = None,
         source: Optional[str] = None,
+        skip_api_call: bool = False,
     ) -> Optional[str]:
         """Async version of create_session for async frameworks like FastAPI.
 
@@ -469,12 +480,15 @@ class TracerContextMixin(TracerContextInterface):
 
         Args:
             session_name: Name for the session. Auto-generated if not provided.
-            session_id: Custom session ID. If provided, sets this ID in baggage
-                       WITHOUT making an API call (bring-your-own-session-id pattern).
+            session_id: Custom session ID. If provided along with skip_api_call=True,
+                       sets this ID in baggage WITHOUT making an API call.
+                       If skip_api_call=False (default), creates session via API
+                       with this ID.
             inputs: Input data for the session
             metadata: Additional metadata for the session
             user_properties: User-specific properties
             source: Source environment override
+            skip_api_call: If True and session_id is provided, skip API call.
 
         Returns:
             Session ID if successful, None otherwise
@@ -498,8 +512,8 @@ class TracerContextMixin(TracerContextInterface):
         .. versionadded:: 1.0.0rc8
         """
         try:
-            # If session_id is provided, just set it in baggage (no API call)
-            if session_id:
+            # If session_id provided with skip_api_call, just set in baggage
+            if session_id and skip_api_call:
                 current_ctx = context.get_current()
                 new_ctx = baggage.set_baggage("session_id", session_id, current_ctx)
                 context.attach(new_ctx)
@@ -507,11 +521,12 @@ class TracerContextMixin(TracerContextInterface):
                 safe_log(
                     self,
                     "info",
-                    f"Set provided session_id in baggage (async): {session_id}",
+                    f"Set provided session_id in baggage (async, no API): {session_id}",
                     honeyhive_data={
                         "session_id": session_id,
                         "storage": "baggage",
                         "source": "provided",
+                        "api_call": False,
                     },
                 )
                 return session_id
@@ -532,6 +547,10 @@ class TracerContextMixin(TracerContextInterface):
                 "source": effective_source,
                 "session_name": effective_session_name,
             }
+
+            # Include customer-provided session_id if specified
+            if session_id:
+                session_params["session_id"] = session_id
 
             if inputs:
                 session_params["inputs"] = inputs

--- a/tests/integration/test_fastapi_multi_session_integration.py
+++ b/tests/integration/test_fastapi_multi_session_integration.py
@@ -1,0 +1,209 @@
+"""Integration test for FastAPI multi-session handling with global tracer.
+
+This test demonstrates and validates the recommended pattern for handling
+multiple concurrent sessions with a single globally-initialized tracer.
+
+The key pattern:
+1. Initialize tracer ONCE at app startup (shared across all requests)
+2. Use create_session() or acreate_session() in middleware to create
+   request-scoped sessions stored in baggage (ContextVar-based)
+3. All spans within a request automatically use the correct session
+
+This test requires:
+- HH_API_KEY environment variable (or in .env file)
+- Network access to HoneyHive API
+"""
+
+import asyncio
+import os
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+# Check for required dependencies
+try:
+    from fastapi import FastAPI, Request
+    from fastapi.testclient import TestClient
+    from httpx import ASGITransport, AsyncClient
+
+    HAS_FASTAPI = True
+except ImportError:
+    HAS_FASTAPI = False
+
+from honeyhive import HoneyHiveTracer, trace
+
+# Skip all tests if FastAPI is not installed
+pytestmark = pytest.mark.skipif(
+    not HAS_FASTAPI, reason="FastAPI not installed (pip install fastapi httpx)"
+)
+
+
+# pylint: disable=redefined-outer-name
+# Justification: Pytest fixtures use the name as dependency injection
+
+
+@pytest.fixture
+def api_key() -> Optional[str]:
+    """Get API key from environment."""
+    return os.getenv("HH_API_KEY") or os.getenv("HONEYHIVE_API_KEY")
+
+
+@pytest.fixture
+def has_api_key(api_key: Optional[str]) -> bool:
+    """Check if API key is available."""
+    return api_key is not None
+
+
+class TestFastAPIMultiSessionIntegration:
+    """Integration tests for FastAPI multi-session handling.
+
+    These tests use real API calls to validate the multi-session pattern.
+    """
+
+    def test_middleware_creates_isolated_sessions_sync(
+        self, api_key: Optional[str], has_api_key: bool
+    ) -> None:
+        """Test that middleware creates isolated sessions for each request.
+
+        This test uses the synchronous create_session() to avoid event loop
+        issues with Starlette's TestClient between requests.
+        """
+        if not has_api_key:
+            pytest.skip("HH_API_KEY not set - skipping integration test")
+
+        # Track created sessions for verification
+        created_sessions: List[str] = []
+
+        # Create FastAPI app with multi-session middleware
+        app = FastAPI()
+
+        # Initialize tracer ONCE (shared across all requests)
+        tracer = HoneyHiveTracer.init(
+            api_key=api_key,
+            project="test-fastapi-multi-session",
+            source="integration-test",
+        )
+
+        @app.middleware("http")
+        async def session_middleware(request: Request, call_next: Any) -> Any:
+            """Create isolated session for each request using baggage."""
+            # Use sync create_session to avoid event loop issues with TestClient
+            # In production with real async servers (uvicorn), use acreate_session
+            session_id = tracer.create_session(
+                session_name=f"test-request-{request.url.path}",
+                inputs={
+                    "method": request.method,
+                    "path": str(request.url.path),
+                },
+            )
+
+            if session_id:
+                created_sessions.append(session_id)
+
+            response = await call_next(request)
+
+            # Enrich session with response data
+            tracer.enrich_session(
+                outputs={"status_code": response.status_code},
+                metadata={"completed": True},
+            )
+
+            return response
+
+        @app.get("/test/{item_id}")
+        @trace(tracer=tracer, event_type="chain")
+        async def test_endpoint(item_id: str) -> Dict[str, str]:
+            """Test endpoint that creates a traced span."""
+            # This span automatically uses the session_id from baggage
+            tracer.enrich_span(metadata={"item_id": item_id})
+            return {"item_id": item_id, "status": "processed"}
+
+        # Make multiple requests using sync TestClient
+        client = TestClient(app)
+
+        response1 = client.get("/test/item-1")
+        assert response1.status_code == 200
+        assert response1.json()["item_id"] == "item-1"
+
+        response2 = client.get("/test/item-2")
+        assert response2.status_code == 200
+        assert response2.json()["item_id"] == "item-2"
+
+        # Verify sessions were created
+        assert len(created_sessions) == 2
+        # Verify sessions are different (isolated)
+        assert created_sessions[0] != created_sessions[1]
+
+        # Cleanup
+        tracer.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_requests_have_isolated_sessions(
+        self, api_key: Optional[str], has_api_key: bool
+    ) -> None:
+        """Test that concurrent async requests have properly isolated sessions.
+
+        This is the critical test for multi-session handling - verifying that
+        concurrent requests don't interfere with each other's session context.
+        """
+        if not has_api_key:
+            pytest.skip("HH_API_KEY not set - skipping integration test")
+
+        # Track session IDs per request
+        request_sessions: Dict[str, str] = {}
+
+        app = FastAPI()
+
+        # Initialize tracer ONCE
+        tracer = HoneyHiveTracer.init(
+            api_key=api_key,
+            project="test-fastapi-concurrent",
+            source="integration-test",
+        )
+
+        @app.middleware("http")
+        async def session_middleware(request: Request, call_next: Any) -> Any:
+            """Create isolated session for each request."""
+            request_id = request.headers.get("X-Request-ID", "unknown")
+
+            session_id = await tracer.acreate_session(
+                session_name=f"concurrent-test-{request_id}",
+                inputs={"request_id": request_id},
+            )
+
+            if session_id:
+                request_sessions[request_id] = session_id
+
+            response = await call_next(request)
+            return response
+
+        @app.get("/slow/{delay}")
+        @trace(tracer=tracer, event_type="chain")
+        async def slow_endpoint(delay: float) -> Dict[str, Any]:
+            """Endpoint with artificial delay to test concurrency."""
+            await asyncio.sleep(delay)
+            return {"delay": delay, "completed": True}
+
+        # Make concurrent requests
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            # Start multiple requests concurrently with different delays
+            tasks = [
+                client.get("/slow/0.1", headers={"X-Request-ID": "req-1"}),
+                client.get("/slow/0.05", headers={"X-Request-ID": "req-2"}),
+                client.get("/slow/0.15", headers={"X-Request-ID": "req-3"}),
+            ]
+
+            responses = await asyncio.gather(*tasks)
+
+        # Verify all requests completed successfully
+        assert all(r.status_code == 200 for r in responses)
+
+        # Verify each request got a unique session
+        assert len(request_sessions) == 3
+        session_ids = list(request_sessions.values())
+        assert len(set(session_ids)) == 3, "All sessions should be unique"
+
+        # Cleanup
+        tracer.shutdown()

--- a/tests/unit/test_fastapi_multi_session.py
+++ b/tests/unit/test_fastapi_multi_session.py
@@ -1,0 +1,248 @@
+"""Unit tests for FastAPI multi-session pattern with mocked API calls.
+
+These tests verify the multi-session pattern works correctly without
+requiring actual API access, making them faster and more reliable for CI.
+"""
+
+from typing import Any, Dict
+from unittest.mock import patch
+
+import pytest
+
+# Check for required dependencies
+try:
+    from fastapi import FastAPI, Request
+    from fastapi.testclient import TestClient
+
+    HAS_FASTAPI = True
+except ImportError:
+    HAS_FASTAPI = False
+
+from honeyhive import HoneyHiveTracer, trace
+
+# Skip all tests if FastAPI is not installed
+pytestmark = pytest.mark.skipif(
+    not HAS_FASTAPI, reason="FastAPI not installed (pip install fastapi httpx)"
+)
+
+
+class TestFastAPIMultiSessionMocked:
+    """Tests for FastAPI multi-session pattern with mocked API calls."""
+
+    def test_session_id_stored_in_baggage_not_instance(self) -> None:
+        """Verify that create_session stores session_id in baggage, not instance.
+
+        This is critical for concurrent request isolation.
+        """
+        app = FastAPI()
+
+        # Create tracer in test mode (no API calls)
+        tracer = HoneyHiveTracer.init(
+            api_key="test-key",
+            project="test-project",
+            test_mode=True,
+        )
+
+        # Track instance session_id
+        initial_session_id = tracer._session_id
+
+        @app.middleware("http")
+        async def session_middleware(request: Request, call_next: Any) -> Any:
+            # Mock the session API to return a session ID
+            with patch.object(tracer, "session_api") as mock_api:
+                mock_response = type(
+                    "Response", (), {"session_id": "mock-session-123"}
+                )()
+
+                async def mock_create_async(_: Any) -> Any:
+                    return mock_response
+
+                mock_api.create_session_from_dict_async = mock_create_async
+
+                session_id = await tracer.acreate_session(session_name="test-session")
+
+                # Verify session was created
+                assert session_id == "mock-session-123"
+
+                # CRITICAL: Instance session_id should NOT be modified
+                assert tracer._session_id == initial_session_id
+
+            return await call_next(request)
+
+        @app.get("/test")
+        async def test_endpoint() -> Dict[str, str]:
+            return {"status": "ok"}
+
+        client = TestClient(app)
+        response = client.get("/test")
+        assert response.status_code == 200
+
+    def test_with_session_context_manager(self) -> None:
+        """Test the with_session context manager pattern."""
+        tracer = HoneyHiveTracer.init(
+            api_key="test-key",
+            project="test-project",
+            test_mode=True,
+        )
+
+        # Mock create_session to return a session ID
+        with patch.object(tracer, "create_session", return_value="ctx-session-456"):
+            with tracer.with_session(
+                session_name="context-manager-test",
+                inputs={"test": "data"},
+            ) as session_id:
+                assert session_id == "ctx-session-456"
+
+    def test_sync_create_session_for_flask_pattern(self) -> None:
+        """Test sync create_session for Flask/Django patterns."""
+        tracer = HoneyHiveTracer.init(
+            api_key="test-key",
+            project="test-project",
+            test_mode=True,
+        )
+
+        # Mock the session API
+        with patch.object(tracer, "session_api") as mock_api:
+            mock_response = type("Response", (), {"session_id": "sync-session-789"})()
+            mock_api.create_session_from_dict.return_value = mock_response
+
+            session_id = tracer.create_session(
+                session_name="sync-test-session",
+                inputs={"sync": True},
+            )
+
+            assert session_id == "sync-session-789"
+
+            # Verify API was called with correct params
+            call_args = mock_api.create_session_from_dict.call_args[0][0]
+            assert call_args["session_name"] == "sync-test-session"
+            assert call_args["inputs"] == {"sync": True}
+
+    def test_create_session_with_provided_session_id(self) -> None:
+        """Test that providing session_id skips API call."""
+        tracer = HoneyHiveTracer.init(
+            api_key="test-key",
+            project="test-project",
+            test_mode=True,
+        )
+
+        # Provide our own session ID - should NOT call API
+        with patch.object(tracer, "session_api") as mock_api:
+            session_id = tracer.create_session(session_id="my-custom-session-id")
+
+            # Verify returned session ID matches what we provided
+            assert session_id == "my-custom-session-id"
+
+            # Verify API was NOT called (we provided the ID)
+            mock_api.create_session_from_dict.assert_not_called()
+
+
+class TestFastAPIMiddlewareExample:
+    """Example-driven tests showing the recommended patterns."""
+
+    # pylint: disable=too-few-public-methods
+    # Justification: This is an example test class, not a production class
+
+    def test_complete_fastapi_example(self) -> None:
+        """Complete example of FastAPI multi-session pattern.
+
+        This test serves as executable documentation of the recommended pattern.
+        """
+        # ===== SETUP: Initialize tracer ONCE at app startup =====
+        tracer = HoneyHiveTracer.init(
+            api_key="test-key",
+            project="my-api",
+            source="production",
+            test_mode=True,  # Use test_mode for this example
+        )
+
+        app = FastAPI()
+
+        # ===== MIDDLEWARE: Create session per request =====
+        @app.middleware("http")
+        async def honeyhive_session_middleware(request: Request, call_next: Any) -> Any:
+            """
+            Multi-session middleware pattern.
+
+            Key points:
+            1. acreate_session() stores session_id in baggage (ContextVar)
+            2. Does NOT modify tracer._session_id (would cause race conditions)
+            3. Each concurrent request gets isolated session context
+            """
+            # For test mode, mock the session creation
+            with patch.object(tracer, "session_api") as mock_api:
+                mock_session_id = f"session-{id(request)}"
+                mock_response = type("Response", (), {"session_id": mock_session_id})()
+
+                async def mock_create_async(_: Any) -> Any:
+                    return mock_response
+
+                mock_api.create_session_from_dict_async = mock_create_async
+
+                session_id = await tracer.acreate_session(
+                    session_name=f"api-{request.url.path}",
+                    inputs={
+                        "method": request.method,
+                        "path": str(request.url.path),
+                        "user_id": request.headers.get("X-User-ID"),
+                    },
+                )
+
+            # Store session_id in request state for access in endpoints
+            request.state.session_id = session_id
+
+            response = await call_next(request)
+
+            # Enrich session with response data
+            # enrich_session reads session_id from baggage automatically
+            tracer.enrich_session(outputs={"status_code": response.status_code})
+
+            # Optionally add session_id to response headers
+            if session_id:
+                response.headers["X-Session-ID"] = session_id
+
+            return response
+
+        # ===== ENDPOINTS: Spans automatically use request's session =====
+        @app.post("/chat")
+        @trace(tracer=tracer, event_type="chain")
+        async def chat_endpoint(request: Request) -> Dict[str, Any]:
+            """
+            Chat endpoint with automatic session association.
+
+            The @trace decorator creates a span that automatically picks up
+            session_id from baggage (set by middleware).
+            """
+            tracer.enrich_span(metadata={"endpoint": "chat"})
+
+            # Nested function calls also use the same session
+            result = await process_message("Hello")
+
+            return {
+                "response": result,
+                "session_id": request.state.session_id,
+            }
+
+        @trace(tracer=tracer, event_type="tool")
+        async def process_message(message: str) -> str:
+            """Process message - span uses parent's session context."""
+            tracer.enrich_span(
+                inputs={"message": message},
+                outputs={"processed": True},
+            )
+            return f"Processed: {message}"
+
+        # ===== TEST THE PATTERN =====
+        client = TestClient(app)
+
+        response = client.post(
+            "/chat",
+            headers={"X-User-ID": "user-123"},
+        )
+
+        assert response.status_code == 200
+        assert "session_id" in response.json()
+        assert "X-Session-ID" in response.headers
+
+        # Cleanup
+        tracer.shutdown()

--- a/tests/unit/test_fastapi_multi_session.py
+++ b/tests/unit/test_fastapi_multi_session.py
@@ -118,22 +118,53 @@ class TestFastAPIMultiSessionMocked:
             assert call_args["session_name"] == "sync-test-session"
             assert call_args["inputs"] == {"sync": True}
 
-    def test_create_session_with_provided_session_id(self) -> None:
-        """Test that providing session_id skips API call."""
+    def test_create_session_with_provided_session_id_calls_api(self) -> None:
+        """Test that providing session_id still calls API by default."""
         tracer = HoneyHiveTracer.init(
             api_key="test-key",
             project="test-project",
             test_mode=True,
         )
 
-        # Provide our own session ID - should NOT call API
+        # Provide our own session ID - should call API with that ID
         with patch.object(tracer, "session_api") as mock_api:
-            session_id = tracer.create_session(session_id="my-custom-session-id")
+            mock_response = type(
+                "Response", (), {"session_id": "my-custom-session-id"}
+            )()
+            mock_api.create_session_from_dict.return_value = mock_response
+
+            session_id = tracer.create_session(
+                session_id="my-custom-session-id",
+                session_name="custom-session",
+            )
 
             # Verify returned session ID matches what we provided
             assert session_id == "my-custom-session-id"
 
-            # Verify API was NOT called (we provided the ID)
+            # Verify API WAS called with the provided session_id
+            mock_api.create_session_from_dict.assert_called_once()
+            call_args = mock_api.create_session_from_dict.call_args[0][0]
+            assert call_args["session_id"] == "my-custom-session-id"
+
+    def test_create_session_with_skip_api_call(self) -> None:
+        """Test that skip_api_call=True skips the API call."""
+        tracer = HoneyHiveTracer.init(
+            api_key="test-key",
+            project="test-project",
+            test_mode=True,
+        )
+
+        # Provide session_id with skip_api_call=True - should NOT call API
+        with patch.object(tracer, "session_api") as mock_api:
+            session_id = tracer.create_session(
+                session_id="existing-session-id",
+                skip_api_call=True,
+            )
+
+            # Verify returned session ID matches what we provided
+            assert session_id == "existing-session-id"
+
+            # Verify API was NOT called
             mock_api.create_session_from_dict.assert_not_called()
 
 

--- a/tests/unit/test_tracer_core_context.py
+++ b/tests/unit/test_tracer_core_context.py
@@ -21,6 +21,14 @@ from opentelemetry.context import Context
 
 from honeyhive.tracer.core.context import TracerContextInterface, TracerContextMixin
 
+# Check if pytest-asyncio is available for async tests
+try:
+    import pytest_asyncio  # noqa: F401
+
+    HAS_ASYNCIO = True
+except ImportError:
+    HAS_ASYNCIO = False
+
 
 class TestTracerContextInterface:
     """Test suite for TracerContextInterface abstract base class."""
@@ -585,6 +593,285 @@ class TestSessionStart:
         )
 
 
+class TestCreateSession:
+    """Test suite for create_session method (multi-session handling)."""
+
+    @pytest.fixture
+    def context_mixin(self) -> MockTracerContextMixin:
+        """Create a mock TracerContextMixin instance for testing."""
+        mixin = MockTracerContextMixin()
+        mixin.project_name = "test-project"  # type: ignore[attr-defined]
+        mixin.source_environment = "test"  # type: ignore[attr-defined]
+        return mixin
+
+    @patch("honeyhive.tracer.core.context.context.attach")
+    @patch("honeyhive.tracer.core.context.baggage.set_baggage")
+    @patch("honeyhive.tracer.core.context.context.get_current")
+    @patch("honeyhive.tracer.core.context.safe_log")
+    def test_create_session_success(
+        self,
+        mock_safe_log: Mock,
+        mock_get_current: Mock,
+        mock_set_baggage: Mock,
+        mock_attach: Mock,
+        context_mixin: MockTracerContextMixin,
+    ) -> None:
+        """Test successful session creation with baggage."""
+        # Arrange
+        mock_session_api = Mock()
+        mock_response = Mock()
+        mock_response.session_id = "new-session-123"
+        mock_session_api.create_session_from_dict.return_value = mock_response
+        context_mixin.session_api = mock_session_api
+
+        mock_current_ctx = Mock()
+        mock_new_ctx = Mock()
+        mock_get_current.return_value = mock_current_ctx
+        mock_set_baggage.return_value = mock_new_ctx
+
+        # Act
+        result = context_mixin.create_session(
+            session_name="test-session",
+            inputs={"query": "test"},
+            metadata={"source": "unit-test"},
+        )
+
+        # Assert
+        assert result == "new-session-123"
+        mock_session_api.create_session_from_dict.assert_called_once()
+        call_args = mock_session_api.create_session_from_dict.call_args[0][0]
+        assert call_args["session_name"] == "test-session"
+        assert call_args["inputs"] == {"query": "test"}
+        assert call_args["metadata"] == {"source": "unit-test"}
+
+        # Verify baggage was set (not instance _session_id)
+        mock_set_baggage.assert_called_once_with(
+            "session_id", "new-session-123", mock_current_ctx
+        )
+        mock_attach.assert_called_once_with(mock_new_ctx)
+
+    @patch("honeyhive.tracer.core.context.safe_log")
+    def test_create_session_no_session_api(
+        self, mock_safe_log: Mock, context_mixin: MockTracerContextMixin
+    ) -> None:
+        """Test create_session without session API."""
+        # Arrange
+        context_mixin.session_api = None
+
+        # Act
+        result = context_mixin.create_session(session_name="test-session")
+
+        # Assert
+        assert result is None
+        mock_safe_log.assert_called_once_with(
+            context_mixin, "warning", "No session API available for session creation"
+        )
+
+    @patch("honeyhive.tracer.core.context.context.get_current")
+    @patch("honeyhive.tracer.core.context.safe_log")
+    def test_create_session_auto_generates_name(
+        self,
+        mock_safe_log: Mock,
+        mock_get_current: Mock,
+        context_mixin: MockTracerContextMixin,
+    ) -> None:
+        """Test create_session auto-generates session name when not provided."""
+        # Arrange
+        mock_session_api = Mock()
+        mock_response = Mock()
+        mock_response.session_id = "auto-session-456"
+        mock_session_api.create_session_from_dict.return_value = mock_response
+        context_mixin.session_api = mock_session_api
+
+        with patch("honeyhive.tracer.core.context.baggage.set_baggage"):
+            with patch("honeyhive.tracer.core.context.context.attach"):
+                # Act
+                result = context_mixin.create_session()
+
+        # Assert
+        assert result == "auto-session-456"
+        call_args = mock_session_api.create_session_from_dict.call_args[0][0]
+        assert call_args["session_name"].startswith("session-")
+
+    @patch("honeyhive.tracer.core.context.safe_log")
+    def test_create_session_exception_handling(
+        self, mock_safe_log: Mock, context_mixin: MockTracerContextMixin
+    ) -> None:
+        """Test create_session exception handling."""
+        # Arrange
+        mock_session_api = Mock()
+        test_error = RuntimeError("API call failed")
+        mock_session_api.create_session_from_dict.side_effect = test_error
+        context_mixin.session_api = mock_session_api
+
+        # Act
+        result = context_mixin.create_session(session_name="test-session")
+
+        # Assert
+        assert result is None
+        mock_safe_log.assert_called_with(
+            context_mixin,
+            "error",
+            f"Failed to create session: {test_error}",
+            honeyhive_data={"error_type": "RuntimeError"},
+        )
+
+    @patch("honeyhive.tracer.core.context.context.attach")
+    @patch("honeyhive.tracer.core.context.baggage.set_baggage")
+    @patch("honeyhive.tracer.core.context.context.get_current")
+    @patch("honeyhive.tracer.core.context.safe_log")
+    def test_create_session_does_not_modify_instance_session_id(
+        self,
+        mock_safe_log: Mock,
+        mock_get_current: Mock,
+        mock_set_baggage: Mock,
+        mock_attach: Mock,
+        context_mixin: MockTracerContextMixin,
+    ) -> None:
+        """Test that create_session does NOT modify tracer._session_id.
+
+        This is critical for multi-session handling - session_id must only
+        be stored in baggage to enable concurrent request isolation.
+        """
+        # Arrange
+        mock_session_api = Mock()
+        mock_response = Mock()
+        mock_response.session_id = "baggage-only-session"
+        mock_session_api.create_session_from_dict.return_value = mock_response
+        context_mixin.session_api = mock_session_api
+        context_mixin._session_id = None  # Start with no session
+
+        # Act
+        result = context_mixin.create_session(session_name="test-session")
+
+        # Assert
+        assert result == "baggage-only-session"
+        # CRITICAL: _session_id should NOT be modified
+        assert context_mixin._session_id is None
+
+
+@pytest.mark.skipif(not HAS_ASYNCIO, reason="pytest-asyncio not installed")
+class TestAcreateSession:
+    """Test suite for acreate_session async method."""
+
+    @pytest.fixture
+    def context_mixin(self) -> MockTracerContextMixin:
+        """Create a mock TracerContextMixin instance for testing."""
+        mixin = MockTracerContextMixin()
+        mixin.project_name = "test-project"  # type: ignore[attr-defined]
+        mixin.source_environment = "test"  # type: ignore[attr-defined]
+        return mixin
+
+    @pytest.mark.asyncio
+    @patch("honeyhive.tracer.core.context.context.attach")
+    @patch("honeyhive.tracer.core.context.baggage.set_baggage")
+    @patch("honeyhive.tracer.core.context.context.get_current")
+    @patch("honeyhive.tracer.core.context.safe_log")
+    async def test_acreate_session_success(
+        self,
+        mock_safe_log: Mock,
+        mock_get_current: Mock,
+        mock_set_baggage: Mock,
+        mock_attach: Mock,
+        context_mixin: MockTracerContextMixin,
+    ) -> None:
+        """Test successful async session creation with baggage."""
+        # Arrange
+        mock_session_api = Mock()
+        mock_response = Mock()
+        mock_response.session_id = "async-session-789"
+
+        async def mock_create(*args: Any, **kwargs: Any) -> Mock:
+            return mock_response
+
+        mock_session_api.create_session_from_dict_async = mock_create
+        context_mixin.session_api = mock_session_api
+
+        mock_current_ctx = Mock()
+        mock_new_ctx = Mock()
+        mock_get_current.return_value = mock_current_ctx
+        mock_set_baggage.return_value = mock_new_ctx
+
+        # Act
+        result = await context_mixin.acreate_session(
+            session_name="async-test-session",
+            inputs={"query": "async test"},
+        )
+
+        # Assert
+        assert result == "async-session-789"
+        mock_set_baggage.assert_called_once_with(
+            "session_id", "async-session-789", mock_current_ctx
+        )
+        mock_attach.assert_called_once_with(mock_new_ctx)
+
+    @pytest.mark.asyncio
+    @patch("honeyhive.tracer.core.context.safe_log")
+    async def test_acreate_session_no_session_api(
+        self, mock_safe_log: Mock, context_mixin: MockTracerContextMixin
+    ) -> None:
+        """Test acreate_session without session API."""
+        # Arrange
+        context_mixin.session_api = None
+
+        # Act
+        result = await context_mixin.acreate_session(session_name="test-session")
+
+        # Assert
+        assert result is None
+        mock_safe_log.assert_called_once_with(
+            context_mixin, "warning", "No session API available for session creation"
+        )
+
+
+class TestWithSession:
+    """Test suite for with_session context manager."""
+
+    @pytest.fixture
+    def context_mixin(self) -> MockTracerContextMixin:
+        """Create a mock TracerContextMixin instance for testing."""
+        mixin = MockTracerContextMixin()
+        mixin.project_name = "test-project"  # type: ignore[attr-defined]
+        mixin.source_environment = "test"  # type: ignore[attr-defined]
+        return mixin
+
+    def test_with_session_yields_session_id(
+        self, context_mixin: MockTracerContextMixin
+    ) -> None:
+        """Test that with_session yields the session_id."""
+        # Arrange
+        with patch.object(
+            context_mixin, "create_session", return_value="ctx-session-123"
+        ) as mock_create:
+            # Act
+            with context_mixin.with_session(
+                session_name="ctx-test",
+                inputs={"query": "test"},
+            ) as session_id:
+                # Assert
+                assert session_id == "ctx-session-123"
+                mock_create.assert_called_once_with(
+                    session_name="ctx-test",
+                    inputs={"query": "test"},
+                    metadata=None,
+                    user_properties=None,
+                    source=None,
+                )
+
+    def test_with_session_handles_none_session_id(
+        self, context_mixin: MockTracerContextMixin
+    ) -> None:
+        """Test with_session when create_session returns None."""
+        # Arrange
+        with patch.object(context_mixin, "create_session", return_value=None):
+            # Act
+            with context_mixin.with_session(
+                session_name="failing-session"
+            ) as session_id:
+                # Assert
+                assert session_id is None
+
+
 class TestPrivateHelperMethods:
     """Test suite for private helper methods."""
 
@@ -653,37 +940,46 @@ class TestPrivateHelperMethods:
             context_mixin, "debug", "No session ID available for enrichment"
         )
 
-    def test_get_session_id_for_enrichment_from_instance(
-        self, context_mixin: MockTracerContextMixin
+    @patch("honeyhive.tracer.core.context.get_current_baggage")
+    def test_get_session_id_for_enrichment_from_instance_fallback(
+        self, mock_get_baggage: Mock, context_mixin: MockTracerContextMixin
     ) -> None:
-        """Test getting session ID from instance variable."""
+        """Test getting session ID from instance when baggage is empty.
+
+        Priority: baggage first, then instance (fallback for backwards compat).
+        """
         # Arrange
         context_mixin._session_id = "instance-session-789"
+        mock_get_baggage.return_value = {}  # Empty baggage
 
         # Act
         result = context_mixin._get_session_id_for_enrichment_dynamically()
 
-        # Assert
+        # Assert - Should fall back to instance session_id
         assert result == "instance-session-789"
 
     @patch("honeyhive.tracer.core.context.get_current_baggage")
     @patch("honeyhive.tracer.core.context.safe_log")
-    def test_get_session_id_for_enrichment_from_baggage(
+    def test_get_session_id_for_enrichment_from_baggage_priority(
         self,
         mock_safe_log: Mock,
         mock_get_baggage: Mock,
         context_mixin: MockTracerContextMixin,
     ) -> None:
-        """Test getting session ID from baggage."""
-        # Arrange
-        context_mixin._session_id = None
-        mock_get_baggage.return_value = {"session_id": "baggage-session-456"}
+        """Test that baggage session_id takes priority over instance.
+
+        This is critical for multi-session handling - baggage is request-scoped
+        while instance session_id is shared across all requests.
+        """
+        # Arrange - BOTH baggage and instance have session_id
+        context_mixin._session_id = "instance-session-should-be-ignored"
+        mock_get_baggage.return_value = {"session_id": "baggage-session-priority"}
 
         # Act
         result = context_mixin._get_session_id_for_enrichment_dynamically()
 
-        # Assert
-        assert result == "baggage-session-456"
+        # Assert - Baggage takes priority (request-scoped)
+        assert result == "baggage-session-priority"
         mock_safe_log.assert_not_called()
 
     @patch("honeyhive.tracer.core.context.get_current_baggage")


### PR DESCRIPTION
## Summary

This PR adds proper multi-session support for web servers (FastAPI, Flask, Django) by storing session IDs in OpenTelemetry baggage instead of on the tracer instance.

## Problem

When using a globally-initialized tracer with concurrent requests in web servers, calling `session_start()` stores the `session_id` on the tracer instance (`tracer._session_id`). This causes race conditions where concurrent requests overwrite each other's session IDs.

## Solution

Added `create_session()` and `acreate_session()` methods that:
1. Create a session via the HoneyHive API
2. Store the `session_id` in **OpenTelemetry baggage** (which uses Python's `ContextVar` internally)
3. Provide request-scoped isolation without modifying the tracer instance

The span processor already reads `session_id` from baggage with priority, so all spans within a request automatically use the correct session.

## Key Changes

### 1. New Methods in `TracerContextMixin`
- `create_session()` - Sync version for Flask/Django
- `acreate_session()` - Async version for FastAPI
- Both support optional `session_id` parameter for 'bring-your-own-session-id' pattern

### 2. Customer-Facing Example
- `examples/fastapi_multi_session_example.py` - Complete runnable example

### 3. Tests
- `tests/integration/test_fastapi_multi_session_integration.py` - Real API tests
- `tests/unit/test_fastapi_multi_session.py` - Mocked unit tests

### 4. Documentation
- Updated `tracer-initialization-patterns.rst` with Pattern 4
- Updated `tracer.rst` with FastAPI multi-session example

## Usage Example

```python
from fastapi import FastAPI, Request
from honeyhive import HoneyHiveTracer, trace

tracer = HoneyHiveTracer.init(api_key="...", project="my-api")
app = FastAPI()

@app.middleware("http")
async def session_middleware(request: Request, call_next):
    # Creates session, stores session_id in baggage (NOT on tracer instance)
    session_id = await tracer.acreate_session(
        session_name=f"api-{request.url.path}",
        inputs={"method": request.method}
    )
    
    response = await call_next(request)
    
    # enrich_session reads session_id from baggage automatically
    tracer.enrich_session(outputs={"status_code": response.status_code})
    return response

@app.post("/chat")
@trace(event_type="chain", tracer=tracer)
async def chat(message: str):
    # Span automatically uses session_id from baggage
    return await process_message(message)
```

## Breaking Changes
None (additive only)

## Deprecation
`session_start()` should not be used for web servers (it still works for single-session scripts)