### PR TITLE
feat: add events export API with backwards-compatible interfaces

### DIFF
--- a/examples/eval_test.py
+++ b/examples/eval_test.py
@@ -1,0 +1,70 @@
+from honeyhive.experiments import evaluate, evaluator
+import os
+from openai import OpenAI
+import random
+from openinference.instrumentation.openai import OpenAIInstrumentor
+
+openai_client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+def function_to_evaluate(datapoint):
+    """Evaluation function that receives a single datapoint dict."""
+    inputs = datapoint.get("inputs", {})
+    ground_truth = datapoint.get("ground_truth", {})
+
+    completion = openai_client.chat.completions.create(
+        model="gpt-4o",
+        messages=[
+            {"role": "system", "content": f"You are an expert analyst specializing in {inputs['product_type']} market trends."},
+            {"role": "user", "content": f"Could you provide an analysis of the current market performance and consumer reception of {inputs['product_type']} in {inputs['region']}? Please include any notable trends or challenges specific to this region."}
+        ]
+    )
+    return completion.choices[0].message.content
+
+dataset = [
+    {
+        "inputs": {
+            "product_type": "electric vehicles",
+            "region": "western europe",
+            "time_period": "first half of 2023",
+            "metric_1": "total revenue",
+            "metric_2": "market share"
+        },
+        "ground_truth": {
+            "response": "As of 2023, the electric vehicle (EV) market in Western Europe is experiencing significant growth, with the region maintaining its status as a global leader in EV adoption. [continue...]",
+        }
+    },
+    {
+        "inputs": {
+            "product_type": "gaming consoles",
+            "region": "north america",
+            "time_period": "holiday season 2022",
+            "metric_1": "units sold",
+            "metric_2": "gross profit margin"
+        },
+        "ground_truth": {
+            "response": "As of 2023, the gaming console market in North America is characterized by intense competition, steady consumer demand, and evolving trends influenced by technological advancements and changing consumer preferences. [continue...]",
+        }
+    }
+]
+
+@evaluator
+def sample_evaluator(outputs, inputs, ground_truth):
+    """Evaluator that receives outputs, inputs, and ground_truth (singular)."""
+    return random.randint(1, 5)
+
+if __name__ == "__main__":
+    result = evaluate(
+        function = function_to_evaluate,                         # Function that will be evaluated
+        api_key = os.getenv("HH_API_KEY"),                       # Your HoneyHive API key
+        name = 'Sample Experiment',                              # Name for this experiment run
+        dataset = dataset,
+        evaluators=[sample_evaluator],                           # Custom client-side evaluators to compute metrics on each run
+        instrumentors=[lambda: OpenAIInstrumentor()],
+        server_url="https://api.testing-dp-1.honeyhive.ai",
+        verbose=True,
+    )
+
+    print(f"\nEvaluation complete!")
+    print(f"Success: {result.success}")
+    print(f"Passed: {len(result.passed)}")
+    print(f"Failed: {len(result.failed)}")

--- a/examples/test.py
+++ b/examples/test.py
@@ -1,12 +1,10 @@
-import os
 import time
-from datetime import datetime, timedelta, timezone
-import httpx
 
 from openai import OpenAI
 from openinference.instrumentation.openai import OpenAIInstrumentor
 
-from honeyhive import HoneyHiveTracer, trace
+from honeyhive import HoneyHive, HoneyHiveTracer, trace
+from honeyhive.models import EventFilter
 
 # Initialize tracer
 tracer = HoneyHiveTracer.init(
@@ -35,49 +33,43 @@ call_openai()
 tracer.force_flush()
 
 # Wait for events to be processed
-print("\nWaiting 5 seconds for events to be processed...")
+print("\nWaiting 10 seconds for events to be processed...")
 time.sleep(10)
 
-# Fetch events for this session using direct httpx request
+# Fetch events for this session using the SDK client
 session_id = tracer.session_id
 project_name = tracer.project_name
-api_url = os.environ.get("HH_API_URL", "http://localhost:3000")
-api_key = os.environ.get("HH_API_KEY", "")
 
 print(f"\nFetching events for session: {session_id}")
 print(f"Project: {project_name}")
 
 try:
-    # Build dateRange (required for ClickHouse query)
-    now = datetime.now(timezone.utc)
-    ten_minutes_ago = now - timedelta(minutes=10)
-    ten_minutes_later = now + timedelta(minutes=10)
+    # Use the HoneyHive API client to export events
+    client = HoneyHive()
 
-    response = httpx.post(
-        f"{api_url}/v1/events/export",
-        headers={
-            "Authorization": f"Bearer {api_key}",
-            "Content-Type": "application/json",
-        },
-        json={
-            "project": project_name,
-            "filters": [
-                {
-                    "field": "session_id",
-                    "operator": "is",
-                    "value": session_id,
-                    "type": "string",
-                }
-            ],
-            "limit": 100,
-        },
+    # Export events using the new export() method with EventFilter
+    response = client.events.export(
+        project=project_name,
+        filters=[
+            EventFilter(
+                field="session_id",
+                operator="is",
+                value=session_id,
+                type="string",
+            )
+        ],
+        limit=100,
     )
-    response.raise_for_status()
-    data = response.json()
-    events = data.get("events", [])
-    total = data.get("count", 0)
-    print(f"\nFound {len(events)} events (total: {total}):")
-    for event in events:
+
+    print(f"\nFound {len(response.events)} events (total: {response.total_events}):")
+    for event in response.events:
         print(f"  - {event.get('event_name', 'N/A')} (type: {event.get('event_type', 'N/A')})")
+
+    # Alternative: Use backwards-compatible list_events() alias
+    # response = client.events.list_events(
+    #     project=project_name,
+    #     filters=[{"field": "session_id", "operator": "is", "value": session_id, "type": "string"}],
+    #     limit=100,
+    # )
 except Exception as e:
     print(f"\nError fetching events: {e}")

--- a/src/honeyhive/__init__.py
+++ b/src/honeyhive/__init__.py
@@ -3,7 +3,7 @@ HoneyHive Python SDK - LLM Observability and Evaluation Platform
 """
 
 # Version must be defined BEFORE imports to avoid circular import issues
-__version__ = "1.0.0rc12"
+__version__ = "1.0.0rc13"
 
 # Main API client
 from .api import HoneyHive

--- a/src/honeyhive/api/client.py
+++ b/src/honeyhive/api/client.py
@@ -18,7 +18,10 @@ Usage::
 
 from typing import Any, Dict, List, Optional, Union
 
+import httpx
+
 from honeyhive._generated.api_config import APIConfig
+from honeyhive.models import EventFilter, EventExportRequest, EventExportResponse
 
 # Import models used in type hints
 from honeyhive._generated.models import (
@@ -539,6 +542,116 @@ class EventsAPI(BaseAPI):
         """Create events in batch."""
         return events_svc.createEventBatch(self._api_config, data=data)
 
+    def export(
+        self,
+        project: str,
+        filters: Optional[List[Union[EventFilter, Dict[str, Any]]]] = None,
+        *,
+        date_range: Optional[Dict[str, str]] = None,
+        projections: Optional[List[str]] = None,
+        limit: int = 1000,
+        page: int = 1,
+    ) -> EventExportResponse:
+        """Export events via POST /events/export (Data Plane).
+
+        This is the primary method for retrieving events from HoneyHive.
+        It uses the Data Plane endpoint which supports filtering by session_id,
+        event_type, and other fields.
+
+        Args:
+            project: Project name associated with the events (required).
+            filters: List of EventFilter objects or dicts with filter criteria.
+                Each filter should have: field, operator, value, type.
+            date_range: Optional date range filter with '$gte' and '$lte' keys
+                containing ISO timestamp strings.
+            projections: Optional list of fields to include in the response.
+            limit: Maximum number of results (default 1000, max 7500).
+            page: Page number for pagination (default 1).
+
+        Returns:
+            EventExportResponse with events list and total_events count.
+
+        Example::
+
+            from honeyhive.models import EventFilter
+
+            # Export events for a session
+            response = client.events.export(
+                project="my-project",
+                filters=[
+                    EventFilter(
+                        field="session_id",
+                        operator="is",
+                        value="abc-123",
+                        type="string"
+                    )
+                ],
+                limit=100
+            )
+
+            for event in response.events:
+                print(event["event_name"])
+
+            # Export with date range
+            response = client.events.export(
+                project="my-project",
+                filters=[],
+                date_range={
+                    "$gte": "2024-01-01T00:00:00Z",
+                    "$lte": "2024-01-31T23:59:59Z"
+                }
+            )
+        """
+        # Build filters array
+        filters_data = []
+        if filters:
+            for f in filters:
+                if isinstance(f, EventFilter):
+                    filters_data.append(f.to_dict())
+                elif isinstance(f, dict):
+                    filters_data.append(f)
+
+        # Build request body
+        request_body: Dict[str, Any] = {
+            "project": project,
+            "filters": filters_data,
+            "limit": limit,
+            "page": page,
+        }
+
+        if date_range:
+            request_body["dateRange"] = date_range
+        if projections:
+            request_body["projections"] = projections
+
+        # Make direct request to /events/export (bypasses generated model issues)
+        base_path = self._api_config.base_path
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self._api_config.get_access_token()}",
+        }
+
+        with httpx.Client(base_url=base_path, verify=self._api_config.verify) as client:
+            response = client.request(
+                "POST",
+                "/v1/events/export",
+                headers=headers,
+                json=request_body,
+            )
+
+        if response.status_code != 200:
+            raise Exception(
+                f"export() failed with status code: {response.status_code}, "
+                f"response: {response.text}"
+            )
+
+        data = response.json()
+        return EventExportResponse(
+            events=data.get("events", []),
+            total_events=data.get("totalEvents", data.get("count", 0)),
+        )
+
     # Async methods
     async def list_async(
         self, query: Union[GetEventsQuery, Dict[str, Any]]
@@ -589,6 +702,83 @@ class EventsAPI(BaseAPI):
         """Create events in batch asynchronously."""
         return await events_svc_async.createEventBatch(self._api_config, data=data)
 
+    async def export_async(
+        self,
+        project: str,
+        filters: Optional[List[Union[EventFilter, Dict[str, Any]]]] = None,
+        *,
+        date_range: Optional[Dict[str, str]] = None,
+        projections: Optional[List[str]] = None,
+        limit: int = 1000,
+        page: int = 1,
+    ) -> EventExportResponse:
+        """Export events via POST /events/export asynchronously (Data Plane).
+
+        Async version of export(). See export() for full documentation.
+
+        Args:
+            project: Project name associated with the events (required).
+            filters: List of EventFilter objects or dicts with filter criteria.
+            date_range: Optional date range filter.
+            projections: Optional list of fields to include in the response.
+            limit: Maximum number of results (default 1000, max 7500).
+            page: Page number for pagination (default 1).
+
+        Returns:
+            EventExportResponse with events list and total_events count.
+        """
+        # Build filters array
+        filters_data = []
+        if filters:
+            for f in filters:
+                if isinstance(f, EventFilter):
+                    filters_data.append(f.to_dict())
+                elif isinstance(f, dict):
+                    filters_data.append(f)
+
+        # Build request body
+        request_body: Dict[str, Any] = {
+            "project": project,
+            "filters": filters_data,
+            "limit": limit,
+            "page": page,
+        }
+
+        if date_range:
+            request_body["dateRange"] = date_range
+        if projections:
+            request_body["projections"] = projections
+
+        # Make direct async request to /events/export
+        base_path = self._api_config.base_path
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self._api_config.get_access_token()}",
+        }
+
+        async with httpx.AsyncClient(
+            base_url=base_path, verify=self._api_config.verify
+        ) as client:
+            response = await client.request(
+                "POST",
+                "/v1/events/export",
+                headers=headers,
+                json=request_body,
+            )
+
+        if response.status_code != 200:
+            raise Exception(
+                f"export_async() failed with status code: {response.status_code}, "
+                f"response: {response.text}"
+            )
+
+        data = response.json()
+        return EventExportResponse(
+            events=data.get("events", []),
+            total_events=data.get("totalEvents", data.get("count", 0)),
+        )
+
     # Backwards compatible aliases
     def create_event(self, request: PostEventRequest) -> PostEventResponse:
         """Create an event (backwards compatible alias for create())."""
@@ -599,16 +789,114 @@ class EventsAPI(BaseAPI):
         return self.update(data)
 
     def list_events(
-        self, query: Union[GetEventsQuery, Dict[str, Any]]
-    ) -> GetEventsResponse:
-        """List events (backwards compatible alias for list())."""
-        return self.list(query)
+        self,
+        project: str,
+        filters: Optional[List[Union[EventFilter, Dict[str, Any]]]] = None,
+        *,
+        date_range: Optional[Dict[str, str]] = None,
+        projections: Optional[List[str]] = None,
+        limit: int = 1000,
+        page: int = 1,
+    ) -> EventExportResponse:
+        """List events via export endpoint (backwards compatible alias).
+
+        This is a backwards compatible alias for export(). Uses the Data Plane
+        POST /events/export endpoint.
+
+        Args:
+            project: Project name.
+            filters: List of EventFilter objects or dicts.
+            date_range: Optional date range filter.
+            projections: Optional list of fields to include.
+            limit: Maximum number of results (default 1000).
+            page: Page number (default 1).
+
+        Returns:
+            EventExportResponse with events and total count.
+        """
+        return self.export(
+            project=project,
+            filters=filters,
+            date_range=date_range,
+            projections=projections,
+            limit=limit,
+            page=page,
+        )
 
     def get_events(
-        self, query: Union[GetEventsQuery, Dict[str, Any]]
-    ) -> GetEventsResponse:
-        """Get events (backwards compatible alias for list())."""
-        return self.list(query)
+        self,
+        project: str,
+        filters: Optional[List[Union[EventFilter, Dict[str, Any]]]] = None,
+        *,
+        date_range: Optional[Dict[str, str]] = None,
+        projections: Optional[List[str]] = None,
+        limit: int = 1000,
+        page: int = 1,
+    ) -> EventExportResponse:
+        """Get events via export endpoint (backwards compatible alias).
+
+        This is a backwards compatible alias for export(). Uses the Data Plane
+        POST /events/export endpoint.
+
+        Args:
+            project: Project name.
+            filters: List of EventFilter objects or dicts.
+            date_range: Optional date range filter.
+            projections: Optional list of fields to include.
+            limit: Maximum number of results (default 1000).
+            page: Page number (default 1).
+
+        Returns:
+            EventExportResponse with events and total count.
+        """
+        return self.export(
+            project=project,
+            filters=filters,
+            date_range=date_range,
+            projections=projections,
+            limit=limit,
+            page=page,
+        )
+
+    async def list_events_async(
+        self,
+        project: str,
+        filters: Optional[List[Union[EventFilter, Dict[str, Any]]]] = None,
+        *,
+        date_range: Optional[Dict[str, str]] = None,
+        projections: Optional[List[str]] = None,
+        limit: int = 1000,
+        page: int = 1,
+    ) -> EventExportResponse:
+        """List events asynchronously (backwards compatible alias for export_async)."""
+        return await self.export_async(
+            project=project,
+            filters=filters,
+            date_range=date_range,
+            projections=projections,
+            limit=limit,
+            page=page,
+        )
+
+    async def get_events_async(
+        self,
+        project: str,
+        filters: Optional[List[Union[EventFilter, Dict[str, Any]]]] = None,
+        *,
+        date_range: Optional[Dict[str, str]] = None,
+        projections: Optional[List[str]] = None,
+        limit: int = 1000,
+        page: int = 1,
+    ) -> EventExportResponse:
+        """Get events asynchronously (backwards compatible alias for export_async)."""
+        return await self.export_async(
+            project=project,
+            filters=filters,
+            date_range=date_range,
+            projections=projections,
+            limit=limit,
+            page=page,
+        )
 
 
 class ExperimentsAPI(BaseAPI):

--- a/src/honeyhive/api/client.py
+++ b/src/honeyhive/api/client.py
@@ -521,9 +521,46 @@ class EventsAPI(BaseAPI):
         # Read operations use Control Plane
         return events_svc.getEvents(self._get_cp_config(), **filtered_data)
 
-    def get_by_session_id(self, session_id: str) -> GetEventsBySessionIdResponse:
-        """Get events by session ID (uses Control Plane endpoint)."""
-        return events_svc.getEventsBySessionId(self._get_cp_config(), id=session_id)
+    def get_by_session_id(
+        self,
+        session_id: str,
+        project: str,
+        *,
+        limit: int = 1000,
+    ) -> EventExportResponse:
+        """Get events by session ID using the Data Plane export endpoint.
+
+        This is a convenience wrapper around export() that filters by session_id.
+
+        Args:
+            session_id: The session ID to fetch events for.
+            project: Project name associated with the events.
+            limit: Maximum number of events to return (default 1000).
+
+        Returns:
+            EventExportResponse with events for the session.
+
+        Example::
+
+            response = client.events.get_by_session_id(
+                session_id="abc-123",
+                project="my-project"
+            )
+            for event in response.events:
+                print(event["event_name"])
+        """
+        return self.export(
+            project=project,
+            filters=[
+                EventFilter(
+                    field="session_id",
+                    operator="is",
+                    value=session_id,
+                    type="string",
+                )
+            ],
+            limit=limit,
+        )
 
     def create(self, request: PostEventRequest) -> PostEventResponse:
         """Create an event."""
@@ -678,11 +715,35 @@ class EventsAPI(BaseAPI):
         return await events_svc_async.getEvents(self._get_cp_config(), **filtered_data)
 
     async def get_by_session_id_async(
-        self, session_id: str
-    ) -> GetEventsBySessionIdResponse:
-        """Get events by session ID asynchronously (uses Control Plane endpoint)."""
-        return await events_svc_async.getEventsBySessionId(
-            self._get_cp_config(), id=session_id
+        self,
+        session_id: str,
+        project: str,
+        *,
+        limit: int = 1000,
+    ) -> EventExportResponse:
+        """Get events by session ID asynchronously using the Data Plane export endpoint.
+
+        Async version of get_by_session_id(). See get_by_session_id() for full documentation.
+
+        Args:
+            session_id: The session ID to fetch events for.
+            project: Project name associated with the events.
+            limit: Maximum number of events to return (default 1000).
+
+        Returns:
+            EventExportResponse with events for the session.
+        """
+        return await self.export_async(
+            project=project,
+            filters=[
+                EventFilter(
+                    field="session_id",
+                    operator="is",
+                    value=session_id,
+                    type="string",
+                )
+            ],
+            limit=limit,
         )
 
     async def create_async(self, request: PostEventRequest) -> PostEventResponse:

--- a/src/honeyhive/experiments/evaluators.py
+++ b/src/honeyhive/experiments/evaluators.py
@@ -1002,7 +1002,9 @@ class evaluator(metaclass=EvaluatorMeta):  # pylint: disable=invalid-name
             results = tuple(results)
             scores = tuple(scores)
         else:
-            _, scores = single_evaluation()
+            result, score = single_evaluation()
+            results = (result,)
+            scores = (score,)
 
         # apply aggregation
         aggregate_result, aggregate_score = self.sync_apply_aggregation(

--- a/src/honeyhive/models/__init__.py
+++ b/src/honeyhive/models/__init__.py
@@ -5,6 +5,9 @@ Usage:
 """
 
 from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
 
 
 class EventType(str, Enum):
@@ -25,6 +28,146 @@ class EventType(str, Enum):
     chain = "chain"
     session = "session"
     generic = "generic"
+
+
+class FilterOperator(str, Enum):
+    """Filter operators for event queries.
+
+    Example::
+
+        from honeyhive.models import EventFilter, FilterOperator
+
+        filter = EventFilter(
+            field="event_type",
+            operator=FilterOperator.IS,
+            value="model",
+            type="string"
+        )
+    """
+
+    IS = "is"
+    IS_NOT = "is not"
+    CONTAINS = "contains"
+    NOT_CONTAINS = "not contains"
+    GREATER_THAN = "greater than"
+
+
+class FilterFieldType(str, Enum):
+    """Field types for event filters."""
+
+    STRING = "string"
+    NUMBER = "number"
+    BOOLEAN = "boolean"
+    ID = "id"
+
+
+class EventFilter(BaseModel):
+    """Filter for querying events.
+
+    Used with the events.export() method to filter events by field values.
+
+    Example::
+
+        from honeyhive.models import EventFilter, FilterOperator
+
+        # Filter by session_id
+        filter = EventFilter(
+            field="session_id",
+            operator=FilterOperator.IS,
+            value="abc-123",
+            type="string"
+        )
+
+        # Filter by event type
+        filter = EventFilter(
+            field="event_type",
+            operator="is",  # Can also use string
+            value="model",
+            type="string"
+        )
+
+        # Filter by metadata field
+        filter = EventFilter(
+            field="metadata.cost",
+            operator="greater than",
+            value="0.01",
+            type="number"
+        )
+    """
+
+    model_config = {"populate_by_name": True}
+
+    field: str = Field(
+        description="The field name to filter by (e.g., 'session_id', 'event_type', 'metadata.cost')"
+    )
+    operator: str = Field(
+        description="Filter operator: 'is', 'is not', 'contains', 'not contains', 'greater than'"
+    )
+    value: str = Field(description="The value to filter for")
+    type: str = Field(
+        default="string",
+        description="Data type: 'string', 'number', 'boolean', 'id'",
+    )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dict for API request."""
+        return {
+            "field": self.field,
+            "operator": self.operator if isinstance(self.operator, str) else self.operator.value,
+            "value": self.value,
+            "type": self.type if isinstance(self.type, str) else self.type.value,
+        }
+
+
+class EventExportRequest(BaseModel):
+    """Request model for exporting events.
+
+    Example::
+
+        from honeyhive.models import EventExportRequest, EventFilter
+
+        request = EventExportRequest(
+            project="my-project",
+            filters=[
+                EventFilter(field="session_id", operator="is", value="abc-123", type="string")
+            ],
+            limit=100,
+        )
+    """
+
+    model_config = {"populate_by_name": True}
+
+    project: str = Field(description="Project name associated with the events")
+    filters: List[EventFilter] = Field(
+        default_factory=list, description="List of filters to apply"
+    )
+    date_range: Optional[Dict[str, str]] = Field(
+        default=None,
+        alias="dateRange",
+        description="Date range filter with '$gte' and '$lte' ISO timestamp strings",
+    )
+    projections: Optional[List[str]] = Field(
+        default=None, description="Fields to include in the response"
+    )
+    limit: Optional[int] = Field(
+        default=1000, description="Limit number of results (default 1000, max 7500)"
+    )
+    page: Optional[int] = Field(default=1, description="Page number (default 1)")
+
+
+class EventExportResponse(BaseModel):
+    """Response model for exported events."""
+
+    model_config = {"populate_by_name": True}
+
+    events: List[Dict[str, Any]] = Field(
+        default_factory=list, description="List of exported events"
+    )
+    total_events: int = Field(
+        default=0,
+        alias="totalEvents",
+        description="Total number of events matching the filter",
+    )
 
 
 # Re-export all generated Pydantic models
@@ -209,4 +352,10 @@ __all__ = [
     "TODOSchema",
     # Enums
     "EventType",
+    "FilterOperator",
+    "FilterFieldType",
+    # Event export models
+    "EventFilter",
+    "EventExportRequest",
+    "EventExportResponse",
 ]


### PR DESCRIPTION
## Summary

- Add `EventFilter`, `EventExportRequest`, `EventExportResponse` Pydantic models for type-safe event querying
- Add `FilterOperator` and `FilterFieldType` enums for filter construction
- Add `export()` and `export_async()` methods to `EventsAPI` using `POST /v1/events/export` (Data Plane)
- Add backwards-compatible aliases: `list_events()`, `get_events()`, `list_events_async()`, `get_events_async()`
- Update `examples/test.py` to demonstrate new SDK client usage
- Bump version to `1.0.0rc13`

## API Usage

```python
from honeyhive import HoneyHive
from honeyhive.models import EventFilter

client = HoneyHive()

# Export events with typed filters
response = client.events.export(
    project="my-project",
    filters=[
        EventFilter(field="session_id", operator="is", value="abc-123", type="string")
    ],
    limit=100
)

for event in response.events:
    print(event["event_name"])
```

## Test plan

- [x] Verify `EventFilter` model creation and `to_dict()` serialization
- [x] Verify `export()` method makes correct HTTP request to `/v1/events/export`
- [x] Verify backwards-compatible aliases route to `export()`
- [x] Verify async methods exist as coroutines
- [ ] End-to-end test once backend auth is updated to support project-scoped API keys on `/events/export`