### PR TITLE
fix: Correct evaluate() docstrings to show correct function signature

### DIFF
--- a/src/honeyhive/experiments/core.py
+++ b/src/honeyhive/experiments/core.py
@@ -170,11 +170,14 @@ def run_experiment(
         List of execution results (one per datapoint)
 
     Examples:
-        >>> def my_function(inputs, ground_truth):
+        >>> def my_function(datapoint):
+        ...     inputs = datapoint.get("inputs", {})
+        ...     ground_truth = datapoint.get("ground_truth", {})
         ...     return {"output": "test"}
         >>>
         >>> # Async functions are also supported
-        >>> async def my_async_function(inputs, ground_truth):
+        >>> async def my_async_function(datapoint):
+        ...     inputs = datapoint.get("inputs", {})
         ...     result = await some_async_call()
         ...     return {"output": result}
         >>>
@@ -844,12 +847,15 @@ def evaluate(  # pylint: disable=too-many-locals,too-many-branches
         >>> from honeyhive.experiments import evaluate
         >>>
         >>> # Define function to test (sync)
-        >>> def my_function(inputs, ground_truth):
+        >>> def my_function(datapoint):
+        ...     inputs = datapoint.get("inputs", {})
+        ...     ground_truth = datapoint.get("ground_truth", {})
         ...     # Your LLM call or function logic
         ...     return {"output": "result"}
         >>>
         >>> # Async functions are also supported
-        >>> async def my_async_function(inputs, ground_truth):
+        >>> async def my_async_function(datapoint):
+        ...     inputs = datapoint.get("inputs", {})
         ...     result = await some_async_llm_call()
         ...     return {"output": result}
         >>>


### PR DESCRIPTION
## Summary
- Fixed incorrect function signature in `evaluate()` and `run_experiment()` docstrings
- Docstrings previously showed `def my_function(inputs, ground_truth):` but the actual implementation passes a single `datapoint` dict
- Updated to correct pattern: `def my_function(datapoint):` with examples of extracting inputs/ground_truth

## Details
The docstrings at lines 173-179 and 847-854 showed the wrong function signature. The actual implementation at lines 297-311 calls `traced_function(datapoint)` with a single dict containing both `inputs` and `ground_truth` keys.

This was confirmed by `examples/eval_example.py` which correctly uses:
```python
def evaluation_function(datapoint):
    inputs = datapoint.get("inputs", {})
    context = inputs.get("context", "")
    ...
```

## Test plan
- [x] Verified docstrings now match actual implementation
- [x] Verified alignment with working example in `eval_example.py`
- [x] No linter errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns documentation with the actual function signature used by the experiments API.
> 
> - Updates `run_experiment()` and `evaluate()` docstring examples to `def my_function(datapoint)` and async equivalent
> - Shows extracting `inputs` and `ground_truth` from `datapoint` in examples
> - Docstring-only changes; no runtime logic modified
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b99639a7ee214781c477ccc48d303a30c00c0730. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->