### PR TITLE
feat: add tests_v2 folder with verified passing unit tests

### DIFF
--- a/tests_v2/TEST_MIGRATION_STATUS.md
+++ b/tests_v2/TEST_MIGRATION_STATUS.md
@@ -1,0 +1,101 @@
+# Test Migration Status
+
+This document tracks the migration of tests from `tests/` to `tests_v2/`.
+
+## Migration Strategy
+
+Tests are migrated after verification that they:
+1. Pass consistently
+2. Don't have stale expectations
+3. Follow current API patterns
+
+## Unit Tests Status
+
+### Tier 1: Utility Tests (No API Dependencies) - MIGRATED
+
+| File | Status | Notes |
+|------|--------|-------|
+| `test_utils_retry.py` | MIGRATED | 34 tests |
+| `test_utils_cache.py` | MIGRATED | 72 tests |
+| `test_utils_dotdict.py` | MIGRATED | 67 tests |
+| `test_utils_logger.py` | MIGRATED | 78 tests |
+| `test_utils_error_handler.py` | MIGRATED | 57 tests |
+| `test_utils_connection_pool.py` | MIGRATED | 68 tests |
+| `test_utils_baggage_dict.py` | MIGRATED | 38 tests |
+| `test_config_validation.py` | MIGRATED | |
+| `test_config_models_base.py` | MIGRATED | |
+| `test_config_models_tracer.py` | MIGRATED | |
+| `test_config_models_http_client.py` | MIGRATED | |
+| `test_config_models_experiment.py` | MIGRATED | |
+
+### Tier 2: Tracer Tests - MIGRATED
+
+| File | Status | Notes |
+|------|--------|-------|
+| `test_tracer_lifecycle_core.py` | MIGRATED | |
+| `test_tracer_lifecycle_flush.py` | MIGRATED | |
+| `test_tracer_lifecycle_shutdown.py` | MIGRATED | |
+| `test_tracer_utils_event_type.py` | MIGRATED | |
+| `test_tracer_utils_general.py` | MIGRATED | |
+| `test_tracer_utils_git.py` | MIGRATED | |
+| `test_tracer_utils_propagation.py` | MIGRATED | |
+| `test_tracer_utils_session.py` | MIGRATED | |
+| `test_tracer_infra_environment.py` | MIGRATED | |
+| `test_tracer_infra_resources.py` | MIGRATED | |
+| `test_tracer_processing_context.py` | MIGRATED | |
+| `test_tracer_processing_context_distributed.py` | MIGRATED | |
+| `test_tracer_processing_otlp_profiles.py` | MIGRATED | |
+| `test_tracer_processing_otlp_session.py` | MIGRATED | |
+| `test_tracer_processing_span_processor.py` | MIGRATED | |
+| `test_models_tracing.py` | MIGRATED | |
+
+### Tier 2.5: Tracer Tests - NOT YET MIGRATED
+
+| File | Status | Notes |
+|------|--------|-------|
+| `test_tracer_instrumentation_*.py` | PENDING | Some have skipped tests |
+
+### Tier 3: API-Dependent Tests (Need Updates)
+
+| File | Status | Notes |
+|------|--------|-------|
+| `test_tracer_core_base.py` | SKIPPED | 16 failures - stale expectations |
+| `test_tracer_core_context.py` | SKIPPED | 22 failures - stale expectations |
+| `test_tracer_processing_otlp_exporter.py` | SKIPPED | 42 failures - stale expectations |
+| `test_experiments_core.py` | SKIPPED | 12 failures - uses generated models |
+| `test_experiments_results.py` | SKIPPED | 24 failures - uses generated models |
+| `test_experiments_immediate_fixes.py` | SKIPPED | 4 failures |
+| `test_cli_main.py` | SKIPPED | 8 failures - uses API client |
+| `test_fastapi_multi_session.py` | SKIPPED | Expects session_api |
+
+## Integration Tests Status
+
+| File | Status | Notes |
+|------|--------|-------|
+| `test_simple_integration.py` | PENDING | Core API tests |
+| `test_tracer_integration.py` | PENDING | Tracer E2E |
+| `api/test_datasets_api.py` | PENDING | Dataset API |
+| `api/test_*.py` | PENDING | Various API tests |
+
+## Current Migration Stats
+
+- **Total tests migrated**: 1324
+- **Tests passing**: 1324 (100%)
+- **tox environment**: `unit-v2`
+
+## CI Status
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Unit tests (py311/312/313) | ENABLED | Runs tests/unit with skips |
+| Unit tests v2 | NEW | Runs tests_v2/unit - all passing |
+| Integration tests | DISABLED | Requires credentials |
+| Quality & Docs | DISABLED | Pre-existing lint issues |
+
+## Next Steps
+
+1. ~~Migrate verified utility tests to tests_v2/unit/~~ DONE
+2. Run integration tests locally with real credentials
+3. Update broken tests to match new API
+4. Re-enable CI checks incrementally
+5. Update CI workflow to run unit-v2 tests

--- a/tests_v2/conftest.py
+++ b/tests_v2/conftest.py
@@ -1,0 +1,205 @@
+"""Shared test configuration and fixtures for verified HoneyHive tests.
+
+This is the tests_v2 folder - a clean slate for verified, working tests.
+Tests are migrated here from tests/ after verification.
+
+Fixture Organization:
+- tests_v2/conftest.py: Shared fixtures (this file)
+- tests_v2/unit/conftest.py: Unit test specific fixtures (mocks)
+- tests_v2/integration/conftest.py: Integration test fixtures (real API)
+"""
+
+import os
+from typing import Any, Generator
+from unittest.mock import Mock
+
+import pytest
+from opentelemetry import baggage, context
+
+from honeyhive.api.client import HoneyHive
+from honeyhive.tracer import HoneyHiveTracer
+
+
+# -----------------------------------------------------------------------------
+# Environment Setup
+# -----------------------------------------------------------------------------
+
+def setup_test_environment() -> None:
+    """Setup test environment variables for isolated testing."""
+    os.environ.setdefault("HH_API_KEY", "test-api-key-12345")
+    os.environ.setdefault("HH_API_URL", "https://api.honeyhive.ai")
+    os.environ.setdefault("HH_SOURCE", "test")
+    os.environ.setdefault("HH_TEST_MODE", "true")
+    os.environ.setdefault("HH_OTLP_ENABLED", "false")
+
+
+def cleanup_test_environment() -> None:
+    """Cleanup test environment variables."""
+    # Reset to defaults rather than removing
+    pass
+
+
+# -----------------------------------------------------------------------------
+# Basic Fixtures
+# -----------------------------------------------------------------------------
+
+@pytest.fixture
+def api_key() -> str:
+    """Test API key."""
+    return "test-api-key-12345"
+
+
+@pytest.fixture
+def project() -> str:
+    """Test project name."""
+    return "test-project"
+
+
+@pytest.fixture
+def source() -> str:
+    """Test source identifier."""
+    return "test"
+
+
+# -----------------------------------------------------------------------------
+# Client Fixtures
+# -----------------------------------------------------------------------------
+
+@pytest.fixture
+def honeyhive_client(api_key: str) -> HoneyHive:
+    """HoneyHive client in test mode."""
+    return HoneyHive(api_key=api_key, test_mode=True)
+
+
+@pytest.fixture
+def client(honeyhive_client: HoneyHive) -> HoneyHive:
+    """Alias for honeyhive_client."""
+    return honeyhive_client
+
+
+# -----------------------------------------------------------------------------
+# Tracer Fixtures
+# -----------------------------------------------------------------------------
+
+@pytest.fixture
+def honeyhive_tracer(api_key: str, project: str, source: str) -> HoneyHiveTracer:
+    """HoneyHive tracer in test mode with HTTP tracing disabled."""
+    return HoneyHiveTracer(
+        api_key=api_key,
+        project=project,
+        source=source,
+        test_mode=True,
+        disable_http_tracing=True,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Mock Fixtures
+# -----------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_client() -> Mock:
+    """Mock HoneyHive client."""
+    return Mock(spec=HoneyHive)
+
+
+@pytest.fixture
+def mock_response() -> Mock:
+    """Mock HTTP response."""
+    mock = Mock()
+    mock.status_code = 200
+    mock.json.return_value = {"success": True}
+    mock.text = '{"success": true}'
+    return mock
+
+
+@pytest.fixture
+def mock_tracer_for_config_tests() -> Any:
+    """Simplified mock tracer for testing config extraction functions.
+    
+    Creates a minimal test double without optimization methods,
+    allowing tests to verify config extraction logic.
+    """
+    from honeyhive.utils.dotdict import DotDict
+
+    class MockConfig:
+        def __init__(self) -> None:
+            self.api_key = "test-api-key"
+            self.project = "test-project"
+            self.source = "test-source"
+
+        def __setattr__(self, name: str, value: Any) -> None:
+            super().__setattr__(name, value)
+
+    class MockTracer:
+        def __init__(self) -> None:
+            self.instance_id = "test-tracer-123"
+            self.session_id = "test-session-456"
+            self.logger = Mock()
+            self._config = MockConfig()
+
+        @property
+        def config(self) -> Any:
+            """Dynamic config that reflects _config values."""
+            class FallbackDotDict(DotDict):
+                def __init__(self, data: dict, tracer_instance: Any) -> None:
+                    super().__init__(data)
+                    self._tracer_instance = tracer_instance
+
+                def get(self, key: str, default: Any = None) -> Any:
+                    value = super().get(key, None)
+                    if value is not None:
+                        return value
+                    return getattr(self._tracer_instance, key, default)
+
+            config_dict = {}
+            if hasattr(self, "_config") and self._config:
+                for attr_name in dir(self._config):
+                    if not attr_name.startswith("_"):
+                        try:
+                            attr_value = getattr(self._config, attr_name)
+                            if not callable(attr_value):
+                                config_dict[attr_name] = attr_value
+                        except (AttributeError, TypeError):
+                            continue
+            return FallbackDotDict(config_dict, self)
+
+        def __getattr__(self, name: str) -> Any:
+            if name in ("_get_config_value_dynamically", "_merged_config"):
+                raise AttributeError(f"'{self.__class__.__name__}' has no attribute '{name}'")
+            raise AttributeError(f"'{self.__class__.__name__}' has no attribute '{name}'")
+
+        def __setattr__(self, name: str, value: Any) -> None:
+            super().__setattr__(name, value)
+
+    return MockTracer()
+
+
+# -----------------------------------------------------------------------------
+# Auto-use Fixtures
+# -----------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def setup_test_env() -> Generator[None, None, None]:
+    """Setup and cleanup test environment."""
+    setup_test_environment()
+    yield
+    cleanup_test_environment()
+
+
+@pytest.fixture(autouse=True)
+def reset_otel_context() -> Generator[None, None, None]:
+    """Reset OpenTelemetry context between tests."""
+    try:
+        context.attach(context.Context())
+        baggage.clear()
+    except (ImportError, AttributeError):
+        pass
+
+    yield
+
+    try:
+        context.attach(context.Context())
+        baggage.clear()
+    except (ImportError, AttributeError):
+        pass

--- a/tests_v2/integration/conftest.py
+++ b/tests_v2/integration/conftest.py
@@ -1,0 +1,53 @@
+"""Integration test fixtures for tests_v2.
+
+Integration tests use real API credentials and make actual API calls.
+They require HH_API_KEY to be set with a valid key.
+"""
+
+import os
+from typing import Optional
+
+import pytest
+
+from honeyhive.api.client import HoneyHive
+from honeyhive.tracer import HoneyHiveTracer
+
+
+def get_api_key() -> Optional[str]:
+    """Get real API key from environment."""
+    return os.environ.get("HH_API_KEY")
+
+
+def get_api_url() -> str:
+    """Get API URL from environment."""
+    return os.environ.get("HH_API_URL", "https://api.honeyhive.ai")
+
+
+@pytest.fixture
+def real_api_key() -> str:
+    """Real API key - skips test if not available."""
+    api_key = get_api_key()
+    if not api_key or api_key.startswith("test-"):
+        pytest.skip("Real HH_API_KEY required for integration tests")
+    return api_key
+
+
+@pytest.fixture
+def real_client(real_api_key: str) -> HoneyHive:
+    """Real HoneyHive client for integration tests."""
+    return HoneyHive(
+        api_key=real_api_key,
+        server_url=get_api_url(),
+        test_mode=False,
+    )
+
+
+@pytest.fixture
+def real_tracer(real_api_key: str) -> HoneyHiveTracer:
+    """Real HoneyHive tracer for integration tests."""
+    return HoneyHiveTracer(
+        api_key=real_api_key,
+        project="sdk-integration-tests",
+        source="integration",
+        test_mode=False,
+    )

--- a/tests_v2/unit/conftest.py
+++ b/tests_v2/unit/conftest.py
@@ -1,0 +1,44 @@
+"""Unit test fixtures for tests_v2.
+
+Unit tests use mocks and should be fast, deterministic, and isolated.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from opentelemetry.trace import NoOpTracerProvider
+
+from honeyhive.tracer.integration import set_global_provider
+
+
+@pytest.fixture(autouse=True)
+def isolate_otel_provider() -> None:
+    """Ensure OpenTelemetry uses NoOp provider for unit tests."""
+    try:
+        set_global_provider(NoOpTracerProvider())
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def mock_tracer() -> Mock:
+    """Fully mocked tracer for unit testing."""
+    mock = Mock()
+    mock.instance_id = "test-tracer-123"
+    mock.session_id = "test-session-456"
+    mock.logger = Mock()
+    
+    # Mock config
+    mock_config = Mock()
+    mock_config.api_key = "test-api-key"
+    mock_config.project = "test-project"
+    mock_config.source = "test-source"
+    mock._config = mock_config
+    
+    # Mock methods
+    mock.start_span = Mock()
+    mock.create_event = Mock()
+    mock.flush = Mock()
+    mock.shutdown = Mock()
+    
+    return mock

--- a/tests_v2/unit/test_config_models_base.py
+++ b/tests_v2/unit/test_config_models_base.py
@@ -1,0 +1,440 @@
+"""Unit tests for HoneyHive config models base functionality.
+
+This module tests the BaseHoneyHiveConfig class including field validation,
+environment variable loading, and common configuration patterns.
+"""
+
+import os
+from typing import Any, Dict, Optional
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from honeyhive.config.models.base import BaseHoneyHiveConfig, _safe_validate_url
+
+
+class TestBaseHoneyHiveConfig:
+    """Test the BaseHoneyHiveConfig class."""
+
+    def test_initialization_with_all_fields(self) -> None:
+        """Test initialization with all fields provided."""
+        config = BaseHoneyHiveConfig(
+            api_key="hh_test_key_123",
+            project="test-project",
+            test_mode=True,
+            verbose=True,
+        )
+
+        assert config.api_key == "hh_test_key_123"
+        assert config.project == "test-project"
+        assert config.test_mode is True
+        assert config.verbose is True
+
+    def test_initialization_with_minimal_fields(self) -> None:
+        """Test initialization with minimal required fields."""
+        # Clear environment to ensure clean test
+        with patch.dict(os.environ, {}, clear=True):
+            config = BaseHoneyHiveConfig(
+                api_key="hh_test_key_123", project="test-project"
+            )
+
+            assert config.api_key == "hh_test_key_123"
+            assert config.project == "test-project"
+            assert config.test_mode is False  # Default value
+            assert config.verbose is False  # Default value
+
+    def test_initialization_with_environment_variables(self) -> None:
+        """Test initialization loads from environment variables."""
+        env_vars = {
+            "HH_API_KEY": "env_api_key_456",
+            "HH_PROJECT": "env-project",
+            "HH_TEST_MODE": "true",
+            "HH_VERBOSE": "false",
+        }
+
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = BaseHoneyHiveConfig()
+
+            assert config.api_key == "env_api_key_456"
+            assert config.project == "env-project"
+            assert config.test_mode is True
+            assert config.verbose is False
+
+    def test_parameter_override_environment(self) -> None:
+        """Test that explicit parameters override environment variables."""
+        env_vars = {
+            "HH_API_KEY": "env_api_key",
+            "HH_PROJECT": "env-project",
+            "HH_TEST_MODE": "true",
+        }
+
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = BaseHoneyHiveConfig(api_key="param_api_key", test_mode=False)
+
+            assert config.api_key == "param_api_key"  # Parameter overrides env
+            assert config.project == "env-project"  # From environment
+            assert config.test_mode is False  # Parameter overrides env
+
+    def test_api_key_validation_valid_keys(self) -> None:
+        """Test API key validation with valid keys."""
+        valid_keys = [
+            "hh_1234567890abcdef",
+            "hh_short",
+            "hh_very_long_api_key_with_underscores_and_numbers_123456789",
+        ]
+
+        for api_key in valid_keys:
+            config = BaseHoneyHiveConfig(api_key=api_key, project="test")
+            assert config.api_key == api_key
+
+    def test_api_key_validation_graceful_degradation(self) -> None:
+        """Test API key validation uses graceful degradation."""
+        # Test empty string gets converted to None
+        config = BaseHoneyHiveConfig(api_key="", project="test")
+        assert config.api_key is None
+
+        # Test whitespace only gets converted to None
+        config = BaseHoneyHiveConfig(api_key="   ", project="test")
+        assert config.api_key is None
+
+        # Test None is allowed
+        config = BaseHoneyHiveConfig(api_key=None, project="test")
+        assert config.api_key is None
+
+        # Test non-hh_ keys are allowed (for backwards compatibility)
+        config = BaseHoneyHiveConfig(api_key="invalid", project="test")
+        assert config.api_key == "invalid"
+
+        # Test non-string api_key gets converted to None with warning
+        config = BaseHoneyHiveConfig(api_key=123, project="test")
+        assert config.api_key is None
+
+    def test_project_validation_valid_projects(self) -> None:
+        """Test project validation with valid project names."""
+        valid_projects = [
+            "simple-project",
+            "project_with_underscores",
+            "project123",
+            "a",  # Single character
+            "very-long-project-name-with-many-hyphens-and-numbers-123",
+        ]
+
+        for project in valid_projects:
+            config = BaseHoneyHiveConfig(api_key="hh_test", project=project)
+            assert config.project == project
+
+    def test_project_validation_graceful_degradation(self) -> None:
+        """Test project validation uses graceful degradation."""
+        # Test empty string gets converted to None
+        config = BaseHoneyHiveConfig(api_key="hh_test", project="")
+        assert config.project is None
+
+        # Test whitespace only gets converted to None
+        config = BaseHoneyHiveConfig(api_key="hh_test", project="   ")
+        assert config.project is None
+
+        # Test invalid characters get converted to None
+        config = BaseHoneyHiveConfig(api_key="hh_test", project="project/with/slash")
+        assert config.project is None
+
+        config = BaseHoneyHiveConfig(api_key="hh_test", project="project?with?question")
+        assert config.project is None
+
+        # Test None is allowed
+        config = BaseHoneyHiveConfig(api_key="hh_test", project=None)
+        assert config.project is None
+
+        # Test non-string project gets converted to None with warning
+        config = BaseHoneyHiveConfig(api_key="hh_test", project=123)
+        assert config.project is None
+
+    @pytest.mark.parametrize(
+        "test_mode_value,expected",
+        [
+            ("true", True),
+            ("false", False),
+            ("1", True),
+            ("0", False),
+            ("yes", True),
+            ("no", False),
+            ("TRUE", True),
+            ("FALSE", False),
+        ],
+    )
+    def test_test_mode_environment_parsing(
+        self, test_mode_value: str, expected: bool
+    ) -> None:
+        """Test test_mode parsing from environment variables."""
+        with patch.dict(os.environ, {"HH_TEST_MODE": test_mode_value}, clear=True):
+            config = BaseHoneyHiveConfig(api_key="hh_test", project="test")
+            assert config.test_mode is expected
+
+    @pytest.mark.parametrize(
+        "verbose_value,expected",
+        [
+            ("true", True),
+            ("false", False),
+            ("1", True),
+            ("0", False),
+            ("yes", True),
+            ("no", False),
+            ("TRUE", True),
+            ("FALSE", False),
+        ],
+    )
+    def test_verbose_environment_parsing(
+        self, verbose_value: str, expected: bool
+    ) -> None:
+        """Test verbose parsing from environment variables."""
+        with patch.dict(os.environ, {"HH_VERBOSE": verbose_value}, clear=True):
+            config = BaseHoneyHiveConfig(api_key="hh_test", project="test")
+            assert config.verbose is expected
+
+    def test_model_config_settings(self) -> None:
+        """Test that model configuration is set correctly."""
+        _ = BaseHoneyHiveConfig(api_key="hh_test", project="test")  # Test instantiation
+
+        # Test that extra fields are forbidden
+        with pytest.raises(ValidationError):
+            BaseHoneyHiveConfig(
+                api_key="hh_test", project="test", invalid_field="should_fail"
+            )
+
+    def test_field_descriptions_and_examples(self) -> None:
+        """Test that fields have proper descriptions and examples."""
+        # This tests the Field definitions in the model
+        schema = BaseHoneyHiveConfig.model_json_schema()
+
+        # Check api_key field (now appears as HH_API_KEY in schema due to
+        # validation_alias)
+        api_key_field = schema["properties"]["HH_API_KEY"]
+        assert "description" in api_key_field
+        assert "examples" in api_key_field
+        assert "hh_" in str(api_key_field["examples"])
+
+        # Check project field (now appears as HH_PROJECT in schema due to
+        # validation_alias)
+        project_field = schema["properties"]["HH_PROJECT"]
+        assert "description" in project_field
+        assert "examples" in project_field
+
+    def test_model_serialization(self) -> None:
+        """Test model serialization to dict and JSON."""
+        config = BaseHoneyHiveConfig(
+            api_key="hh_test_key", project="test-project", test_mode=True, verbose=False
+        )
+
+        # Test dict serialization
+        config_dict = config.model_dump()
+        expected_dict = {
+            "api_key": "hh_test_key",
+            "project": "test-project",
+            "test_mode": True,
+            "verbose": False,
+        }
+        assert config_dict == expected_dict
+
+        # Test JSON serialization
+        config_json = config.model_dump_json()
+        assert isinstance(config_json, str)
+        assert "hh_test_key" in config_json
+        assert "test-project" in config_json
+
+    def test_model_deserialization(self) -> None:
+        """Test model deserialization from dict."""
+        config_data = {
+            "api_key": "hh_test_key",
+            "project": "test-project",
+            "test_mode": True,
+            "verbose": False,
+        }
+
+        config = BaseHoneyHiveConfig(**config_data)
+
+        assert config.api_key == "hh_test_key"
+        assert config.project == "test-project"
+        assert config.test_mode is True
+        assert config.verbose is False
+
+    def test_case_insensitive_field_names(self) -> None:
+        """Test that field names are case insensitive."""
+        # The model should accept both cases due to case_sensitive=False
+        config = BaseHoneyHiveConfig(
+            api_key="hh_test_key",  # Lowercase (standard)
+            project="test-project",  # Lowercase (standard)
+            test_mode=True,
+            verbose=False,
+        )
+
+        assert config.api_key == "hh_test_key"
+        assert config.project == "test-project"
+        assert config.test_mode is True
+        assert config.verbose is False
+
+    def test_inheritance_compatibility(self) -> None:
+        """Test that the base config can be properly inherited."""
+
+        class TestChildConfig(BaseHoneyHiveConfig):
+            """Test child configuration class."""
+
+            child_field: Optional[str] = None
+
+        config = TestChildConfig(
+            api_key="hh_test", project="test", child_field="child_value"
+        )
+
+        # Base fields should work
+        assert config.api_key == "hh_test"
+        assert config.project == "test"
+
+        # Child field should work
+        assert config.child_field == "child_value"
+
+    def test_environment_variable_precedence(self) -> None:
+        """Test environment variable precedence order."""
+        # Test that explicit parameters have highest precedence
+        env_vars = {
+            "HH_API_KEY": "env_key",
+            "HH_PROJECT": "env_project",
+        }
+
+        with patch.dict(os.environ, env_vars, clear=True):
+            # Explicit parameters should override environment
+            config = BaseHoneyHiveConfig(
+                api_key="explicit_key", project="explicit_project"
+            )
+
+            assert config.api_key == "explicit_key"
+            assert config.project == "explicit_project"
+
+            # Environment should be used when no explicit parameter
+            config2 = BaseHoneyHiveConfig()
+            assert config2.api_key == "env_key"
+            assert config2.project == "env_project"
+
+    def test_graceful_degradation_empty_strings(self) -> None:
+        """Test that empty strings are handled gracefully with warnings."""
+        # logging and patch imported at top level
+
+        # Test empty API key - should log warning and set to None
+        with patch("honeyhive.config.models.base.logger") as mock_logger:
+            config = BaseHoneyHiveConfig(api_key="", project="test")
+
+            # Should have logged warning about empty api_key
+            mock_logger.warning.assert_called()
+            assert config.api_key is None
+            assert config.project == "test"
+
+        # Test empty project - should log warning and set to None
+        with patch("honeyhive.config.models.base.logger") as mock_logger:
+            config = BaseHoneyHiveConfig(api_key="hh_test", project="")
+
+            # Should have logged warning about empty project
+            mock_logger.warning.assert_called()
+            assert config.api_key == "hh_test"
+            assert config.project is None
+
+    def test_graceful_degradation_invalid_types(self) -> None:
+        """Test that invalid config types never crash the application."""
+        # These should all work without raising exceptions
+        invalid_inputs: list[Dict[str, Any]] = [
+            {"api_key": 123, "project": "test"},
+            {"api_key": [], "project": "test"},
+            {"api_key": {}, "project": "test"},
+            {"api_key": None, "project": 456},
+            {"api_key": "valid", "project": []},
+            {"api_key": "valid", "project": {}},
+        ]
+
+        for invalid_input in invalid_inputs:
+            # Should not crash - graceful degradation should handle it
+            config = BaseHoneyHiveConfig(**invalid_input)
+            # Invalid values should be converted to None or safe defaults
+            assert config is not None
+
+    def test_graceful_degradation_logging(self) -> None:
+        """Test that graceful degradation produces appropriate warning logs."""
+        # logging and patch imported at top level
+
+        with patch("honeyhive.config.models.base.logger") as mock_logger:
+            # Create config with invalid values
+            config = BaseHoneyHiveConfig(api_key=123, project="test")
+
+            # Should have logged warnings about invalid values
+            assert mock_logger.warning.called
+
+            # Config should still be created successfully
+            assert config is not None
+            assert config.api_key is None  # Invalid value converted to None
+
+    def test_boolean_validation_none_values(self) -> None:
+        """Test boolean validation with None values."""
+        # Test that None values are handled correctly (line 224)
+        config = BaseHoneyHiveConfig(
+            api_key="test", project="test", test_mode=None, verbose=None
+        )
+        assert config.test_mode is False
+        assert config.verbose is False
+
+    def test_boolean_validation_invalid_types(self) -> None:
+        """Test boolean validation with invalid types."""
+        # logging and patch imported at top level
+
+        with patch("honeyhive.config.models.base.logger") as mock_logger:
+            # Test non-string, non-bool types (lines 245-249)
+            config = BaseHoneyHiveConfig(
+                api_key="test",
+                project="test",
+                test_mode=123,  # Invalid type
+                verbose=[],  # Invalid type
+            )
+
+            # Should log warnings for invalid types
+            assert mock_logger.warning.call_count >= 2
+
+            # Should default to False
+            assert config.test_mode is False
+            assert config.verbose is False
+
+    def test_boolean_validation_invalid_strings(self) -> None:
+        """Test boolean validation with invalid string values."""
+        # logging and patch imported at top level
+
+        with patch("honeyhive.config.models.base.logger") as mock_logger:
+            # Test invalid boolean strings (lines 238-242)
+            config = BaseHoneyHiveConfig(
+                api_key="test",
+                project="test",
+                test_mode="invalid_bool_string",
+                verbose="not_a_boolean",
+            )
+
+            # Should log warnings for invalid boolean strings
+            assert mock_logger.warning.call_count >= 2
+
+            # Should default to False
+            assert config.test_mode is False
+            assert config.verbose is False
+
+    def test_url_validation_invalid_protocol(self) -> None:
+        """Test URL validation with invalid protocols."""
+        # logging and patch imported at top level
+
+        # _safe_validate_url imported at top level
+
+        with patch("honeyhive.config.models.base.logger") as mock_logger:
+            # Test URL that doesn't start with http/https (lines 80-87)
+            result = _safe_validate_url(
+                "ftp://example.com", "test_url", default="https://default.com"
+            )
+
+            # Should log warning and return default
+            mock_logger.warning.assert_called()
+            assert result == "https://default.com"
+
+            # Test valid URL (line 87)
+            result_valid = _safe_validate_url(
+                "https://valid.com", "test_url", default="https://default.com"
+            )
+            assert result_valid == "https://valid.com"

--- a/tests_v2/unit/test_config_models_experiment.py
+++ b/tests_v2/unit/test_config_models_experiment.py
@@ -1,0 +1,508 @@
+"""Unit tests for honeyhive.config.models.experiment.
+
+This module contains comprehensive unit tests for experiment configuration models
+including ExperimentConfig class and related utility functions.
+"""
+
+# pylint: disable=too-many-lines
+# Justification: Comprehensive unit test coverage requires extensive test cases
+
+# pylint: disable=redefined-outer-name
+# Justification: Pytest fixture pattern requires parameter shadowing
+
+# pylint: disable=protected-access
+# Justification: Unit tests need to verify private method behavior
+
+import json
+import logging
+import os
+from typing import Any, Dict, Optional
+from unittest.mock import Mock, patch
+
+from honeyhive.config.models.experiment import ExperimentConfig, _get_env_json
+
+
+class TestGetEnvJson:
+    """Test suite for _get_env_json utility function."""
+
+    def test_get_env_json_with_valid_json_string(self) -> None:
+        """Test _get_env_json with valid JSON string from environment."""
+        # Arrange
+        test_key: str = "TEST_JSON_KEY"
+        test_value: str = '{"model_type": "gpt-4", "temperature": 0.7}'
+        expected_result: Dict[str, Any] = {"model_type": "gpt-4", "temperature": 0.7}
+
+        with patch.object(os, "getenv", return_value=test_value):
+            # Act
+            result: Optional[Dict[str, Any]] = _get_env_json(test_key)
+
+            # Assert
+            assert result == expected_result
+
+    def test_get_env_json_with_empty_environment_variable(self) -> None:
+        """Test _get_env_json with empty environment variable returns default."""
+        # Arrange
+        test_key: str = "EMPTY_JSON_KEY"
+        default_value: Dict[str, str] = {"default": "value"}
+
+        with patch.object(os, "getenv", return_value=None):
+            # Act
+            result: Optional[Dict[str, Any]] = _get_env_json(test_key, default_value)
+
+            # Assert
+            assert result == default_value
+
+    def test_get_env_json_with_no_default_returns_none(self) -> None:
+        """Test _get_env_json with no environment variable and no default."""
+        # Arrange
+        test_key: str = "MISSING_JSON_KEY"
+
+        with patch.object(os, "getenv", return_value=None):
+            # Act
+            result: Optional[Dict[str, Any]] = _get_env_json(test_key)
+
+            # Assert
+            assert result is None
+
+    def test_get_env_json_with_invalid_json_returns_default(self) -> None:
+        """Test _get_env_json with invalid JSON string returns default."""
+        # Arrange
+        test_key: str = "INVALID_JSON_KEY"
+        invalid_json: str = '{"invalid": json}'
+        default_value: Dict[str, str] = {"fallback": "value"}
+
+        with patch.object(os, "getenv", return_value=invalid_json):
+            # Act
+            result: Optional[Dict[str, Any]] = _get_env_json(test_key, default_value)
+
+            # Assert
+            assert result == default_value
+
+    def test_get_env_json_with_non_dict_json_returns_default(self) -> None:
+        """Test _get_env_json with non-dict JSON (list/string) returns default."""
+        # Arrange
+        test_key: str = "NON_DICT_JSON_KEY"
+        non_dict_json: str = '["item1", "item2", "item3"]'
+        default_value: Dict[str, str] = {"type": "dict"}
+
+        with patch.object(os, "getenv", return_value=non_dict_json):
+            # Act
+            result: Optional[Dict[str, Any]] = _get_env_json(test_key, default_value)
+
+            # Assert
+            assert result == default_value
+
+    def test_get_env_json_with_json_decode_error_returns_default(self) -> None:
+        """Test _get_env_json handles JSONDecodeError gracefully."""
+        # Arrange
+        test_key: str = "MALFORMED_JSON_KEY"
+        malformed_json: str = '{"key": value}'  # Missing quotes around value
+
+        with patch.object(os, "getenv", return_value=malformed_json):
+            # Act
+            result: Optional[Dict[str, Any]] = _get_env_json(test_key)
+
+            # Assert
+            assert result is None
+
+    def test_get_env_json_with_type_error_returns_default(self) -> None:
+        """Test _get_env_json handles TypeError gracefully."""
+        # Arrange
+        test_key: str = "TYPE_ERROR_KEY"
+
+        with patch.object(os, "getenv", return_value="valid_string"):
+            with patch.object(json, "loads", side_effect=TypeError("Type error")):
+                # Act
+                result: Optional[Dict[str, Any]] = _get_env_json(test_key)
+
+                # Assert
+                assert result is None
+
+
+class TestExperimentConfig:
+    """Test suite for ExperimentConfig class."""
+
+    def test_experiment_config_initialization_with_direct_parameters(self) -> None:
+        """Test ExperimentConfig initialization with direct parameters."""
+        # Arrange
+        test_data: Dict[str, Any] = {
+            "experiment_id": "exp_12345",
+            "experiment_name": "model-comparison",
+            "experiment_variant": "baseline",
+            "experiment_group": "control",
+            "experiment_metadata": {"model_type": "gpt-4", "temperature": 0.7},
+        }
+
+        # Act
+        config: ExperimentConfig = ExperimentConfig(**test_data)
+
+        # Assert
+        assert config.experiment_id == "exp_12345"
+        assert config.experiment_name == "model-comparison"
+        assert config.experiment_variant == "baseline"
+        assert config.experiment_group == "control"
+        assert config.experiment_metadata == {"model_type": "gpt-4", "temperature": 0.7}
+
+    def test_experiment_config_initialization_with_environment_variables(self) -> None:
+        """Test ExperimentConfig initialization with environment variable fallbacks."""
+        # Arrange
+        env_vars: Dict[str, str] = {
+            "HH_EXPERIMENT_ID": "env_exp_123",
+            "HH_EXPERIMENT_NAME": "env_experiment",
+            "HH_EXPERIMENT_VARIANT": "env_variant",
+            "HH_EXPERIMENT_GROUP": "env_group",
+        }
+
+        with patch.dict(os.environ, env_vars, clear=False):
+            # Act
+            config: ExperimentConfig = ExperimentConfig()
+
+            # Assert
+            assert config.experiment_id == "env_exp_123"
+            assert config.experiment_name == "env_experiment"
+            assert config.experiment_variant == "env_variant"
+            assert config.experiment_group == "env_group"
+
+    def test_experiment_config_initialization_with_mlflow_fallbacks(self) -> None:
+        """Test ExperimentConfig initialization with MLflow env fallbacks."""
+        # Arrange
+        env_vars: Dict[str, str] = {
+            "MLFLOW_EXPERIMENT_ID": "mlflow_exp_456",
+            "MLFLOW_EXPERIMENT_NAME": "mlflow_experiment",
+        }
+
+        with patch.dict(os.environ, env_vars, clear=False):
+            # Act
+            config: ExperimentConfig = ExperimentConfig()
+
+            # Assert
+            assert config.experiment_id == "mlflow_exp_456"
+            assert config.experiment_name == "mlflow_experiment"
+
+    def test_experiment_config_initialization_with_wandb_fallbacks(self) -> None:
+        """Test ExperimentConfig initialization with W&B fallbacks."""
+        # Arrange
+        env_vars: Dict[str, str] = {
+            "WANDB_RUN_ID": "wandb_run_789",
+            "WANDB_PROJECT": "wandb_project",
+        }
+
+        with patch.dict(os.environ, env_vars, clear=False):
+            # Act
+            config: ExperimentConfig = ExperimentConfig()
+
+            # Assert
+            assert config.experiment_id == "wandb_run_789"
+            assert config.experiment_name == "wandb_project"
+
+    def test_experiment_config_initialization_with_comet_fallbacks(self) -> None:
+        """Test ExperimentConfig initialization with Comet ML fallbacks."""
+        # Arrange
+        env_vars: Dict[str, str] = {
+            "COMET_EXPERIMENT_KEY": "comet_key_abc",
+            "COMET_PROJECT_NAME": "comet_project",
+        }
+
+        with patch.dict(os.environ, env_vars, clear=False):
+            # Act
+            config: ExperimentConfig = ExperimentConfig()
+
+            # Assert
+            assert config.experiment_id == "comet_key_abc"
+            assert config.experiment_name == "comet_project"
+
+    def test_experiment_config_initialization_with_generic_fallbacks(self) -> None:
+        """Test ExperimentConfig initialization with generic env fallbacks."""
+        # Arrange
+        env_vars: Dict[str, str] = {
+            "EXPERIMENT_ID": "generic_exp_999",
+            "EXPERIMENT_NAME": "generic_experiment",
+            "VARIANT": "generic_variant",
+            "GROUP": "generic_group",
+        }
+
+        with patch.dict(os.environ, env_vars, clear=False):
+            # Act
+            config: ExperimentConfig = ExperimentConfig()
+
+            # Assert
+            assert config.experiment_id == "generic_exp_999"
+            assert config.experiment_name == "generic_experiment"
+            assert config.experiment_variant == "generic_variant"
+            assert config.experiment_group == "generic_group"
+
+    def test_experiment_config_initialization_with_ab_test_fallbacks(self) -> None:
+        """Test ExperimentConfig initialization with A/B test env fallbacks."""
+        # Arrange
+        env_vars: Dict[str, str] = {
+            "AB_TEST_VARIANT": "ab_variant_a",
+            "AB_TEST_GROUP": "ab_group_1",
+            "TREATMENT": "treatment_x",
+            "COHORT": "cohort_y",
+        }
+
+        with patch.dict(os.environ, env_vars, clear=False):
+            # Act
+            config: ExperimentConfig = ExperimentConfig()
+
+            # Assert
+            assert config.experiment_variant == "ab_variant_a"
+            assert config.experiment_group == "ab_group_1"
+
+    def test_experiment_config_initialization_with_metadata_fallbacks(self) -> None:
+        """Test ExperimentConfig initialization with metadata env fallbacks."""
+        # Arrange
+        test_metadata: Dict[str, Any] = {"model": "gpt-4", "version": "1.0"}
+
+        with patch(
+            "honeyhive.config.models.experiment._get_env_json"
+        ) as mock_get_env_json:
+            mock_get_env_json.return_value = test_metadata
+
+            # Act
+            config: ExperimentConfig = ExperimentConfig()
+
+            # Assert
+            assert config.experiment_metadata == test_metadata
+            mock_get_env_json.assert_called()
+
+    def test_experiment_config_direct_data_overrides_environment(self) -> None:
+        """Test that direct parameters override environment variables."""
+        # Arrange
+        env_vars: Dict[str, str] = {
+            "HH_EXPERIMENT_ID": "env_id",
+            "HH_EXPERIMENT_NAME": "env_name",
+        }
+        direct_data: Dict[str, str] = {
+            "experiment_id": "direct_id",
+            "experiment_name": "direct_name",
+        }
+
+        with patch.dict(os.environ, env_vars, clear=False):
+            # Act
+            config: ExperimentConfig = ExperimentConfig(**direct_data)
+
+            # Assert
+            assert config.experiment_id == "direct_id"
+            assert config.experiment_name == "direct_name"
+
+    def test_experiment_config_initialization_with_no_environment_variables(
+        self,
+    ) -> None:
+        """Test ExperimentConfig initialization with no environment variables."""
+        # Arrange
+        with patch.dict(os.environ, {}, clear=True):
+            # Act
+            config: ExperimentConfig = ExperimentConfig()
+
+            # Assert
+            assert config.experiment_id is None
+            assert config.experiment_name is None
+            assert config.experiment_variant is None
+            assert config.experiment_group is None
+            assert config.experiment_metadata is None
+
+    def test_validate_experiment_strings_with_valid_string(self) -> None:
+        """Test validate_experiment_strings with valid string input."""
+        # Arrange
+        test_string: str = "valid_experiment_id"
+
+        # Act
+        result: Optional[str] = ExperimentConfig.validate_experiment_strings(
+            test_string
+        )
+
+        # Assert
+        assert result == "valid_experiment_id"
+
+    def test_validate_experiment_strings_with_none_input(self) -> None:
+        """Test validate_experiment_strings with None input returns None."""
+        # Act
+        result: Optional[str] = ExperimentConfig.validate_experiment_strings(None)
+
+        # Assert
+        assert result is None
+
+    def test_validate_experiment_strings_with_empty_string(self) -> None:
+        """Test validate_experiment_strings with empty string."""
+        # Act
+        result: Optional[str] = ExperimentConfig.validate_experiment_strings("")
+
+        # Assert
+        assert result is None
+
+    def test_validate_experiment_strings_with_whitespace_string(self) -> None:
+        """Test validate_experiment_strings with whitespace-only string."""
+        # Act
+        result: Optional[str] = ExperimentConfig.validate_experiment_strings("   ")
+
+        # Assert
+        assert result is None
+
+    def test_validate_experiment_metadata_with_valid_dict(self) -> None:
+        """Test validate_experiment_metadata with valid dictionary input."""
+        # Arrange
+        test_metadata: Dict[str, Any] = {
+            "model_type": "gpt-4",
+            "temperature": 0.7,
+            "max_tokens": 100,
+        }
+
+        # Act
+        result: Optional[Dict[str, Any]] = (
+            ExperimentConfig.validate_experiment_metadata(test_metadata)
+        )
+
+        # Assert
+        assert result == test_metadata
+
+    def test_validate_experiment_metadata_with_none_input(self) -> None:
+        """Test validate_experiment_metadata with None input returns None."""
+        # Act
+        result: Optional[Dict[str, Any]] = (
+            ExperimentConfig.validate_experiment_metadata(None)
+        )
+
+        # Assert
+        assert result is None
+
+    def test_validate_experiment_metadata_with_invalid_type_logs_warning(self) -> None:
+        """Test validate_experiment_metadata with invalid type logs warning."""
+        # Arrange
+        invalid_metadata: str = "not_a_dict"
+
+        with patch.object(logging, "getLogger") as mock_get_logger:
+            mock_logger: Mock = Mock()
+            mock_get_logger.return_value = mock_logger
+
+            # Act
+            result: Optional[
+                Dict[str, Any]
+            ] = ExperimentConfig.validate_experiment_metadata(
+                invalid_metadata  # type: ignore[arg-type]
+            )
+
+            # Assert
+            assert result is None
+            mock_logger.warning.assert_called_once()
+            warning_call = mock_logger.warning.call_args
+            assert (
+                "Invalid experiment_metadata: expected dict, got %s. Using None."
+                in warning_call[0][0]
+            )
+
+    def test_validate_experiment_metadata_with_invalid_keys_filters_them(self) -> None:
+        """Test validate_experiment_metadata filters out non-string keys."""
+        # Arrange
+        metadata_with_invalid_keys: Dict[Any, Any] = {
+            "valid_key": "valid_value",
+            123: "numeric_key",
+            None: "none_key",
+            "another_valid": "another_value",
+        }
+        expected_result: Dict[str, Any] = {
+            "valid_key": "valid_value",
+            "another_valid": "another_value",
+        }
+
+        with patch.object(logging, "getLogger") as mock_get_logger:
+            mock_logger: Mock = Mock()
+            mock_get_logger.return_value = mock_logger
+
+            # Act
+            result: Optional[Dict[str, Any]] = (
+                ExperimentConfig.validate_experiment_metadata(
+                    metadata_with_invalid_keys
+                )
+            )
+
+            # Assert
+            assert result == expected_result
+            assert mock_logger.warning.call_count == 2  # Two invalid keys
+
+    def test_validate_experiment_metadata_with_all_invalid_keys_returns_none(
+        self,
+    ) -> None:
+        """Test validate_experiment_metadata returns None when all keys are invalid."""
+        # Arrange
+        metadata_all_invalid_keys: Dict[Any, Any] = {
+            123: "numeric_key",
+            None: "none_key",
+            45.6: "float_key",
+        }
+
+        with patch.object(logging, "getLogger") as mock_get_logger:
+            mock_logger: Mock = Mock()
+            mock_get_logger.return_value = mock_logger
+
+            # Act
+            result: Optional[Dict[str, Any]] = (
+                ExperimentConfig.validate_experiment_metadata(metadata_all_invalid_keys)
+            )
+
+            # Assert
+            assert result is None
+            assert mock_logger.warning.call_count == 3  # Three invalid keys
+
+    def test_experiment_config_field_validation_integration(self) -> None:
+        """Test ExperimentConfig field validation integration with Pydantic."""
+        # Arrange
+        test_data: Dict[str, Any] = {
+            "experiment_id": "  valid_id  ",  # Should be validated
+            "experiment_name": "",  # Should become None
+            "experiment_variant": None,  # Should remain None
+            "experiment_metadata": {"key": "value"},  # Should be validated
+        }
+
+        # Act
+        config: ExperimentConfig = ExperimentConfig(**test_data)
+
+        # Assert
+        assert config.experiment_id == "valid_id"  # Trimmed by _safe_validate_string
+        assert config.experiment_name is None  # Empty string converted to None
+        assert config.experiment_variant is None
+        assert config.experiment_metadata == {"key": "value"}
+
+    def test_experiment_config_model_config_settings(self) -> None:
+        """Test ExperimentConfig model configuration settings."""
+        # Arrange & Act
+        config: ExperimentConfig = ExperimentConfig()
+
+        # Assert
+        assert config.model_config["env_prefix"] == ""
+        assert config.model_config["validate_assignment"] is True
+        assert config.model_config["extra"] == "forbid"
+        assert config.model_config["case_sensitive"] is False
+
+    def test_experiment_config_with_mixed_environment_priority(self) -> None:
+        """Test ExperimentConfig env variable priority (HH_ > generic > platform)."""
+        # Arrange
+        env_vars: Dict[str, str] = {
+            "HH_EXPERIMENT_ID": "honeyhive_id",
+            "EXPERIMENT_ID": "generic_id",
+            "MLFLOW_EXPERIMENT_ID": "mlflow_id",
+            "WANDB_RUN_ID": "wandb_id",
+        }
+
+        with patch.dict(os.environ, env_vars, clear=False):
+            # Act
+            config: ExperimentConfig = ExperimentConfig()
+
+            # Assert
+            assert config.experiment_id == "honeyhive_id"  # HH_ prefix takes priority
+
+    def test_experiment_config_environment_fallback_chain(self) -> None:
+        """Test ExperimentConfig environment variable fallback chain works correctly."""
+        # Arrange - Only set lower priority variables
+        env_vars: Dict[str, str] = {
+            "MLFLOW_EXPERIMENT_ID": "mlflow_fallback",
+            "WANDB_PROJECT": "wandb_fallback",
+        }
+
+        with patch.dict(os.environ, env_vars, clear=False):
+            # Act
+            config: ExperimentConfig = ExperimentConfig()
+
+            # Assert
+            assert config.experiment_id == "mlflow_fallback"
+            assert config.experiment_name == "wandb_fallback"

--- a/tests_v2/unit/test_config_models_http_client.py
+++ b/tests_v2/unit/test_config_models_http_client.py
@@ -1,0 +1,233 @@
+"""Tests for HTTP client configuration models."""
+
+# pylint: disable=import-outside-toplevel,unused-import,reimported,redefined-outer-name
+# Justification: Test isolation requires dynamic imports and mock redefinition
+
+import os
+from unittest.mock import patch
+
+from honeyhive.config.models.http_client import HTTPClientConfig
+
+
+class TestHTTPClientConfig:
+    """Test HTTP client configuration model."""
+
+    def test_http_client_config_initialization(self) -> None:
+        """Test HTTP client config initialization with default values."""
+
+        # Clear environment to test defaults
+        with patch.dict(os.environ, {}, clear=True):
+            config = HTTPClientConfig()
+            assert config.timeout == 30.0
+            assert config.max_connections == 10
+            assert config.max_keepalive_connections == 20
+            assert config.keepalive_expiry == 30.0
+            assert config.pool_timeout == 10.0
+            assert config.rate_limit_calls == 100
+            assert config.rate_limit_window == 60.0
+            assert config.max_retries == 3
+            assert config.http_proxy is None
+            assert config.https_proxy is None
+            assert config.no_proxy is None
+            assert config.verify_ssl is True
+            assert config.follow_redirects is True
+
+    def test_http_client_config_with_environment_variables(self) -> None:
+        """Test HTTP client config with environment variables."""
+        from honeyhive.config.models.http_client import HTTPClientConfig
+
+        env_vars = {
+            "HH_TIMEOUT": "60.0",
+            "HH_MAX_CONNECTIONS": "50",
+            "HH_MAX_KEEPALIVE_CONNECTIONS": "100",
+            "HH_KEEPALIVE_EXPIRY": "120.0",
+            "HH_POOL_TIMEOUT": "20.0",
+            "HH_RATE_LIMIT_CALLS": "200",
+            "HH_RATE_LIMIT_WINDOW": "300.0",
+            "HH_MAX_RETRIES": "5",
+            "HH_HTTP_PROXY": "http://proxy.company.com:8080",
+            "HH_HTTPS_PROXY": "https://proxy.company.com:8080",
+            "HH_NO_PROXY": "localhost,127.0.0.1",
+            "HH_VERIFY_SSL": "false",
+            "HH_FOLLOW_REDIRECTS": "false",
+        }
+
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = HTTPClientConfig()
+            assert config.timeout == 60.0
+            assert config.max_connections == 50
+            assert config.max_keepalive_connections == 100
+            assert config.keepalive_expiry == 120.0
+            assert config.pool_timeout == 20.0
+            assert config.rate_limit_calls == 200
+            assert config.rate_limit_window == 300.0
+            assert config.max_retries == 5
+            assert config.http_proxy == "http://proxy.company.com:8080"
+            assert config.https_proxy == "https://proxy.company.com:8080"
+            assert config.no_proxy == "localhost,127.0.0.1"
+            assert config.verify_ssl is False
+            assert config.follow_redirects is False
+
+    def test_env_bool_true_values(self) -> None:
+        """Test environment boolean parsing for true values (line 25)."""
+        from honeyhive.config.models.http_client import HTTPClientConfig
+
+        with patch.dict(os.environ, {"HH_VERIFY_SSL": "true"}, clear=True):
+            config = HTTPClientConfig()
+            assert config.verify_ssl is True
+
+    def test_env_bool_false_values(self) -> None:
+        """Test environment boolean parsing for false values (line 27)."""
+        from honeyhive.config.models.http_client import HTTPClientConfig
+
+        with patch.dict(os.environ, {"HH_VERIFY_SSL": "false"}, clear=True):
+            config = HTTPClientConfig()
+            assert config.verify_ssl is False
+
+    def test_env_int_invalid_values(self) -> None:
+        """Test environment int parsing for invalid values (lines 35-36)."""
+        from honeyhive.config.models.http_client import HTTPClientConfig
+
+        with patch.dict(os.environ, {"HH_MAX_CONNECTIONS": "invalid"}, clear=True):
+            config = HTTPClientConfig()
+            assert config.max_connections == 10  # Should fall back to default
+
+    def test_env_float_invalid_values(self) -> None:
+        """Test environment float parsing for invalid values (lines 43-44)."""
+        from honeyhive.config.models.http_client import HTTPClientConfig
+
+        with patch.dict(os.environ, {"HH_TIMEOUT": "invalid"}, clear=True):
+            config = HTTPClientConfig()
+            assert config.timeout == 30.0  # Should fall back to default
+
+    def test_positive_float_validation_invalid_values(self) -> None:
+        """Test positive float validation with invalid values (lines 239-245)."""
+        import logging
+        from unittest.mock import patch
+
+        from honeyhive.config.models.http_client import HTTPClientConfig
+
+        with patch(
+            "honeyhive.config.models.http_client.logging.getLogger"
+        ) as mock_get_logger:
+            mock_logger = mock_get_logger.return_value
+
+            # Test negative timeout
+            config = HTTPClientConfig(timeout=-5.0)
+            assert config.timeout == 30.0  # Default for invalid value
+            mock_logger.warning.assert_called()
+
+    def test_positive_float_validation_none_values(self) -> None:
+        """Test positive float validation with None values."""
+        from honeyhive.config.models.http_client import HTTPClientConfig
+
+        config = HTTPClientConfig(timeout=None)
+        assert config.timeout == 30.0  # Default for None
+
+    def test_positive_float_validation_invalid_types(self) -> None:
+        """Test positive float validation with invalid types."""
+        import logging
+        from unittest.mock import patch
+
+        from honeyhive.config.models.http_client import HTTPClientConfig
+
+        with patch(
+            "honeyhive.config.models.http_client.logging.getLogger"
+        ) as mock_get_logger:
+            mock_logger = mock_get_logger.return_value
+
+            config = HTTPClientConfig(timeout="not-a-number")
+            assert config.timeout == 30.0  # Default for invalid type
+            mock_logger.warning.assert_called()
+
+    def test_positive_int_validation_invalid_values(self) -> None:
+        """Test positive int validation with invalid values (lines 271-277)."""
+        import logging
+        from unittest.mock import patch
+
+        from honeyhive.config.models.http_client import HTTPClientConfig
+
+        with patch(
+            "honeyhive.config.models.http_client.logging.getLogger"
+        ) as mock_get_logger:
+            mock_logger = mock_get_logger.return_value
+
+            # Test negative max_connections
+            config = HTTPClientConfig(max_connections=-5)
+            assert config.max_connections == 100  # Default for invalid value
+            mock_logger.warning.assert_called()
+
+    def test_positive_int_validation_none_values(self) -> None:
+        """Test positive int validation with None values."""
+        from honeyhive.config.models.http_client import HTTPClientConfig
+
+        config = HTTPClientConfig(max_connections=None)
+        assert config.max_connections == 100  # Default for None
+
+    def test_positive_int_validation_invalid_types(self) -> None:
+        """Test positive int validation with invalid types."""
+        import logging
+        from unittest.mock import patch
+
+        from honeyhive.config.models.http_client import HTTPClientConfig
+
+        with patch(
+            "honeyhive.config.models.http_client.logging.getLogger"
+        ) as mock_get_logger:
+            mock_logger = mock_get_logger.return_value
+
+            config = HTTPClientConfig(max_connections="not-a-number")
+            assert config.max_connections == 100  # Default for invalid type
+            mock_logger.warning.assert_called()
+
+    def test_proxy_url_validation(self) -> None:
+        """Test proxy URL validation with graceful degradation."""
+        from honeyhive.config.models.http_client import HTTPClientConfig
+
+        # Test with invalid URL
+        config = HTTPClientConfig(http_proxy="not-a-url")
+        assert config.http_proxy is None  # Should gracefully degrade
+
+        # Test with valid URL
+        config_valid = HTTPClientConfig(http_proxy="http://proxy.company.com:8080")
+        assert config_valid.http_proxy == "http://proxy.company.com:8080"
+
+    def test_graceful_degradation_invalid_values(self) -> None:
+        """Test graceful degradation with various invalid values."""
+        from honeyhive.config.models.http_client import HTTPClientConfig
+
+        # Should not crash with invalid values
+        config = HTTPClientConfig(
+            timeout=-1.0,  # Invalid negative
+            max_connections=0,  # Invalid zero
+            keepalive_expiry=-5.0,  # Invalid negative
+            max_retries=-1,  # Invalid negative
+        )
+
+        # Should use safe defaults
+        assert config.timeout == 30.0  # Default
+        assert config.max_connections == 100  # Default
+        assert config.keepalive_expiry == 30.0  # Default
+        assert config.max_retries == 100  # Default
+
+    def test_fallback_environment_variables(self) -> None:
+        """Test fallback to standard HTTP_* environment variables."""
+        from honeyhive.config.models.http_client import HTTPClientConfig
+
+        env_vars = {
+            "HTTP_MAX_CONNECTIONS": "25",
+            "HTTP_PROXY": "http://fallback.proxy.com:8080",
+            "HTTPS_PROXY": "https://fallback.proxy.com:8080",
+            "NO_PROXY": "fallback.local",
+            "VERIFY_SSL": "false",
+            "FOLLOW_REDIRECTS": "false",
+        }
+
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = HTTPClientConfig()
+            assert config.max_connections == 25
+            assert config.http_proxy == "http://fallback.proxy.com:8080"
+            assert config.https_proxy == "https://fallback.proxy.com:8080"
+            assert config.no_proxy == "fallback.local"
+            assert config.verify_ssl is False
+            assert config.follow_redirects is False

--- a/tests_v2/unit/test_config_models_tracer.py
+++ b/tests_v2/unit/test_config_models_tracer.py
@@ -1,0 +1,640 @@
+"""Unit tests for honeyhive.config.models.tracer.
+
+This module contains comprehensive unit tests for tracer configuration models
+including TracerConfig, SessionConfig, and EvaluationConfig classes with
+their field validation logic.
+"""
+
+# pylint: disable=too-many-lines
+# Justification: Comprehensive unit test coverage requires extensive test cases
+
+# pylint: disable=redefined-outer-name
+# Justification: Pytest fixture pattern requires parameter shadowing
+
+# pylint: disable=protected-access
+# Justification: Unit tests need to verify private method behavior
+
+from unittest.mock import Mock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from honeyhive.config.models.tracer import EvaluationConfig, SessionConfig, TracerConfig
+
+
+class TestTracerConfig:
+    """Test suite for TracerConfig class."""
+
+    def test_initialization_with_defaults(self) -> None:
+        """Test TracerConfig initialization with default values."""
+        # Clear any environment variables that might affect defaults
+        with patch.dict("os.environ", {}, clear=True):
+            config = TracerConfig()
+
+            assert config.api_key is None
+            assert config.project is None
+            assert config.test_mode is False
+            assert config.verbose is False
+            assert config.session_name is None
+            assert config.source == "dev"
+            assert config.server_url == "https://api.honeyhive.ai"
+            assert config.disable_http_tracing is True
+            assert config.disable_batch is False
+            assert config.disable_tracing is False
+            assert config.cache_enabled is True
+            assert config.cache_max_size is None
+            assert config.cache_ttl is None
+            assert config.cache_cleanup_interval is None
+            assert config.session_id is None
+            assert config.inputs is None
+            assert config.link_carrier is None
+            assert config.is_evaluation is False
+            assert config.run_id is None
+            assert config.dataset_id is None
+            assert config.datapoint_id is None
+            # Span limit defaults
+            assert config.max_attributes == 1024
+            assert config.max_events == 1024
+            assert config.max_links == 128
+            assert config.max_span_size == 10 * 1024 * 1024  # 10MB
+            assert config.preserve_core_attributes is True  # Default enabled
+
+    def test_initialization_with_values(self) -> None:
+        """Test TracerConfig initialization with provided values."""
+        config = TracerConfig(
+            api_key="hh_test_key",
+            project="test-project",
+            session_name="test-session",
+            source="production",
+            server_url="https://api.honeyhive.ai",
+            verbose=True,
+            test_mode=True,
+            disable_http_tracing=False,
+            disable_batch=True,
+            cache_enabled=False,
+            cache_max_size=1000,
+            cache_ttl=300.0,
+            session_id="550e8400-e29b-41d4-a716-446655440000",
+            inputs={"user_id": "123"},
+            is_evaluation=True,
+            run_id="eval-run-123",
+            max_attributes=2048,
+            max_events=256,
+            max_links=256,
+            max_span_size=20 * 1024 * 1024,  # 20MB
+            preserve_core_attributes=False,  # Explicitly disable for testing
+        )
+
+        assert config.api_key == "hh_test_key"
+        assert config.project == "test-project"
+        assert config.session_name == "test-session"
+        assert config.source == "production"
+        assert config.server_url == "https://api.honeyhive.ai"
+        assert config.verbose is True
+        assert config.test_mode is True
+        assert config.disable_http_tracing is False
+        assert config.disable_batch is True
+        assert config.cache_enabled is False
+        assert config.cache_max_size == 1000
+        assert config.cache_ttl == 300.0
+        assert config.session_id == "550e8400-e29b-41d4-a716-446655440000"
+        assert config.inputs == {"user_id": "123"}
+        assert config.is_evaluation is True
+        assert config.run_id == "eval-run-123"
+        # Span limit custom values
+        assert config.max_attributes == 2048
+        assert config.max_events == 256
+        assert config.max_links == 256
+        assert config.max_span_size == 20 * 1024 * 1024  # 20MB
+        assert config.preserve_core_attributes is False  # Custom value
+
+    def test_validate_server_url_valid_https(self) -> None:
+        """Test server URL validation with valid HTTPS URL."""
+        config = TracerConfig(server_url="https://api.honeyhive.ai")
+        assert config.server_url == "https://api.honeyhive.ai"
+
+    def test_validate_server_url_valid_http(self) -> None:
+        """Test server URL validation with valid HTTP URL."""
+        config = TracerConfig(server_url="http://localhost:8080")
+        assert config.server_url == "http://localhost:8080"
+
+    @patch("honeyhive.config.models.base.logger")
+    def test_validate_server_url_invalid_protocol(self, mock_logger: Mock) -> None:
+        """Test server URL validation with invalid protocol falls back to default."""
+        config = TracerConfig(server_url="ftp://invalid.com")
+
+        assert config.server_url == "https://api.honeyhive.ai"
+        mock_logger.warning.assert_called_once()
+        call_args = mock_logger.warning.call_args
+        assert (
+            "Invalid" in call_args[0][0] and "must be HTTP/HTTPS URL" in call_args[0][0]
+        )
+
+    @patch("honeyhive.config.models.base.logger")
+    def test_validate_server_url_non_string(self, mock_logger: Mock) -> None:
+        """Test server URL validation with non-string value falls back to default."""
+        config = TracerConfig(server_url=12345)  # type: ignore[arg-type]
+
+        assert config.server_url == "https://api.honeyhive.ai"
+        mock_logger.warning.assert_called_once()
+        call_args = mock_logger.warning.call_args
+        assert (
+            "Invalid" in call_args[0][0]
+            and "expected string" in call_args[0][0]
+            and "got" in call_args[0][0]
+        )
+
+    def test_validate_server_url_none(self) -> None:
+        """Test server URL validation with None value defaults to API URL."""
+        config = TracerConfig(server_url=None)
+        assert config.server_url == "https://api.honeyhive.ai"
+
+    def test_validate_source_valid_string(self) -> None:
+        """Test source validation with valid string."""
+        config = TracerConfig(source="production")
+        assert config.source == "production"
+
+    @patch("honeyhive.config.models.base.logger")
+    def test_validate_source_non_string(self, mock_logger: Mock) -> None:
+        """Test source validation with non-string value."""
+        config = TracerConfig(source=123)  # type: ignore[arg-type]
+
+        assert config.source == "dev"
+        mock_logger.warning.assert_called_once()
+        call_args = mock_logger.warning.call_args
+        assert (
+            "Invalid" in call_args[0][0]
+            and "expected string" in call_args[0][0]
+            and "got" in call_args[0][0]
+        )
+
+    @patch("honeyhive.config.models.base.logger")
+    def test_validate_source_empty_string(self, mock_logger: Mock) -> None:
+        """Test source validation with empty string."""
+        config = TracerConfig(source="")
+
+        assert config.source == "dev"
+        mock_logger.warning.assert_called_once()
+        call_args = mock_logger.warning.call_args
+        assert "Empty" in call_args[0][0] and "provided" in call_args[0][0]
+
+    def test_validate_session_id_valid_uuid(self) -> None:
+        """Test session ID validation with valid UUID."""
+        valid_uuid = "550e8400-e29b-41d4-a716-446655440000"
+        config = TracerConfig(session_id=valid_uuid)
+        assert config.session_id == valid_uuid.lower()
+
+    def test_validate_session_id_uppercase_uuid(self) -> None:
+        """Test session ID validation normalizes uppercase UUID to lowercase."""
+        uppercase_uuid = "550E8400-E29B-41D4-A716-446655440000"
+        config = TracerConfig(session_id=uppercase_uuid)
+        assert config.session_id == uppercase_uuid.lower()
+
+    @patch("honeyhive.config.models.tracer.logger")
+    def test_validate_session_id_invalid_uuid(self, mock_logger: Mock) -> None:
+        """Test session ID validation with invalid UUID format."""
+        config = TracerConfig(session_id="invalid-uuid")
+
+        assert config.session_id is None
+        mock_logger.warning.assert_called_once()
+        call_args = mock_logger.warning.call_args
+        assert "Invalid session_id: must be a valid UUID" in call_args[0][0]
+
+    @patch("honeyhive.config.models.base.logger")
+    def test_validate_session_id_non_string(self, mock_logger: Mock) -> None:
+        """Test session ID validation with non-string value."""
+        config = TracerConfig(session_id=12345)  # type: ignore[arg-type]
+
+        assert config.session_id is None
+        mock_logger.warning.assert_called_once()
+        call_args = mock_logger.warning.call_args
+        assert (
+            "Invalid" in call_args[0][0]
+            and "expected string" in call_args[0][0]
+            and "got" in call_args[0][0]
+        )
+
+    def test_validate_session_id_none(self) -> None:
+        """Test session ID validation with None value."""
+        config = TracerConfig(session_id=None)
+        assert config.session_id is None
+
+    def test_validate_ids_valid_strings(self) -> None:
+        """Test ID field validation with valid strings."""
+        config = TracerConfig(
+            run_id="eval-run-123",
+            dataset_id="dataset-456",
+            datapoint_id="datapoint-789",
+        )
+
+        assert config.run_id == "eval-run-123"
+        assert config.dataset_id == "dataset-456"
+        assert config.datapoint_id == "datapoint-789"
+
+    @patch("honeyhive.config.models.base.logger")
+    def test_validate_ids_non_string_values(self, mock_logger: Mock) -> None:
+        """Test ID field validation with non-string values."""
+        config = TracerConfig(
+            run_id=123,  # type: ignore[arg-type]
+            dataset_id=456,  # type: ignore[arg-type]
+            datapoint_id=789,  # type: ignore[arg-type]
+        )
+
+        assert config.run_id is None
+        assert config.dataset_id is None
+        assert config.datapoint_id is None
+        assert mock_logger.warning.call_count == 3
+
+    @patch("honeyhive.config.models.base.logger")
+    def test_validate_ids_empty_strings(self, mock_logger: Mock) -> None:
+        """Test ID field validation with empty strings."""
+        config = TracerConfig(run_id="", dataset_id="   ", datapoint_id="")
+
+        assert config.run_id is None
+        assert config.dataset_id is None
+        assert config.datapoint_id is None
+        assert mock_logger.warning.call_count == 3
+
+    def test_validate_ids_none_values(self) -> None:
+        """Test ID field validation with None values."""
+        config = TracerConfig(run_id=None, dataset_id=None, datapoint_id=None)
+
+        assert config.run_id is None
+        assert config.dataset_id is None
+        assert config.datapoint_id is None
+
+    def test_environment_variable_loading(self) -> None:
+        """Test configuration loading from environment variables."""
+        with patch.dict(
+            "os.environ",
+            {
+                "HH_API_KEY": "env_api_key",
+                "HH_PROJECT": "env_project",
+                "HH_SOURCE": "env_source",
+                "HH_API_URL": "https://env.honeyhive.ai",
+                "HH_VERBOSE": "true",
+                "HH_TEST_MODE": "true",
+                "HH_DISABLE_HTTP_TRACING": "false",
+                "HH_DISABLE_BATCH": "true",
+                "HH_CACHE_ENABLED": "false",
+                "HH_CACHE_MAX_SIZE": "2000",
+                "HH_CACHE_TTL": "600.0",
+                "HH_MAX_ATTRIBUTES": "5000",
+                "HH_MAX_EVENTS": "512",
+                "HH_MAX_LINKS": "256",
+                "HH_MAX_SPAN_SIZE": "52428800",  # 50MB in bytes
+                "HH_PRESERVE_CORE_ATTRIBUTES": "false",  # Disable via env var
+            },
+            clear=True,
+        ):
+            config = TracerConfig()
+
+            assert config.api_key == "env_api_key"
+            assert config.project == "env_project"
+            assert config.source == "env_source"
+            assert config.server_url == "https://env.honeyhive.ai"
+            assert config.verbose is True
+            assert config.test_mode is True
+            assert config.disable_http_tracing is False
+            assert config.disable_batch is True
+            assert config.cache_enabled is False
+            assert config.cache_max_size == 2000
+            assert config.cache_ttl == 600.0
+            # Span limit environment variables
+            assert config.max_attributes == 5000
+            assert config.max_events == 512
+            assert config.max_links == 256
+            assert config.max_span_size == 52428800  # 50MB
+            assert config.preserve_core_attributes is False  # Disabled via env var
+
+    def test_extra_fields_forbidden(self) -> None:
+        """Test that extra fields are forbidden in configuration."""
+        with pytest.raises(ValidationError) as exc_info:
+            TracerConfig(invalid_field="should_fail")  # type: ignore[call-arg]
+
+        assert "Extra inputs are not permitted" in str(exc_info.value)
+
+    def test_complex_inputs_dict(self) -> None:
+        """Test configuration with complex inputs dictionary."""
+        complex_inputs = {
+            "user_id": "user-123",
+            "session_data": {
+                "timestamp": "2024-01-01T00:00:00Z",
+                "metadata": {"version": "1.0"},
+            },
+            "query": "test query",
+        }
+
+        config = TracerConfig(inputs=complex_inputs)
+        assert config.inputs == complex_inputs
+
+    def test_complex_link_carrier_dict(self) -> None:
+        """Test configuration with complex link carrier dictionary."""
+        link_carrier = {
+            "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+            "baggage": "userId=alice,serverNode=DF:28,isProduction=false",
+            "custom_header": "custom_value",
+        }
+
+        config = TracerConfig(link_carrier=link_carrier)
+        assert config.link_carrier == link_carrier
+
+
+class TestSessionConfig:
+    """Test suite for SessionConfig class."""
+
+    def test_initialization_with_defaults(self) -> None:
+        """Test SessionConfig initialization with default values."""
+        with patch.dict("os.environ", {}, clear=True):
+            config = SessionConfig()
+
+            assert config.api_key is None
+            assert config.project is None
+            assert config.test_mode is False
+            assert config.verbose is False
+            assert config.session_id is None
+            assert config.inputs is None
+            assert config.link_carrier is None
+
+    def test_initialization_with_values(self) -> None:
+        """Test SessionConfig initialization with provided values."""
+        config = SessionConfig(
+            api_key="hh_session_key",
+            project="session-project",
+            session_id="550e8400-e29b-41d4-a716-446655440000",
+            inputs={"user_id": "session-user"},
+            link_carrier={"traceparent": "00-123"},
+            verbose=True,
+        )
+
+        assert config.api_key == "hh_session_key"
+        assert config.project == "session-project"
+        assert config.session_id == "550e8400-e29b-41d4-a716-446655440000"
+        assert config.inputs == {"user_id": "session-user"}
+        assert config.link_carrier == {"traceparent": "00-123"}
+        assert config.verbose is True
+
+    def test_validate_session_id_valid_uuid(self) -> None:
+        """Test session ID validation with valid UUID."""
+        valid_uuid = "550e8400-e29b-41d4-a716-446655440000"
+        config = SessionConfig(session_id=valid_uuid)
+        assert config.session_id == valid_uuid.lower()
+
+    def test_validate_session_id_uppercase_uuid(self) -> None:
+        """Test session ID validation normalizes uppercase UUID to lowercase."""
+        uppercase_uuid = "550E8400-E29B-41D4-A716-446655440000"
+        config = SessionConfig(session_id=uppercase_uuid)
+        assert config.session_id == uppercase_uuid.lower()
+
+    @patch("honeyhive.config.models.tracer.logger")
+    def test_validate_session_id_invalid_uuid(self, mock_logger: Mock) -> None:
+        """Test session ID validation with invalid UUID format."""
+        config = SessionConfig(session_id="invalid-uuid")
+
+        assert config.session_id is None
+        mock_logger.warning.assert_called_once()
+        call_args = mock_logger.warning.call_args
+        assert "Invalid session_id: must be a valid UUID" in call_args[0][0]
+
+    @patch("honeyhive.config.models.base.logger")
+    def test_validate_session_id_non_string(self, mock_logger: Mock) -> None:
+        """Test session ID validation with non-string value."""
+        config = SessionConfig(session_id=12345)  # type: ignore[arg-type]
+
+        assert config.session_id is None
+        mock_logger.warning.assert_called_once()
+        call_args = mock_logger.warning.call_args
+        assert (
+            "Invalid" in call_args[0][0]
+            and "expected string" in call_args[0][0]
+            and "got" in call_args[0][0]
+        )
+
+    def test_validate_session_id_none(self) -> None:
+        """Test session ID validation with None value."""
+        config = SessionConfig(session_id=None)
+        assert config.session_id is None
+
+    def test_extra_fields_forbidden(self) -> None:
+        """Test that extra fields are forbidden in session configuration."""
+        with pytest.raises(ValidationError) as exc_info:
+            SessionConfig(invalid_field="should_fail")  # type: ignore[call-arg]
+
+        assert "Extra inputs are not permitted" in str(exc_info.value)
+
+    def test_inheritance_from_base_config(self) -> None:
+        """Test that SessionConfig properly inherits from BaseHoneyHiveConfig."""
+        config = SessionConfig(
+            api_key="hh_inherited_key",
+            project="inherited-project",
+            test_mode=True,
+            verbose=True,
+        )
+
+        # Test inherited fields work correctly
+        assert config.api_key == "hh_inherited_key"
+        assert config.project == "inherited-project"
+        assert config.test_mode is True
+        assert config.verbose is True
+
+
+class TestEvaluationConfig:
+    """Test suite for EvaluationConfig class."""
+
+    def test_initialization_with_defaults(self) -> None:
+        """Test EvaluationConfig initialization with default values."""
+        with patch.dict("os.environ", {}, clear=True):
+            config = EvaluationConfig()
+
+            assert config.api_key is None
+            assert config.project is None
+            assert config.test_mode is False
+            assert config.verbose is False
+            assert config.is_evaluation is False
+            assert config.run_id is None
+            assert config.dataset_id is None
+            assert config.datapoint_id is None
+
+    def test_initialization_with_values(self) -> None:
+        """Test EvaluationConfig initialization with provided values."""
+        config = EvaluationConfig(
+            api_key="hh_eval_key",
+            project="eval-project",
+            is_evaluation=True,
+            run_id="eval-run-456",
+            dataset_id="eval-dataset-789",
+            datapoint_id="eval-datapoint-123",
+            verbose=True,
+        )
+
+        assert config.api_key == "hh_eval_key"
+        assert config.project == "eval-project"
+        assert config.is_evaluation is True
+        assert config.run_id == "eval-run-456"
+        assert config.dataset_id == "eval-dataset-789"
+        assert config.datapoint_id == "eval-datapoint-123"
+        assert config.verbose is True
+
+    def test_validate_ids_valid_strings(self) -> None:
+        """Test ID field validation with valid strings."""
+        config = EvaluationConfig(
+            run_id="eval-run-123",
+            dataset_id="dataset-456",
+            datapoint_id="datapoint-789",
+        )
+
+        assert config.run_id == "eval-run-123"
+        assert config.dataset_id == "dataset-456"
+        assert config.datapoint_id == "datapoint-789"
+
+    @patch("honeyhive.config.models.base.logger")
+    def test_validate_ids_non_string_values(self, mock_logger: Mock) -> None:
+        """Test ID field validation with non-string values."""
+        config = EvaluationConfig(
+            run_id=123,  # type: ignore[arg-type]
+            dataset_id=456,  # type: ignore[arg-type]
+            datapoint_id=789,  # type: ignore[arg-type]
+        )
+
+        assert config.run_id is None
+        assert config.dataset_id is None
+        assert config.datapoint_id is None
+        assert mock_logger.warning.call_count == 3
+
+    @patch("honeyhive.config.models.base.logger")
+    def test_validate_ids_empty_strings(self, mock_logger: Mock) -> None:
+        """Test ID field validation with empty strings."""
+        config = EvaluationConfig(run_id="", dataset_id="   ", datapoint_id="")
+
+        assert config.run_id is None
+        assert config.dataset_id is None
+        assert config.datapoint_id is None
+        assert mock_logger.warning.call_count == 3
+
+    def test_validate_ids_none_values(self) -> None:
+        """Test ID field validation with None values."""
+        config = EvaluationConfig(run_id=None, dataset_id=None, datapoint_id=None)
+
+        assert config.run_id is None
+        assert config.dataset_id is None
+        assert config.datapoint_id is None
+
+    def test_extra_fields_forbidden(self) -> None:
+        """Test that extra fields are forbidden in evaluation configuration."""
+        with pytest.raises(ValidationError) as exc_info:
+            EvaluationConfig(invalid_field="should_fail")  # type: ignore[call-arg]
+
+        assert "Extra inputs are not permitted" in str(exc_info.value)
+
+    def test_inheritance_from_base_config(self) -> None:
+        """Test that EvaluationConfig properly inherits from BaseHoneyHiveConfig."""
+        config = EvaluationConfig(
+            api_key="hh_inherited_key",
+            project="inherited-project",
+            test_mode=True,
+            verbose=True,
+        )
+
+        # Test inherited fields work correctly
+        assert config.api_key == "hh_inherited_key"
+        assert config.project == "inherited-project"
+        assert config.test_mode is True
+        assert config.verbose is True
+
+    def test_evaluation_mode_enabled(self) -> None:
+        """Test evaluation mode configuration."""
+        config = EvaluationConfig(
+            is_evaluation=True,
+            run_id="experiment-2024-01-15",
+            dataset_id="qa-dataset-v2",
+            datapoint_id="question-42",
+        )
+
+        assert config.is_evaluation is True
+        assert config.run_id == "experiment-2024-01-15"
+        assert config.dataset_id == "qa-dataset-v2"
+        assert config.datapoint_id == "question-42"
+
+
+class TestConfigModelIntegration:
+    """Test suite for integration scenarios between config models."""
+
+    def test_tracer_config_with_session_and_evaluation_fields(self) -> None:
+        """Test TracerConfig with both session and evaluation fields."""
+        config = TracerConfig(
+            api_key="hh_integrated_key",
+            project="integrated-project",
+            # Session fields
+            session_id="550e8400-e29b-41d4-a716-446655440000",
+            inputs={"user_id": "integrated-user"},
+            link_carrier={"traceparent": "00-integrated"},
+            # Evaluation fields
+            is_evaluation=True,
+            run_id="integrated-run",
+            dataset_id="integrated-dataset",
+            datapoint_id="integrated-datapoint",
+        )
+
+        # Base config fields
+        assert config.api_key == "hh_integrated_key"
+        assert config.project == "integrated-project"
+
+        # Session fields
+        assert config.session_id == "550e8400-e29b-41d4-a716-446655440000"
+        assert config.inputs == {"user_id": "integrated-user"}
+        assert config.link_carrier == {"traceparent": "00-integrated"}
+
+        # Evaluation fields
+        assert config.is_evaluation is True
+        assert config.run_id == "integrated-run"
+        assert config.dataset_id == "integrated-dataset"
+        assert config.datapoint_id == "integrated-datapoint"
+
+    def test_config_model_field_types(self) -> None:
+        """Test that all config models have correct field types."""
+        # Test TracerConfig field types
+        tracer_config = TracerConfig()
+        assert isinstance(tracer_config.disable_http_tracing, bool)
+        assert isinstance(tracer_config.disable_batch, bool)
+        assert isinstance(tracer_config.cache_enabled, bool)
+
+        # Test SessionConfig field types
+        session_config = SessionConfig()
+        assert session_config.session_id is None or isinstance(
+            session_config.session_id, str
+        )
+        assert session_config.inputs is None or isinstance(session_config.inputs, dict)
+
+        # Test EvaluationConfig field types
+        eval_config = EvaluationConfig()
+        assert isinstance(eval_config.is_evaluation, bool)
+        assert eval_config.run_id is None or isinstance(eval_config.run_id, str)
+
+    def test_config_model_validation_error_handling(self) -> None:
+        """Test that config models handle validation errors gracefully."""
+        # Test that invalid types are handled gracefully through validators
+        # rather than raising ValidationError for basic type mismatches
+
+        # These should not raise ValidationError due to graceful degradation
+        tracer_config = TracerConfig(
+            server_url=12345,  # type: ignore[arg-type]  # Invalid type
+            source=None,  # type: ignore[arg-type]  # Invalid for source
+            session_id="invalid-uuid",  # Invalid UUID, should become None
+        )
+
+        assert tracer_config.server_url == "https://api.honeyhive.ai"
+        assert tracer_config.source == "dev"
+        assert tracer_config.session_id is None
+
+    @patch("honeyhive.config.models.tracer.uuid.UUID")
+    def test_uuid_validation_exception_handling(self, mock_uuid: Mock) -> None:
+        """Test UUID validation handles ValueError exceptions."""
+        mock_uuid.side_effect = ValueError("Invalid UUID format")
+
+        with patch("honeyhive.config.models.tracer.logger") as mock_logger:
+            config = TracerConfig(session_id="test-uuid")
+
+            assert config.session_id is None
+            mock_logger.warning.assert_called_once()
+            call_args = mock_logger.warning.call_args
+            assert "Invalid session_id: must be a valid UUID" in call_args[0][0]

--- a/tests_v2/unit/test_config_validation.py
+++ b/tests_v2/unit/test_config_validation.py
@@ -1,0 +1,413 @@
+"""Configuration Validation Integration Tests.
+
+TRUE integration tests (no SDK mocks) that validate:
+- Real config loading and merging
+- Real environment variable loading
+- Real tracer initialization with various configs
+- Real Pydantic validation
+- Real default value fallbacks
+- Real config serialization
+
+Reference: INTEGRATION_TEST_INVENTORY_AND_GAP_ANALYSIS.md Phase 1 Critical Tests
+Standards: .agent-os/standards/testing/integration-testing.md
+
+HARD RULE: NO MOCKS for SDK code - only mock external environment variables.
+"""
+
+# pylint: disable=duplicate-code,too-many-statements,too-many-locals,too-few-public-methods
+
+import uuid
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from honeyhive import HoneyHiveTracer
+from honeyhive.config.models.otlp import OTLPConfig
+from honeyhive.config.models.tracer import EvaluationConfig, SessionConfig, TracerConfig
+
+
+class TestEnvironmentVariables:
+    """Test environment variable loading and precedence with REAL env vars."""
+
+    def test_hh_api_key_precedence(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test HH_API_KEY environment variable is loaded and can be overridden."""
+        # Set env var
+        test_api_key_from_env = "env-api-key-12345"
+        monkeypatch.setenv("HH_API_KEY", test_api_key_from_env)
+
+        # Test 1: Env var alone should be used
+        tracer1 = HoneyHiveTracer(project="test-project", test_mode=True)
+        assert tracer1.api_key == test_api_key_from_env
+        tracer1.shutdown()
+
+        # Test 2: Individual param should override env var (highest priority)
+        override_api_key = "override-api-key-67890"
+        tracer2 = HoneyHiveTracer(
+            api_key=override_api_key, project="test-project", test_mode=True
+        )
+        assert tracer2.api_key == override_api_key
+        tracer2.shutdown()
+
+        # Test 3: TracerConfig should override env var
+        config_api_key = "config-api-key-11111"
+        tracer_config = TracerConfig(
+            api_key=config_api_key, project="test-project", test_mode=True
+        )
+        tracer3 = HoneyHiveTracer(config=tracer_config)
+        assert tracer3.api_key == config_api_key
+        tracer3.shutdown()
+
+    def test_hh_api_url_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test HH_API_URL environment variable overrides default server_url."""
+        # Set custom server URL via env var
+        custom_url = "https://custom.api.honeyhive.ai"
+        monkeypatch.setenv("HH_API_URL", custom_url)
+
+        # Tracer should use env var URL
+        tracer = HoneyHiveTracer(
+            api_key="test-key", project="test-project", test_mode=True
+        )
+        # Note: server_url may not be directly accessible, test via config
+        assert tracer.config.get("server_url") == custom_url
+        tracer.shutdown()
+
+    def test_hh_project_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test HH_PROJECT environment variable provides default project."""
+        # Set project via env var
+        env_project = "env-test-project"
+        monkeypatch.setenv("HH_PROJECT", env_project)
+
+        # Tracer should use env var project
+        tracer = HoneyHiveTracer(api_key="test-key", test_mode=True)
+        assert tracer.project == env_project
+        tracer.shutdown()
+
+    def test_priority_order(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test complete priority order.
+
+        individual > SessionConfig > EvaluationConfig > TracerConfig > env vars
+        """
+        # Setup: env var as lowest priority
+        monkeypatch.setenv("HH_API_KEY", "env-key")
+        monkeypatch.setenv("HH_PROJECT", "env-project")
+
+        # TracerConfig (overrides env vars)
+        tracer_config = TracerConfig(
+            api_key="tracer-config-key",
+            project="tracer-config-project",
+            test_mode=True,
+        )
+
+        # SessionConfig (overrides TracerConfig for shared fields)
+        session_config = SessionConfig(project="session-config-project")
+
+        # Individual param (highest priority)
+        tracer = HoneyHiveTracer(
+            config=tracer_config,
+            session_config=session_config,
+            api_key="individual-key",  # This should win for api_key
+            # project comes from session_config (no individual override)
+        )
+
+        # Verify priority order
+        assert tracer.api_key == "individual-key"  # individual param wins
+        assert tracer.project == "session-config-project"  # SessionConfig wins
+        tracer.shutdown()
+
+
+class TestDefaultValues:
+    """Test default value fallbacks with REAL tracer initialization."""
+
+    def test_default_server_url(self) -> None:
+        """Test default server_url is set when not provided."""
+        tracer = HoneyHiveTracer(
+            api_key="test-key", project="test-project", test_mode=True
+        )
+
+        # Default server URL should be set
+        # (may be staging or production depending on env)
+        server_url = tracer.config.get("server_url")
+        assert server_url is not None
+        assert "honeyhive.ai" in server_url
+        tracer.shutdown()
+
+    def test_default_test_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test default test_mode is False when HH_TEST_MODE not set."""
+        # Clear HH_TEST_MODE environment variable to test true default
+        monkeypatch.delenv("HH_TEST_MODE", raising=False)
+
+        # Create TracerConfig without test_mode
+        config = TracerConfig(api_key="test-key", project="test-project")
+        assert config.test_mode is False  # Pydantic default
+
+    def test_default_batch_settings(self) -> None:
+        """Test default batch_size, flush_interval, export_timeout values."""
+        # Create OTLPConfig with defaults
+        otlp_config = OTLPConfig()
+
+        # Verify default batch settings (these are Pydantic defaults)
+        assert isinstance(otlp_config.batch_size, int)
+        assert otlp_config.batch_size > 0
+        assert isinstance(otlp_config.flush_interval, (int, float))
+        assert otlp_config.flush_interval > 0
+        assert isinstance(otlp_config.export_timeout, (int, float))
+        assert otlp_config.export_timeout > 0
+
+
+class TestTypeValidation:
+    """Test Pydantic type validation with REAL validation errors."""
+
+    def test_session_config_invalid_session_id_format(self) -> None:
+        """Test invalid session_id format is handled gracefully."""
+        # SDK uses graceful degradation: logs warning, sets to None
+        config = SessionConfig(
+            session_id="not-a-uuid-format",  # Invalid UUID
+            project="test-project",
+        )
+
+        # SDK should set invalid UUID to None (graceful degradation)
+        assert config.session_id is None
+
+    def test_evaluation_config_invalid_uuid_formats(self) -> None:
+        """Test EvaluationConfig accepts string IDs without strict UUID validation."""
+        # SDK accepts string IDs for evaluation fields (no strict UUID validation)
+        # This allows flexibility for different ID formats
+
+        # Test run_id - accepts any string
+        config1 = EvaluationConfig(
+            run_id="not-a-valid-uuid",
+            project="test-project",
+        )
+        assert config1.run_id == "not-a-valid-uuid"  # Accepted as-is
+
+        # Test dataset_id - accepts any string
+        config2 = EvaluationConfig(
+            dataset_id="invalid-dataset-id-123",
+            project="test-project",
+        )
+        assert config2.dataset_id == "invalid-dataset-id-123"  # Accepted as-is
+
+        # Test datapoint_id - accepts any string
+        config3 = EvaluationConfig(
+            datapoint_id="12345",  # Not UUID format but accepted
+            project="test-project",
+        )
+        assert config3.datapoint_id == "12345"  # Accepted as-is
+
+    def test_otlp_config_invalid_numeric_values(self) -> None:
+        """Test invalid numeric values are handled gracefully."""
+        # SDK uses graceful degradation for invalid values
+
+        # Test negative batch_size - should use default
+        config = OTLPConfig(batch_size=-1)
+        assert config.batch_size == 100  # Default value
+
+        # Test negative export_timeout - should use default
+        config2 = OTLPConfig(export_timeout=-10.0)
+        assert config2.export_timeout > 0  # Positive default
+
+        # Test zero batch_size - should use default
+        config3 = OTLPConfig(batch_size=0)
+        assert config3.batch_size == 100  # Default value
+
+
+class TestConfigSerialization:
+    """Test config serialization/deserialization with REAL models."""
+
+    def test_to_dict_all_models(self) -> None:
+        """Test model_dump() on all config models."""
+        # TracerConfig
+        tracer_config = TracerConfig(
+            api_key="test-key",
+            project="test-project",
+            test_mode=True,
+        )
+        tracer_dict = tracer_config.model_dump()
+        assert isinstance(tracer_dict, dict)
+        assert tracer_dict["api_key"] == "test-key"
+        assert tracer_dict["project"] == "test-project"
+        assert tracer_dict["test_mode"] is True
+
+        # SessionConfig
+        session_id = str(uuid.uuid4())
+        session_config = SessionConfig(
+            session_id=session_id,
+            project="test-project",
+        )
+        session_dict = session_config.model_dump()
+        assert isinstance(session_dict, dict)
+        assert session_dict["session_id"] == session_id
+
+        # EvaluationConfig
+        run_id = str(uuid.uuid4())
+        eval_config = EvaluationConfig(
+            run_id=run_id,
+            project="test-project",
+        )
+        eval_dict = eval_config.model_dump()
+        assert isinstance(eval_dict, dict)
+        assert eval_dict["run_id"] == run_id
+
+        # OTLPConfig
+        otlp_config = OTLPConfig(batch_size=100, export_timeout=30.0)
+        otlp_dict = otlp_config.model_dump()
+        assert isinstance(otlp_dict, dict)
+        assert otlp_dict["batch_size"] == 100
+        assert otlp_dict["export_timeout"] == 30.0
+
+    def test_from_dict_reconstruction(self) -> None:
+        """Test model_validate() reconstruction for all models."""
+        # TracerConfig from dict
+        tracer_dict = {
+            "api_key": "test-key",
+            "project": "test-project",
+            "test_mode": True,
+        }
+        tracer_config = TracerConfig.model_validate(tracer_dict)
+        assert tracer_config.api_key == "test-key"
+        assert tracer_config.project == "test-project"
+        assert tracer_config.test_mode is True
+
+        # SessionConfig from dict
+        session_id = str(uuid.uuid4())
+        session_dict = {
+            "session_id": session_id,
+            "project": "test-project",
+        }
+        session_config = SessionConfig.model_validate(session_dict)
+        assert session_config.session_id == session_id
+
+        # OTLPConfig from dict
+        otlp_dict = {"batch_size": 200, "export_timeout": 60.0}
+        otlp_config = OTLPConfig.model_validate(otlp_dict)
+        assert otlp_config.batch_size == 200
+        assert otlp_config.export_timeout == 60.0
+
+    def test_json_serialization(self) -> None:
+        """Test JSON.dumps/loads for all models."""
+        # Create config
+        tracer_config = TracerConfig(
+            api_key="test-key",
+            project="test-project",
+            test_mode=True,
+        )
+
+        # Serialize to JSON string
+        json_str = tracer_config.model_dump_json()
+        assert isinstance(json_str, str)
+
+        # Deserialize from JSON string
+        reconstructed = TracerConfig.model_validate_json(json_str)
+        assert reconstructed.api_key == tracer_config.api_key
+        assert reconstructed.project == tracer_config.project
+        assert reconstructed.test_mode == tracer_config.test_mode
+
+    def test_roundtrip_no_data_loss(self) -> None:
+        """Test config → dict → config preserves all data."""
+        # Create config with all fields
+        session_id = str(uuid.uuid4())
+        original_config = SessionConfig(
+            session_id=session_id,
+            project="test-project",
+            api_key="test-key",
+        )
+
+        # Round trip: config → dict → config
+        config_dict = original_config.model_dump()
+        reconstructed_config = SessionConfig.model_validate(config_dict)
+
+        # Verify all fields preserved
+        assert reconstructed_config.session_id == original_config.session_id
+        assert reconstructed_config.project == original_config.project
+        assert reconstructed_config.api_key == original_config.api_key
+
+
+class TestRequiredFields:
+    """Test required field validation with REAL tracer initialization."""
+
+    def test_missing_api_key_graceful_error(self) -> None:
+        """Test missing api_key → graceful error or test mode."""
+        # Without api_key or test_mode, tracer may fail gracefully
+        # This is a REAL integration test - no mocks
+        try:
+            tracer = HoneyHiveTracer(project="test-project")
+            # If it succeeds, verify it's in a safe mode
+            assert tracer is not None
+            tracer.shutdown()
+        except (ValueError, ValidationError, TypeError) as e:
+            # Expected behavior: clear error message
+            assert "api_key" in str(e).lower() or "required" in str(e).lower()
+
+    def test_missing_project(self) -> None:
+        """Test missing project → uses default or errors."""
+        # Test with api_key but no project
+        tracer = HoneyHiveTracer(api_key="test-key", test_mode=True)
+
+        # Should either have a default project or handle gracefully
+        assert tracer is not None
+        assert hasattr(tracer, "project")
+        # Project may be None, empty string, or a default value
+        tracer.shutdown()
+
+
+class TestInvalidConfigCombinations:
+    """Test invalid configuration combinations with REAL initialization."""
+
+    def test_clear_error_messages(self) -> None:
+        """Verify SDK provides clear graceful degradation for invalid configs."""
+        # SDK uses graceful degradation with warning logs
+        # Test invalid session_id - should set to None with warning log
+        config = SessionConfig(session_id="invalid-uuid", project="test")
+
+        # SDK gracefully degrades invalid UUID to None
+        assert config.session_id is None
+        # In real usage, this would also log a warning message
+        # which is more user-friendly than raising ValidationError
+
+
+class TestEnvFileLoading:
+    """Test .env file loading with REAL file operations."""
+
+    def test_env_file_loading(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test .env file is parsed and loaded."""
+        # Create temp .env file
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "HH_API_KEY=env-file-key\n"
+            "HH_PROJECT=env-file-project\n"
+            "HH_API_URL=https://test.api.honeyhive.ai\n"
+        )
+
+        # Change to temp directory
+        monkeypatch.chdir(tmp_path)
+
+        # NOTE: The SDK may or may not auto-load .env files
+        # This test verifies the behavior if it does
+        # If not auto-loaded, this documents expected behavior
+
+        # For now, manually set env vars to simulate .env loading
+        monkeypatch.setenv("HH_API_KEY", "env-file-key")
+        monkeypatch.setenv("HH_PROJECT", "env-file-project")
+
+        tracer = HoneyHiveTracer(test_mode=True)
+        assert tracer.api_key == "env-file-key"
+        assert tracer.project == "env-file-project"
+        tracer.shutdown()
+
+    def test_file_not_found_uses_defaults(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test missing .env file uses defaults without crash."""
+        # Change to temp directory with no .env file
+        monkeypatch.chdir(tmp_path)
+
+        # Should not crash, should use defaults/provided values
+        tracer = HoneyHiveTracer(
+            api_key="test-key", project="test-project", test_mode=True
+        )
+        assert tracer is not None
+        assert tracer.api_key == "test-key"
+        tracer.shutdown()

--- a/tests_v2/unit/test_models_tracing.py
+++ b/tests_v2/unit/test_models_tracing.py
@@ -1,0 +1,41 @@
+"""Unit tests for tracing models."""
+
+from honeyhive.models.tracing import TracingParams
+
+
+class TestTracingModels:
+    """Test tracing-related model functionality."""
+
+    def test_tracing_params_creation(self) -> None:
+        """Test creating a TracingParams model."""
+        params = TracingParams(
+            event_type="model",
+            event_name="test_event",
+            inputs={"query": "test query"},
+            outputs={"response": "test response"},
+            metadata={"version": "1.0"},
+        )
+
+        assert params.event_type == "model"
+        assert params.event_name == "test_event"
+        assert params.inputs == {"query": "test query"}
+        assert params.outputs == {"response": "test response"}
+        assert params.metadata == {"version": "1.0"}
+
+    def test_tracing_params_optional_fields(self) -> None:
+        """Test TracingParams with optional fields."""
+        params = TracingParams()
+
+        assert params.event_type is None
+        assert params.event_name is None
+        assert params.inputs is None
+        assert params.outputs is None
+
+    def test_tracing_params_validation(self) -> None:
+        """Test TracingParams validation."""
+        # Test that TracingParams can be created with minimal fields
+        params = TracingParams(event_type="tool")  # Use valid event_type
+
+        assert params is not None
+        assert hasattr(params, "event_type")
+        assert hasattr(params, "event_name")

--- a/tests_v2/unit/test_tracer_infra_environment.py
+++ b/tests_v2/unit/test_tracer_infra_environment.py
@@ -1,0 +1,1513 @@
+"""Unit tests for honeyhive.tracer.infra.environment.
+
+This module contains comprehensive unit tests for environment detection and
+resource analysis functionality in the HoneyHive tracer infrastructure.
+"""
+
+# pylint: disable=too-many-lines
+# Justification: Comprehensive unit test coverage requires extensive test cases
+
+# pylint: disable=redefined-outer-name
+# Justification: Pytest fixture pattern requires parameter shadowing
+
+# pylint: disable=protected-access
+# Justification: Unit tests need to verify private method behavior
+
+# pylint: disable=too-few-public-methods
+# Justification: Test classes are focused on specific functionality
+
+import os
+from unittest.mock import Mock, patch
+
+from honeyhive.tracer.infra.environment import (
+    EnvironmentDetector,
+    clear_environment_cache,
+    get_comprehensive_environment_analysis,
+    get_environment_type,
+    get_performance_characteristics,
+    get_resource_constraints,
+)
+
+
+class TestEnvironmentDetectorInitialization:
+    """Test EnvironmentDetector initialization."""
+
+    def test_init_with_tracer_instance(self) -> None:
+        """Test initialization with tracer instance."""
+        mock_tracer = Mock()
+        detector = EnvironmentDetector(mock_tracer)
+
+        assert detector.tracer_instance is mock_tracer
+        assert not detector._cache
+
+    def test_init_without_tracer_instance(self) -> None:
+        """Test initialization without tracer instance."""
+        detector = EnvironmentDetector(None)
+
+        assert detector.tracer_instance is None
+        assert not detector._cache
+
+    def test_init_with_optional_tracer(self) -> None:
+        """Test initialization with optional tracer parameter."""
+        detector = EnvironmentDetector()
+
+        assert detector.tracer_instance is None
+        assert not detector._cache
+
+
+class TestEnvironmentDetectorPrimaryEnvironmentType:
+    """Test primary environment type detection."""
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch.dict(os.environ, {"AWS_LAMBDA_FUNCTION_NAME": "test-function"})
+    def test_detect_aws_lambda_environment(self, __mock_safe_log: Mock) -> None:
+        """Test detection of AWS Lambda environment."""
+        detector = EnvironmentDetector()
+
+        result = detector.detect_primary_environment_type()
+
+        assert result == "aws_lambda"
+        assert detector._cache["environment_type"] == "aws_lambda"
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch.dict(os.environ, {"KUBERNETES_SERVICE_HOST": "10.0.0.1"})
+    def test_detect_kubernetes_environment(self, _mock_safe_log: Mock) -> None:
+        """Test detection of Kubernetes environment."""
+        detector = EnvironmentDetector()
+
+        result = detector.detect_primary_environment_type()
+
+        assert result == "kubernetes"
+        assert detector._cache["environment_type"] == "kubernetes"
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch("os.path.exists")
+    def test_detect_docker_environment_with_dockerenv(
+        self, mock_exists: Mock, _mock_safe_log: Mock
+    ) -> None:
+        """Test detection of Docker environment via .dockerenv file."""
+        mock_exists.return_value = True
+        detector = EnvironmentDetector()
+
+        result = detector.detect_primary_environment_type()
+
+        assert result == "docker"
+        mock_exists.assert_called_with("/.dockerenv")
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch.dict(os.environ, {"DOCKER_CONTAINER": "true"})
+    def test_detect_docker_environment_with_env_var(self, _mock_safe_log: Mock) -> None:
+        """Test detection of Docker environment via environment variable."""
+        detector = EnvironmentDetector()
+
+        result = detector.detect_primary_environment_type()
+
+        assert result == "docker"
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch.dict(os.environ, {"GOOGLE_CLOUD_PROJECT": "test-project"})
+    def test_detect_gcp_environment(self, _mock_safe_log: Mock) -> None:
+        """Test detection of GCP environment."""
+        detector = EnvironmentDetector()
+
+        result = detector.detect_primary_environment_type()
+
+        assert result == "gcp"
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch.dict(os.environ, {"GCP_PROJECT": "test-project"})
+    def test_detect_gcp_environment_alternative_var(self, _mock_safe_log: Mock) -> None:
+        """Test detection of GCP environment with alternative variable."""
+        detector = EnvironmentDetector()
+
+        result = detector.detect_primary_environment_type()
+
+        assert result == "gcp"
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch.dict(os.environ, {"AZURE_RESOURCE_GROUP": "test-rg"})
+    def test_detect_azure_environment(self, _mock_safe_log: Mock) -> None:
+        """Test detection of Azure environment."""
+        detector = EnvironmentDetector()
+
+        result = detector.detect_primary_environment_type()
+
+        assert result == "azure"
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch.dict(os.environ, {"WEBSITE_RESOURCE_GROUP": "test-rg"})
+    def test_detect_azure_environment_alternative_var(
+        self, _mock_safe_log: Mock
+    ) -> None:
+        """Test detection of Azure environment with alternative variable."""
+        detector = EnvironmentDetector()
+
+        result = detector.detect_primary_environment_type()
+
+        assert result == "azure"
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch.dict(os.environ, {"AWS_REGION": "us-east-1"})
+    def test_detect_aws_ec2_environment(self, _mock_safe_log: Mock) -> None:
+        """Test detection of AWS EC2 environment."""
+        detector = EnvironmentDetector()
+
+        result = detector.detect_primary_environment_type()
+
+        assert result == "aws_ec2"
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    def test_detect_standard_environment(self, _mock_safe_log: Mock) -> None:
+        """Test detection of standard environment when no cloud indicators."""
+        detector = EnvironmentDetector()
+
+        result = detector.detect_primary_environment_type()
+
+        assert result == "standard"
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    def test_detect_environment_type_caching(self, _mock_safe_log: Mock) -> None:
+        """Test that environment type detection uses caching."""
+        detector = EnvironmentDetector()
+        detector._cache["environment_type"] = "cached_type"
+
+        result = detector.detect_primary_environment_type()
+
+        assert result == "cached_type"
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch.dict(os.environ, {"AWS_LAMBDA_FUNCTION_NAME": "test"})
+    def test_detect_environment_type_exception_handling(
+        self, _mock_safe_log: Mock
+    ) -> None:
+        """Test exception handling in environment type detection."""
+        detector = EnvironmentDetector()
+
+        with patch("os.getenv", side_effect=Exception("Test error")):
+            result = detector.detect_primary_environment_type()
+
+            assert result == "standard"
+            _mock_safe_log.assert_called_with(
+                detector.tracer_instance,
+                "debug",
+                "Error detecting environment type: Test error",
+            )
+
+
+class TestEnvironmentDetectorContainerEnvironment:
+    """Test container environment detection."""
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch("os.path.exists")
+    def test_detect_docker_container_with_dockerenv(
+        self, mock_exists: Mock, _mock_safe_log: Mock
+    ) -> None:
+        """Test Docker container detection via .dockerenv file."""
+        mock_exists.return_value = True
+        detector = EnvironmentDetector()
+
+        result = detector.detect_container_environment()
+
+        assert result["container.runtime"] == "docker"
+        mock_exists.assert_called_with("/.dockerenv")
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch.dict(os.environ, {"DOCKER_CONTAINER": "true", "HOSTNAME": "container-123"})
+    def test_detect_docker_container_with_hostname(self, _mock_safe_log: Mock) -> None:
+        """Test Docker container detection with hostname."""
+        detector = EnvironmentDetector()
+
+        result = detector.detect_container_environment()
+
+        assert result["container.runtime"] == "docker"
+        assert result["container.id"] == "container-123"
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch.dict(
+        os.environ,
+        {
+            "KUBERNETES_SERVICE_HOST": "10.0.0.1",
+            "K8S_CLUSTER_NAME": "test-cluster",
+            "K8S_NAMESPACE": "test-namespace",
+            "K8S_POD_NAME": "test-pod",
+            "K8S_DEPLOYMENT_NAME": "test-deployment",
+        },
+    )
+    def test_detect_kubernetes_container_full_info(self, _mock_safe_log: Mock) -> None:
+        """Test Kubernetes container detection with full information."""
+        detector = EnvironmentDetector()
+
+        result = detector.detect_container_environment()
+
+        assert result["k8s.cluster.name"] == "test-cluster"
+        assert result["k8s.namespace.name"] == "test-namespace"
+        assert result["k8s.pod.name"] == "test-pod"
+        assert result["k8s.deployment.name"] == "test-deployment"
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch.dict(
+        os.environ, {"KUBERNETES_SERVICE_HOST": "10.0.0.1", "HOSTNAME": "fallback-pod"}
+    )
+    def test_detect_kubernetes_container_with_defaults(
+        self, _mock_safe_log: Mock
+    ) -> None:
+        """Test Kubernetes container detection with default values."""
+        detector = EnvironmentDetector()
+
+        result = detector.detect_container_environment()
+
+        assert result["k8s.cluster.name"] == "unknown"
+        assert result["k8s.namespace.name"] == "default"
+        assert result["k8s.pod.name"] == "fallback-pod"
+        assert result["k8s.deployment.name"] == "unknown"
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    def test_detect_container_environment_empty(self, _mock_safe_log: Mock) -> None:
+        """Test container environment detection with no container indicators."""
+        detector = EnvironmentDetector()
+
+        result = detector.detect_container_environment()
+
+        assert not result
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    def test_detect_container_environment_caching(self, _mock_safe_log: Mock) -> None:
+        """Test that container environment detection uses caching."""
+        detector = EnvironmentDetector()
+        detector._cache["container_info"] = {"cached": "info"}
+
+        result = detector.detect_container_environment()
+
+        assert result == {"cached": "info"}
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch.dict(os.environ, {"KUBERNETES_SERVICE_HOST": "10.0.0.1"})
+    def test_detect_container_environment_exception_handling(
+        self, _mock_safe_log: Mock
+    ) -> None:
+        """Test exception handling in container environment detection."""
+        detector = EnvironmentDetector()
+
+        with patch("os.getenv", side_effect=Exception("Test error")):
+            result = detector.detect_container_environment()
+
+            assert not result
+            _mock_safe_log.assert_called_with(
+                detector.tracer_instance,
+                "debug",
+                "Error detecting container environment: Test error",
+            )
+
+
+class TestEnvironmentDetectorCloudEnvironment:
+    """Test cloud environment detection."""
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch.dict(
+        os.environ,
+        {
+            "AWS_REGION": "us-east-1",
+            "AWS_LAMBDA_FUNCTION_NAME": "test-function",
+            "AWS_LAMBDA_FUNCTION_VERSION": "1",
+            "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "512",
+            "AWS_LAMBDA_FUNCTION_TIMEOUT": "30",
+        },
+    )
+    @patch("platform.python_version")
+    def test_detect_aws_lambda_cloud_environment(
+        self, mock_python_version: Mock, _mock_safe_log: Mock
+    ) -> None:
+        """Test AWS Lambda cloud environment detection."""
+        mock_python_version.return_value = "3.11.0"
+        detector = EnvironmentDetector()
+
+        result = detector.detect_cloud_environment()
+
+        assert result["cloud.provider"] == "aws"
+        assert result["cloud.region"] == "us-east-1"
+        assert result["faas.name"] == "test-function"
+        assert result["faas.version"] == "1"
+        assert result["faas.runtime"] == "python3.11.0"
+        assert result["faas.memory_size"] == "512"
+        assert result["faas.timeout"] == "30"
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch.dict(os.environ, {"AWS_REGION": "us-west-2"})
+    def test_detect_aws_ec2_cloud_environment(self, _mock_safe_log: Mock) -> None:
+        """Test AWS EC2 cloud environment detection."""
+        detector = EnvironmentDetector()
+
+        result = detector.detect_cloud_environment()
+
+        assert result["cloud.provider"] == "aws"
+        assert result["cloud.region"] == "us-west-2"
+        assert "faas.name" not in result
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch.dict(
+        os.environ,
+        {"GOOGLE_CLOUD_PROJECT": "test-project", "GOOGLE_CLOUD_REGION": "us-central1"},
+    )
+    def test_detect_gcp_cloud_environment(self, _mock_safe_log: Mock) -> None:
+        """Test GCP cloud environment detection."""
+        detector = EnvironmentDetector()
+
+        result = detector.detect_cloud_environment()
+
+        assert result["cloud.provider"] == "gcp"
+        assert result["cloud.region"] == "us-central1"
+        assert result["gcp.project.id"] == "test-project"
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch.dict(os.environ, {"GCP_PROJECT": "alt-project"})
+    def test_detect_gcp_cloud_environment_alternative_var(
+        self, _mock_safe_log: Mock
+    ) -> None:
+        """Test GCP cloud environment detection with alternative variable."""
+        detector = EnvironmentDetector()
+
+        result = detector.detect_cloud_environment()
+
+        assert result["cloud.provider"] == "gcp"
+        assert result["cloud.region"] == "unknown"
+        assert result["gcp.project.id"] == "alt-project"
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch.dict(
+        os.environ, {"AZURE_RESOURCE_GROUP": "test-rg", "AZURE_REGION": "eastus"}
+    )
+    def test_detect_azure_cloud_environment(self, _mock_safe_log: Mock) -> None:
+        """Test Azure cloud environment detection."""
+        detector = EnvironmentDetector()
+
+        result = detector.detect_cloud_environment()
+
+        assert result["cloud.provider"] == "azure"
+        assert result["cloud.region"] == "eastus"
+        assert result["azure.resource_group"] == "test-rg"
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch.dict(os.environ, {"WEBSITE_RESOURCE_GROUP": "webapp-rg"})
+    def test_detect_azure_cloud_environment_alternative_var(
+        self, _mock_safe_log: Mock
+    ) -> None:
+        """Test Azure cloud environment detection with alternative variable."""
+        detector = EnvironmentDetector()
+
+        result = detector.detect_cloud_environment()
+
+        assert result["cloud.provider"] == "azure"
+        assert result["cloud.region"] == "unknown"
+        assert result["azure.resource_group"] == "webapp-rg"
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    def test_detect_cloud_environment_empty(self, _mock_safe_log: Mock) -> None:
+        """Test cloud environment detection with no cloud indicators."""
+        detector = EnvironmentDetector()
+
+        result = detector.detect_cloud_environment()
+
+        assert not result
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    def test_detect_cloud_environment_caching(self, _mock_safe_log: Mock) -> None:
+        """Test that cloud environment detection uses caching."""
+        detector = EnvironmentDetector()
+        detector._cache["cloud_info"] = {"cached": "cloud"}
+
+        result = detector.detect_cloud_environment()
+
+        assert result == {"cached": "cloud"}
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch.dict(os.environ, {"AWS_REGION": "us-east-1"})
+    def test_detect_cloud_environment_exception_handling(
+        self, _mock_safe_log: Mock
+    ) -> None:
+        """Test exception handling in cloud environment detection."""
+        detector = EnvironmentDetector()
+
+        with patch("os.getenv", side_effect=Exception("Test error")):
+            result = detector.detect_cloud_environment()
+
+            assert not result
+            _mock_safe_log.assert_called_with(
+                detector.tracer_instance,
+                "debug",
+                "Error detecting cloud environment: Test error",
+            )
+
+
+class TestEnvironmentDetectorResourceConstraints:
+    """Test resource constraints detection."""
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch.object(EnvironmentDetector, "_analyze_memory_constraints_dynamically")
+    @patch.object(EnvironmentDetector, "_analyze_cpu_constraints_dynamically")
+    @patch.object(EnvironmentDetector, "_analyze_network_constraints_dynamically")
+    def test_detect_resource_constraints_success(
+        self,
+        mock_network: Mock,
+        mock_cpu: Mock,
+        mock_memory: Mock,
+        _mock_safe_log: Mock,
+    ) -> None:
+        """Test successful resource constraints detection."""
+        mock_memory.return_value = {"memory_tier": "medium"}
+        mock_cpu.return_value = {"cpu_tier": "high"}
+        mock_network.return_value = {"network_tier": "standard"}
+
+        detector = EnvironmentDetector()
+        result = detector.detect_resource_constraints()
+
+        assert result["memory_tier"] == "medium"
+        assert result["cpu_tier"] == "high"
+        assert result["network_tier"] == "standard"
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    def test_detect_resource_constraints_caching(self, _mock_safe_log: Mock) -> None:
+        """Test that resource constraints detection uses caching."""
+        detector = EnvironmentDetector()
+        detector._cache["resource_constraints"] = {"cached": "constraints"}
+
+        result = detector.detect_resource_constraints()
+
+        assert result == {"cached": "constraints"}
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch.object(EnvironmentDetector, "_get_fallback_resource_constraints")
+    @patch.object(EnvironmentDetector, "_analyze_memory_constraints_dynamically")
+    def test_detect_resource_constraints_exception_handling(
+        self,
+        mock_memory: Mock,
+        mock_fallback: Mock,
+        _mock_safe_log: Mock,
+    ) -> None:
+        """Test exception handling in resource constraints detection."""
+        mock_memory.side_effect = Exception("Test error")
+        mock_fallback.return_value = {"fallback": "constraints"}
+
+        detector = EnvironmentDetector()
+        result = detector.detect_resource_constraints()
+
+        assert result == {"fallback": "constraints"}
+        _mock_safe_log.assert_called_with(
+            detector.tracer_instance,
+            "debug",
+            "Error detecting resource constraints: Test error",
+        )
+
+
+class TestEnvironmentDetectorMemoryConstraints:
+    """Test memory constraints analysis."""
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch.dict(os.environ, {"AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "1024"})
+    def test_analyze_memory_constraints_lambda(self, _mock_safe_log: Mock) -> None:
+        """Test memory constraints analysis for Lambda environment."""
+        detector = EnvironmentDetector()
+
+        result = detector._analyze_memory_constraints_dynamically()
+
+        assert result["memory_mb"] == 1024
+        assert result["memory_tier"] == "medium"
+        assert result["memory_source"] == "lambda_config"
+        assert result["memory_constraint_factor"] == 1.0
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch.object(EnvironmentDetector, "_detect_container_memory_limit")
+    def test_analyze_memory_constraints_container(
+        self, mock_container_memory: Mock, _mock_safe_log: Mock
+    ) -> None:
+        """Test memory constraints analysis for container environment."""
+        mock_container_memory.return_value = 2048
+        detector = EnvironmentDetector()
+
+        result = detector._analyze_memory_constraints_dynamically()
+
+        assert result["memory_mb"] == 2048
+        assert result["memory_tier"] == "high"
+        assert result["memory_source"] == "container_cgroup"
+        assert result["memory_constraint_factor"] == 1.3
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch.object(EnvironmentDetector, "_detect_container_memory_limit")
+    @patch.object(EnvironmentDetector, "detect_primary_environment_type")
+    @patch.object(EnvironmentDetector, "_estimate_memory_by_environment")
+    def test_analyze_memory_constraints_estimated(
+        self,
+        mock_estimate: Mock,
+        mock_env_type: Mock,
+        mock_container_memory: Mock,
+        _mock_safe_log: Mock,
+    ) -> None:
+        """Test memory constraints analysis with estimation."""
+        mock_container_memory.return_value = None
+        mock_env_type.return_value = "docker"
+        mock_estimate.return_value = 1024
+        detector = EnvironmentDetector()
+
+        result = detector._analyze_memory_constraints_dynamically()
+
+        assert result["memory_tier"] == "medium"
+        assert result["memory_source"] == "environment_estimated"
+        assert result["memory_constraint_factor"] == 1.0
+
+
+class TestEnvironmentDetectorCpuConstraints:
+    """Test CPU constraints analysis."""
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch("multiprocessing.cpu_count")
+    def test_analyze_cpu_constraints_success(
+        self, mock_cpu_count: Mock, _mock_safe_log: Mock
+    ) -> None:
+        """Test successful CPU constraints analysis."""
+        mock_cpu_count.return_value = 4
+        detector = EnvironmentDetector()
+
+        result = detector._analyze_cpu_constraints_dynamically()
+
+        assert result["cpu_count"] == 4
+        assert result["cpu_tier"] == "medium"
+        assert result["cpu_source"] == "detected"
+        assert result["cpu_scaling_factor"] == 1.0
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch("multiprocessing.cpu_count")
+    @patch.object(EnvironmentDetector, "detect_primary_environment_type")
+    @patch.object(EnvironmentDetector, "_estimate_cpu_by_environment")
+    def test_analyze_cpu_constraints_fallback(
+        self,
+        mock_estimate: Mock,
+        mock_env_type: Mock,
+        mock_cpu_count: Mock,
+        _mock_safe_log: Mock,
+    ) -> None:
+        """Test CPU constraints analysis with fallback."""
+        mock_cpu_count.side_effect = Exception("CPU detection failed")
+        mock_env_type.return_value = "aws_lambda"
+        mock_estimate.return_value = 1
+        detector = EnvironmentDetector()
+
+        result = detector._analyze_cpu_constraints_dynamically()
+
+        assert result["cpu_count"] == 1
+        assert result["cpu_tier"] == "minimal"
+        assert result["cpu_source"] == "environment_fallback"
+        assert result["cpu_scaling_factor"] == 0.5
+
+
+class TestEnvironmentDetectorNetworkConstraints:
+    """Test network constraints analysis."""
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch.object(EnvironmentDetector, "detect_primary_environment_type")
+    @patch.object(EnvironmentDetector, "detect_cloud_environment")
+    @patch.object(EnvironmentDetector, "detect_container_environment")
+    def test_analyze_network_constraints_serverless(
+        self,
+        mock_container: Mock,
+        mock_cloud: Mock,
+        mock_env_type: Mock,
+        _mock_safe_log: Mock,
+    ) -> None:
+        """Test network constraints analysis for serverless environment."""
+        mock_env_type.return_value = "aws_lambda"
+        mock_cloud.return_value = {"faas.name": "test-function"}
+        mock_container.return_value = {}
+        detector = EnvironmentDetector()
+
+        result = detector._analyze_network_constraints_dynamically()
+
+        assert result["network_tier"] == "serverless_constrained"
+        assert result["network_scaling_factor"] == 0.3
+        assert result["connection_limit_factor"] == 0.2
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch.object(EnvironmentDetector, "detect_primary_environment_type")
+    @patch.object(EnvironmentDetector, "detect_cloud_environment")
+    @patch.object(EnvironmentDetector, "detect_container_environment")
+    def test_analyze_network_constraints_kubernetes(
+        self,
+        mock_container: Mock,
+        mock_cloud: Mock,
+        mock_env_type: Mock,
+        _mock_safe_log: Mock,
+    ) -> None:
+        """Test network constraints analysis for Kubernetes environment."""
+        mock_env_type.return_value = "kubernetes"
+        mock_cloud.return_value = {}
+        mock_container.return_value = {"k8s.cluster.name": "test-cluster"}
+        detector = EnvironmentDetector()
+
+        result = detector._analyze_network_constraints_dynamically()
+
+        assert result["network_tier"] == "orchestrated_managed"
+        assert result["network_scaling_factor"] == 0.8
+        assert result["connection_limit_factor"] == 0.8
+
+
+class TestEnvironmentDetectorCalculationMethods:
+    """Test calculation methods for tiers and factors."""
+
+    def test_calculate_memory_tier_dynamically(self) -> None:
+        """Test memory tier calculation with various memory sizes."""
+        detector = EnvironmentDetector()
+
+        assert detector._calculate_memory_tier_dynamically(128) == "minimal"
+        assert detector._calculate_memory_tier_dynamically(512) == "low"
+        assert detector._calculate_memory_tier_dynamically(1024) == "medium"
+        assert detector._calculate_memory_tier_dynamically(2048) == "high"
+        assert detector._calculate_memory_tier_dynamically(4096) == "high"
+
+    def test_calculate_cpu_tier_dynamically(self) -> None:
+        """Test CPU tier calculation with various CPU counts."""
+        detector = EnvironmentDetector()
+
+        assert detector._calculate_cpu_tier_dynamically(1) == "minimal"
+        assert detector._calculate_cpu_tier_dynamically(2) == "low"
+        assert detector._calculate_cpu_tier_dynamically(4) == "medium"
+        assert detector._calculate_cpu_tier_dynamically(8) == "high"
+        assert detector._calculate_cpu_tier_dynamically(16) == "very_high"
+
+    def test_calculate_network_tier_dynamically(self) -> None:
+        """Test network tier calculation with various environments."""
+        detector = EnvironmentDetector()
+
+        # Serverless environment
+        result = detector._calculate_network_tier_dynamically(
+            "aws_lambda", {"faas.name": "test"}, {}
+        )
+        assert result == "serverless_constrained"
+
+        # Kubernetes environment
+        result = detector._calculate_network_tier_dynamically(
+            "kubernetes", {}, {"k8s.cluster.name": "test"}
+        )
+        assert result == "orchestrated_managed"
+
+        # Container environment
+        result = detector._calculate_network_tier_dynamically(
+            "docker", {}, {"container.runtime": "docker"}
+        )
+        assert result == "containerized_isolated"
+
+        # Cloud environment
+        result = detector._calculate_network_tier_dynamically(
+            "aws_ec2", {"cloud.provider": "aws"}, {}
+        )
+        assert result == "cloud_aws_optimized"
+
+        # Standard environment
+        result = detector._calculate_network_tier_dynamically("standard", {}, {})
+        assert result == "standard_networking"
+
+    def test_calculate_memory_constraint_factor(self) -> None:
+        """Test memory constraint factor calculation."""
+        detector = EnvironmentDetector()
+
+        assert detector._calculate_memory_constraint_factor(128) == 0.3
+        assert detector._calculate_memory_constraint_factor(256) == 0.5
+        assert detector._calculate_memory_constraint_factor(512) == 0.7
+        assert detector._calculate_memory_constraint_factor(1024) == 1.0
+        assert detector._calculate_memory_constraint_factor(2048) == 1.3
+
+    def test_calculate_cpu_scaling_factor(self) -> None:
+        """Test CPU scaling factor calculation."""
+        detector = EnvironmentDetector()
+
+        assert detector._calculate_cpu_scaling_factor(1) == 0.5
+        assert detector._calculate_cpu_scaling_factor(2) == 0.5
+        assert detector._calculate_cpu_scaling_factor(4) == 1.0
+        assert detector._calculate_cpu_scaling_factor(8) == 2.0
+        assert detector._calculate_cpu_scaling_factor(16) == 2.0
+
+    def test_calculate_network_scaling_factor(self) -> None:
+        """Test network scaling factor calculation."""
+        detector = EnvironmentDetector()
+
+        assert (
+            detector._calculate_network_scaling_factor("serverless_constrained") == 0.3
+        )
+        assert (
+            detector._calculate_network_scaling_factor("containerized_isolated") == 0.6
+        )
+        assert detector._calculate_network_scaling_factor("orchestrated_managed") == 0.8
+        assert detector._calculate_network_scaling_factor("cloud_aws_optimized") == 1.2
+        assert detector._calculate_network_scaling_factor("cloud_gcp_optimized") == 1.1
+        assert (
+            detector._calculate_network_scaling_factor("cloud_azure_optimized") == 1.0
+        )
+        assert detector._calculate_network_scaling_factor("standard_networking") == 1.0
+        assert detector._calculate_network_scaling_factor("unknown_tier") == 1.0
+
+    def test_calculate_connection_limit_factor(self) -> None:
+        """Test connection limit factor calculation."""
+        detector = EnvironmentDetector()
+
+        assert detector._calculate_connection_limit_factor("aws_lambda") == 0.2
+        assert detector._calculate_connection_limit_factor("docker") == 0.6
+        assert detector._calculate_connection_limit_factor("kubernetes") == 0.8
+        assert detector._calculate_connection_limit_factor("gcp") == 1.0
+        assert detector._calculate_connection_limit_factor("azure") == 1.0
+        assert detector._calculate_connection_limit_factor("aws_ec2") == 1.2
+        assert detector._calculate_connection_limit_factor("unknown") == 1.0
+
+
+class TestEnvironmentDetectorContainerMemoryLimit:
+    """Test container memory limit detection."""
+
+    @patch("os.path.exists")
+    @patch("builtins.open")
+    def test_detect_container_memory_limit_success(
+        self, mock_open: Mock, mock_exists: Mock
+    ) -> None:
+        """Test successful container memory limit detection."""
+        mock_exists.return_value = True
+        mock_open.return_value.__enter__.return_value.read.return_value = "1073741824"
+        detector = EnvironmentDetector()
+
+        result = detector._detect_container_memory_limit()
+
+        assert result == 1024  # 1073741824 bytes = 1024 MB
+
+    @patch("os.path.exists")
+    def test_detect_container_memory_limit_no_file(self, mock_exists: Mock) -> None:
+        """Test container memory limit detection when no cgroup files exist."""
+        mock_exists.return_value = False
+        detector = EnvironmentDetector()
+
+        result = detector._detect_container_memory_limit()
+
+        assert result is None
+
+    @patch("os.path.exists")
+    @patch("builtins.open")
+    def test_detect_container_memory_limit_max_value(
+        self, mock_open: Mock, mock_exists: Mock
+    ) -> None:
+        """Test container memory limit detection with max cgroup value."""
+        mock_exists.return_value = True
+        mock_open.return_value.__enter__.return_value.read.return_value = str(1 << 62)
+        detector = EnvironmentDetector()
+
+        result = detector._detect_container_memory_limit()
+
+        assert result is None
+
+    @patch("os.path.exists")
+    @patch("builtins.open")
+    def test_detect_container_memory_limit_exception(
+        self, mock_open: Mock, mock_exists: Mock
+    ) -> None:
+        """Test container memory limit detection with exception."""
+        mock_exists.return_value = True
+        mock_open.side_effect = Exception("File read error")
+        detector = EnvironmentDetector()
+
+        result = detector._detect_container_memory_limit()
+
+        assert result is None
+
+
+class TestEnvironmentDetectorEstimationMethods:
+    """Test environment-based estimation methods."""
+
+    def test_estimate_memory_by_environment(self) -> None:
+        """Test memory estimation by environment type."""
+        detector = EnvironmentDetector()
+
+        assert detector._estimate_memory_by_environment("aws_lambda") == 512
+        assert detector._estimate_memory_by_environment("docker") == 1024
+        assert detector._estimate_memory_by_environment("kubernetes") == 2048
+        assert detector._estimate_memory_by_environment("gcp") == 1024
+        assert detector._estimate_memory_by_environment("azure") == 1024
+        assert detector._estimate_memory_by_environment("aws_ec2") == 2048
+        assert detector._estimate_memory_by_environment("unknown") == 1024
+
+    def test_estimate_cpu_by_environment(self) -> None:
+        """Test CPU estimation by environment type."""
+        detector = EnvironmentDetector()
+
+        assert detector._estimate_cpu_by_environment("aws_lambda") == 1
+        assert detector._estimate_cpu_by_environment("docker") == 2
+        assert detector._estimate_cpu_by_environment("kubernetes") == 2
+        assert detector._estimate_cpu_by_environment("gcp") == 2
+        assert detector._estimate_cpu_by_environment("azure") == 2
+        assert detector._estimate_cpu_by_environment("aws_ec2") == 4
+        assert detector._estimate_cpu_by_environment("unknown") == 2
+
+
+class TestEnvironmentDetectorFallbackMethods:
+    """Test fallback methods for error scenarios."""
+
+    @patch.object(EnvironmentDetector, "detect_primary_environment_type")
+    def test_get_fallback_resource_constraints(self, mock_env_type: Mock) -> None:
+        """Test fallback resource constraints generation."""
+        mock_env_type.return_value = "docker"
+        detector = EnvironmentDetector()
+
+        result = detector._get_fallback_resource_constraints()
+
+        assert result["memory_tier"] == "medium"
+        assert result["cpu_tier"] == "medium"
+        assert result["network_tier"] == "docker_fallback"
+        assert result["memory_constraint_factor"] == 0.7
+        assert result["cpu_scaling_factor"] == 1.0
+        assert result["network_scaling_factor"] == 1.0
+        assert result["connection_limit_factor"] == 1.0
+        assert result["fallback_reason"] == "constraint_detection_failed"
+
+
+class TestEnvironmentDetectorPerformanceCharacteristics:
+    """Test performance characteristics detection."""
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch.object(EnvironmentDetector, "_analyze_execution_model_dynamically")
+    @patch.object(EnvironmentDetector, "_analyze_concurrency_patterns_dynamically")
+    @patch.object(EnvironmentDetector, "_analyze_latency_sensitivity_dynamically")
+    @patch.object(EnvironmentDetector, "_analyze_scaling_characteristics_dynamically")
+    def test_detect_performance_characteristics_success(
+        self,
+        mock_scaling: Mock,
+        mock_latency: Mock,
+        mock_concurrency: Mock,
+        mock_execution: Mock,
+        _mock_safe_log: Mock,
+    ) -> None:
+        """Test successful performance characteristics detection."""
+        mock_execution.return_value = {"execution_model": "serverless"}
+        mock_concurrency.return_value = {"concurrency_pattern": "burst"}
+        mock_latency.return_value = {"latency_sensitivity": "high"}
+        mock_scaling.return_value = {"scaling_pattern": "aggressive"}
+
+        detector = EnvironmentDetector()
+        result = detector.detect_performance_characteristics()
+
+        assert result["execution_model"] == "serverless"
+        assert result["concurrency_pattern"] == "burst"
+        assert result["latency_sensitivity"] == "high"
+        assert result["scaling_pattern"] == "aggressive"
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    def test_detect_performance_characteristics_caching(
+        self, _mock_safe_log: Mock
+    ) -> None:
+        """Test that performance characteristics detection uses caching."""
+        detector = EnvironmentDetector()
+        detector._cache["performance_characteristics"] = {"cached": "performance"}
+
+        result = detector.detect_performance_characteristics()
+
+        assert result == {"cached": "performance"}
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch.object(EnvironmentDetector, "_get_fallback_performance_characteristics")
+    @patch.object(EnvironmentDetector, "_analyze_execution_model_dynamically")
+    def test_detect_performance_characteristics_exception_handling(
+        self,
+        mock_execution: Mock,
+        mock_fallback: Mock,
+        _mock_safe_log: Mock,
+    ) -> None:
+        """Test exception handling in performance characteristics detection."""
+        mock_execution.side_effect = Exception("Test error")
+        mock_fallback.return_value = {"fallback": "performance"}
+
+        detector = EnvironmentDetector()
+        result = detector.detect_performance_characteristics()
+
+        assert result == {"fallback": "performance"}
+        _mock_safe_log.assert_called_with(
+            detector.tracer_instance,
+            "debug",
+            "Error detecting performance characteristics: Test error",
+        )
+
+
+class TestEnvironmentDetectorExecutionModel:
+    """Test execution model analysis."""
+
+    @patch.object(EnvironmentDetector, "detect_primary_environment_type")
+    @patch.object(EnvironmentDetector, "detect_cloud_environment")
+    @patch.object(EnvironmentDetector, "detect_container_environment")
+    def test_analyze_execution_model_serverless(
+        self, mock_container: Mock, mock_cloud: Mock, mock_env_type: Mock
+    ) -> None:
+        """Test execution model analysis for serverless environment."""
+        mock_env_type.return_value = "aws_lambda"
+        mock_cloud.return_value = {"faas.name": "test-function"}
+        mock_container.return_value = {}
+        detector = EnvironmentDetector()
+
+        result = detector._analyze_execution_model_dynamically()
+
+        assert result["execution_model"] == "serverless"
+        assert result["cold_start_sensitive"] is True
+        assert result["connection_reuse_critical"] is True
+        assert result["execution_time_limited"] is True
+        assert result["memory_optimization_critical"] is True
+
+    @patch.object(EnvironmentDetector, "detect_primary_environment_type")
+    @patch.object(EnvironmentDetector, "detect_cloud_environment")
+    @patch.object(EnvironmentDetector, "detect_container_environment")
+    def test_analyze_execution_model_orchestrated(
+        self, mock_container: Mock, mock_cloud: Mock, mock_env_type: Mock
+    ) -> None:
+        """Test execution model analysis for orchestrated environment."""
+        mock_env_type.return_value = "kubernetes"
+        mock_cloud.return_value = {}
+        mock_container.return_value = {"k8s.cluster.name": "test-cluster"}
+        detector = EnvironmentDetector()
+
+        result = detector._analyze_execution_model_dynamically()
+
+        assert result["execution_model"] == "orchestrated"
+        assert result["scaling_dynamic"] is True
+        assert result["connection_persistence"] == "managed"
+        assert result["resource_allocation_dynamic"] is True
+        assert result["graceful_shutdown_required"] is True
+
+    @patch.object(EnvironmentDetector, "detect_primary_environment_type")
+    @patch.object(EnvironmentDetector, "detect_cloud_environment")
+    @patch.object(EnvironmentDetector, "detect_container_environment")
+    def test_analyze_execution_model_containerized(
+        self, mock_container: Mock, mock_cloud: Mock, mock_env_type: Mock
+    ) -> None:
+        """Test execution model analysis for containerized environment."""
+        mock_env_type.return_value = "docker"
+        mock_cloud.return_value = {}
+        mock_container.return_value = {"container.runtime": "docker"}
+        detector = EnvironmentDetector()
+
+        result = detector._analyze_execution_model_dynamically()
+
+        assert result["execution_model"] == "containerized"
+        assert result["resource_constrained"] is True
+        assert result["connection_persistence"] == "isolated"
+        assert result["resource_allocation_fixed"] is True
+        assert result["isolation_boundaries"] is True
+
+    @patch.object(EnvironmentDetector, "detect_primary_environment_type")
+    @patch.object(EnvironmentDetector, "detect_cloud_environment")
+    @patch.object(EnvironmentDetector, "detect_container_environment")
+    def test_analyze_execution_model_persistent(
+        self, mock_container: Mock, mock_cloud: Mock, mock_env_type: Mock
+    ) -> None:
+        """Test execution model analysis for persistent environment."""
+        mock_env_type.return_value = "standard"
+        mock_cloud.return_value = {}
+        mock_container.return_value = {}
+        detector = EnvironmentDetector()
+
+        result = detector._analyze_execution_model_dynamically()
+
+        assert result["execution_model"] == "persistent"
+        assert result["connection_persistence"] == "long_lived"
+        assert result["resource_allocation_stable"] is True
+        assert result["scaling_manual"] is True
+        assert result["full_system_access"] is True
+
+
+class TestEnvironmentDetectorConcurrencyPatterns:
+    """Test concurrency patterns analysis."""
+
+    @patch.dict(os.environ, {"HH_HIGH_CONCURRENCY": "true"})
+    def test_analyze_concurrency_patterns_high_explicit(self) -> None:
+        """Test concurrency patterns analysis with explicit high concurrency."""
+        detector = EnvironmentDetector()
+
+        result = detector._analyze_concurrency_patterns_dynamically()
+
+        assert result["concurrency_pattern"] == "high_explicit"
+        assert result["concurrency_multiplier"] == 2.0
+        assert result["connection_pool_scaling"] == "aggressive"
+
+    @patch.object(EnvironmentDetector, "detect_primary_environment_type")
+    def test_analyze_concurrency_patterns_lambda(self, mock_env_type: Mock) -> None:
+        """Test concurrency patterns analysis for Lambda environment."""
+        mock_env_type.return_value = "aws_lambda"
+        detector = EnvironmentDetector()
+
+        result = detector._analyze_concurrency_patterns_dynamically()
+
+        assert result["concurrency_pattern"] == "burst_serverless"
+        assert result["concurrency_multiplier"] == 0.5
+        assert result["connection_pool_scaling"] == "minimal"
+
+    @patch.object(EnvironmentDetector, "detect_container_environment")
+    def test_analyze_concurrency_patterns_kubernetes(
+        self, mock_container: Mock
+    ) -> None:
+        """Test concurrency patterns analysis for Kubernetes environment."""
+        mock_container.return_value = {"k8s.cluster.name": "test-cluster"}
+        detector = EnvironmentDetector()
+
+        result = detector._analyze_concurrency_patterns_dynamically()
+
+        assert result["concurrency_pattern"] == "orchestrated_scaling"
+        assert result["concurrency_multiplier"] == 1.2
+        assert result["connection_pool_scaling"] == "managed"
+
+    def test_analyze_concurrency_patterns_standard(self) -> None:
+        """Test concurrency patterns analysis for standard environment."""
+        detector = EnvironmentDetector()
+
+        with patch.object(
+            detector, "detect_primary_environment_type", return_value="standard"
+        ):
+            with patch.object(
+                detector, "detect_container_environment", return_value={}
+            ):
+                result = detector._analyze_concurrency_patterns_dynamically()
+
+        assert result["concurrency_pattern"] == "standard_persistent"
+        assert result["concurrency_multiplier"] == 1.0
+        assert result["connection_pool_scaling"] == "balanced"
+
+
+class TestEnvironmentDetectorLatencySensitivity:
+    """Test latency sensitivity analysis."""
+
+    @patch.dict(os.environ, {"HH_SESSION_NAME": "benchmark-test"})
+    def test_analyze_latency_sensitivity_performance_testing(self) -> None:
+        """Test latency sensitivity analysis for performance testing."""
+        detector = EnvironmentDetector()
+
+        result = detector._analyze_latency_sensitivity_dynamically()
+
+        assert result["latency_sensitivity"] == "critical_performance_testing"
+        assert result["timeout_multiplier"] == 0.4
+        assert result["retry_multiplier"] == 0.5
+
+    @patch.object(EnvironmentDetector, "detect_primary_environment_type")
+    def test_analyze_latency_sensitivity_lambda(self, mock_env_type: Mock) -> None:
+        """Test latency sensitivity analysis for Lambda environment."""
+        mock_env_type.return_value = "aws_lambda"
+        detector = EnvironmentDetector()
+
+        result = detector._analyze_latency_sensitivity_dynamically()
+
+        assert result["latency_sensitivity"] == "high_serverless_constraints"
+        assert result["timeout_multiplier"] == 0.6
+        assert result["retry_multiplier"] == 0.7
+
+    @patch.dict(os.environ, {"PROD": "true"})
+    def test_analyze_latency_sensitivity_production(self) -> None:
+        """Test latency sensitivity analysis for production environment."""
+        detector = EnvironmentDetector()
+
+        result = detector._analyze_latency_sensitivity_dynamically()
+
+        assert result["latency_sensitivity"] == "high_production"
+        assert result["timeout_multiplier"] == 0.8
+        assert result["retry_multiplier"] == 1.2
+
+    @patch.dict(os.environ, {"DEV": "true"})
+    def test_analyze_latency_sensitivity_development(self) -> None:
+        """Test latency sensitivity analysis for development environment."""
+        detector = EnvironmentDetector()
+
+        result = detector._analyze_latency_sensitivity_dynamically()
+
+        assert result["latency_sensitivity"] == "low_development"
+        assert result["timeout_multiplier"] == 1.5
+        assert result["retry_multiplier"] == 1.0
+
+    def test_analyze_latency_sensitivity_standard(self) -> None:
+        """Test latency sensitivity analysis for standard environment."""
+        detector = EnvironmentDetector()
+
+        result = detector._analyze_latency_sensitivity_dynamically()
+
+        assert result["latency_sensitivity"] == "standard_balanced"
+        assert result["timeout_multiplier"] == 1.0
+        assert result["retry_multiplier"] == 1.0
+
+
+class TestEnvironmentDetectorScalingCharacteristics:
+    """Test scaling characteristics analysis."""
+
+    @patch.object(EnvironmentDetector, "detect_primary_environment_type")
+    @patch.object(EnvironmentDetector, "detect_resource_constraints")
+    def test_analyze_scaling_characteristics_constrained(
+        self, mock_constraints: Mock, mock_env_type: Mock
+    ) -> None:
+        """Test scaling characteristics analysis for constrained environment."""
+        mock_env_type.return_value = "aws_lambda"
+        mock_constraints.return_value = {
+            "memory_constraint_factor": 0.3,
+            "cpu_scaling_factor": 0.5,
+            "network_scaling_factor": 0.3,
+        }
+        detector = EnvironmentDetector()
+
+        result = detector._analyze_scaling_characteristics_dynamically()
+
+        assert result["scaling_pattern"] == "constrained_minimal"
+        assert result["overall_scaling_factor"] < 0.5
+
+    @patch.object(EnvironmentDetector, "detect_primary_environment_type")
+    @patch.object(EnvironmentDetector, "detect_resource_constraints")
+    def test_analyze_scaling_characteristics_aggressive(
+        self, mock_constraints: Mock, mock_env_type: Mock
+    ) -> None:
+        """Test scaling characteristics analysis for high-resource environment."""
+        mock_env_type.return_value = "aws_ec2"
+        mock_constraints.return_value = {
+            "memory_constraint_factor": 1.3,
+            "cpu_scaling_factor": 2.0,
+            "network_scaling_factor": 1.2,
+        }
+        detector = EnvironmentDetector()
+
+        result = detector._analyze_scaling_characteristics_dynamically()
+
+        assert result["scaling_pattern"] == "aggressive_scaling"
+        assert result["overall_scaling_factor"] > 1.3
+
+    @patch.object(EnvironmentDetector, "detect_primary_environment_type")
+    @patch.object(EnvironmentDetector, "detect_resource_constraints")
+    def test_analyze_scaling_characteristics_balanced(
+        self, mock_constraints: Mock, mock_env_type: Mock
+    ) -> None:
+        """Test scaling characteristics analysis for balanced environment."""
+        mock_env_type.return_value = "docker"
+        mock_constraints.return_value = {
+            "memory_constraint_factor": 1.0,
+            "cpu_scaling_factor": 1.0,
+            "network_scaling_factor": 1.0,
+        }
+        detector = EnvironmentDetector()
+
+        result = detector._analyze_scaling_characteristics_dynamically()
+
+        assert result["scaling_pattern"] == "balanced_scaling"
+        assert 0.8 <= result["overall_scaling_factor"] <= 1.3
+
+
+class TestEnvironmentDetectorFallbackPerformance:
+    """Test fallback performance characteristics."""
+
+    @patch.object(EnvironmentDetector, "detect_primary_environment_type")
+    def test_get_fallback_performance_characteristics(
+        self, mock_env_type: Mock
+    ) -> None:
+        """Test fallback performance characteristics generation."""
+        mock_env_type.return_value = "kubernetes"
+        detector = EnvironmentDetector()
+
+        result = detector._get_fallback_performance_characteristics()
+
+        assert result["execution_model"] == "persistent"
+        assert result["latency_sensitivity"] == "standard_fallback"
+        assert result["concurrency_pattern"] == "kubernetes_fallback"
+        assert result["scaling_pattern"] == "conservative_fallback"
+        assert result["timeout_multiplier"] == 1.0
+        assert result["retry_multiplier"] == 1.0
+        assert result["concurrency_multiplier"] == 1.0
+        assert result["overall_scaling_factor"] == 1.0
+        assert result["fallback_reason"] == "performance_detection_failed"
+
+
+class TestEnvironmentDetectorSystemInfo:
+    """Test system information detection."""
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch("platform.system")
+    @patch("platform.platform")
+    @patch("platform.python_version")
+    @patch("os.getpid")
+    @patch("platform.machine")
+    @patch.dict(os.environ, {"HOSTNAME": "test-host"})
+    def test_detect_system_info_complete(  # pylint: disable=R0917 # too-many-positional-arguments
+        self,
+        mock_machine: Mock,
+        mock_getpid: Mock,
+        mock_python_version: Mock,
+        mock_platform: Mock,
+        mock_system: Mock,
+        _mock_safe_log: Mock,
+    ) -> None:
+        """Test complete system information detection."""
+        mock_system.return_value = "Linux"
+        mock_platform.return_value = "Linux-5.4.0-x86_64"
+        mock_python_version.return_value = "3.11.0"
+        mock_getpid.return_value = 12345
+        mock_machine.return_value = "x86_64"
+
+        detector = EnvironmentDetector()
+        result = detector.detect_system_info()
+
+        assert result["os.type"] == "Linux"
+        assert result["os.description"] == "Linux-5.4.0-x86_64"
+        assert result["process.runtime.name"] == "python"
+        assert result["process.runtime.version"] == "3.11.0"
+        assert result["process.pid"] == 12345
+        assert result["host.arch"] == "x86_64"
+        assert result["host.name"] == "test-host"
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch("platform.system")
+    @patch("platform.platform")
+    @patch("platform.python_version")
+    @patch("os.getpid")
+    @patch("platform.machine")
+    def test_detect_system_info_without_hostname(  # pylint: disable=R0917 # too-many-positional-arguments
+        self,
+        mock_machine: Mock,
+        mock_getpid: Mock,
+        mock_python_version: Mock,
+        mock_platform: Mock,
+        mock_system: Mock,
+        _mock_safe_log: Mock,
+    ) -> None:
+        """Test system information detection without hostname."""
+        mock_system.return_value = "Darwin"
+        mock_platform.return_value = "Darwin-21.6.0-x86_64"
+        mock_python_version.return_value = "3.11.0"
+        mock_getpid.return_value = 54321
+        mock_machine.return_value = "x86_64"
+
+        detector = EnvironmentDetector()
+        result = detector.detect_system_info()
+
+        assert result["os.type"] == "Darwin"
+        assert result["os.description"] == "Darwin-21.6.0-x86_64"
+        assert result["process.runtime.name"] == "python"
+        assert result["process.runtime.version"] == "3.11.0"
+        assert result["process.pid"] == 54321
+        assert result["host.arch"] == "x86_64"
+        assert "host.name" not in result
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    def test_detect_system_info_caching(self, _mock_safe_log: Mock) -> None:
+        """Test that system info detection uses caching."""
+        detector = EnvironmentDetector()
+        detector._cache["system_info"] = {"cached": "system"}
+
+        result = detector.detect_system_info()
+
+        assert result == {"cached": "system"}
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch("platform.system")
+    def test_detect_system_info_exception_handling(
+        self, mock_system: Mock, _mock_safe_log: Mock
+    ) -> None:
+        """Test exception handling in system info detection."""
+        mock_system.side_effect = Exception("System error")
+        detector = EnvironmentDetector()
+
+        result = detector.detect_system_info()
+
+        assert not result
+        _mock_safe_log.assert_called_with(
+            detector.tracer_instance,
+            "debug",
+            "Error detecting system info: System error",
+        )
+
+
+class TestEnvironmentDetectorComprehensiveAnalysis:
+    """Test comprehensive environment analysis."""
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    @patch.object(EnvironmentDetector, "detect_primary_environment_type")
+    @patch.object(EnvironmentDetector, "detect_container_environment")
+    @patch.object(EnvironmentDetector, "detect_cloud_environment")
+    @patch.object(EnvironmentDetector, "detect_resource_constraints")
+    @patch.object(EnvironmentDetector, "detect_performance_characteristics")
+    @patch.object(EnvironmentDetector, "detect_system_info")
+    def test_get_comprehensive_analysis_success(  # pylint: disable=R0917 # too-many-positional-arguments
+        self,
+        mock_system: Mock,
+        mock_performance: Mock,
+        mock_constraints: Mock,
+        mock_cloud: Mock,
+        mock_container: Mock,
+        mock_env_type: Mock,
+        _mock_safe_log: Mock,
+    ) -> None:
+        """Test successful comprehensive environment analysis."""
+        mock_env_type.return_value = "aws_lambda"
+        mock_container.return_value = {"container.runtime": "docker"}
+        mock_cloud.return_value = {"cloud.provider": "aws"}
+        mock_constraints.return_value = {"memory_tier": "medium"}
+        mock_performance.return_value = {"execution_model": "serverless"}
+        mock_system.return_value = {"os.type": "Linux"}
+
+        detector = EnvironmentDetector()
+        result = detector.get_comprehensive_analysis()
+
+        assert result["environment_type"] == "aws_lambda"
+        assert result["container_info"]["container.runtime"] == "docker"
+        assert result["cloud_info"]["cloud.provider"] == "aws"
+        assert result["resource_constraints"]["memory_tier"] == "medium"
+        assert result["performance_characteristics"]["execution_model"] == "serverless"
+        assert result["system_info"]["os.type"] == "Linux"
+
+        _mock_safe_log.assert_called_with(
+            detector.tracer_instance,
+            "debug",
+            "Environment analysis complete: aws_lambda",
+            honeyhive_data={
+                "environment_type": "aws_lambda",
+                "has_container_info": True,
+                "has_cloud_info": True,
+                "resource_constraints": {"memory_tier": "medium"},
+            },
+        )
+
+    @patch("honeyhive.tracer.infra.environment.safe_log")
+    def test_get_comprehensive_analysis_caching(self, _mock_safe_log: Mock) -> None:
+        """Test that comprehensive analysis uses caching."""
+        detector = EnvironmentDetector()
+        detector._cache["comprehensive_analysis"] = {"cached": "analysis"}
+
+        result = detector.get_comprehensive_analysis()
+
+        assert result == {"cached": "analysis"}
+
+
+class TestEnvironmentDetectorCacheManagement:
+    """Test cache management functionality."""
+
+    def test_clear_cache(self) -> None:
+        """Test cache clearing functionality."""
+        detector = EnvironmentDetector()
+        detector._cache = {"test": "data", "another": "value"}
+
+        detector.clear_cache()
+
+        assert not detector._cache
+
+
+class TestModuleLevelFunctions:
+    """Test module-level convenience functions."""
+
+    @patch.object(EnvironmentDetector, "detect_primary_environment_type")
+    def test_get_environment_type_with_tracer(self, mock_detect: Mock) -> None:
+        """Test get_environment_type function with tracer instance."""
+        mock_detect.return_value = "aws_lambda"
+        mock_tracer = Mock()
+
+        result = get_environment_type(mock_tracer)
+
+        assert result == "aws_lambda"
+
+    @patch.object(EnvironmentDetector, "detect_primary_environment_type")
+    def test_get_environment_type_without_tracer(self, mock_detect: Mock) -> None:
+        """Test get_environment_type function without tracer instance."""
+        mock_detect.return_value = "docker"
+
+        result = get_environment_type()
+
+        assert result == "docker"
+
+    @patch.object(EnvironmentDetector, "detect_resource_constraints")
+    def test_get_resource_constraints_with_tracer(self, mock_detect: Mock) -> None:
+        """Test get_resource_constraints function with tracer instance."""
+        mock_detect.return_value = {"memory_tier": "high"}
+        mock_tracer = Mock()
+
+        result = get_resource_constraints(mock_tracer)
+
+        assert result == {"memory_tier": "high"}
+
+    @patch.object(EnvironmentDetector, "detect_resource_constraints")
+    def test_get_resource_constraints_without_tracer(self, mock_detect: Mock) -> None:
+        """Test get_resource_constraints function without tracer instance."""
+        mock_detect.return_value = {"cpu_tier": "medium"}
+
+        result = get_resource_constraints()
+
+        assert result == {"cpu_tier": "medium"}
+
+    @patch.object(EnvironmentDetector, "detect_performance_characteristics")
+    def test_get_performance_characteristics_with_tracer(
+        self, mock_detect: Mock
+    ) -> None:
+        """Test get_performance_characteristics function with tracer instance."""
+        mock_detect.return_value = {"execution_model": "orchestrated"}
+        mock_tracer = Mock()
+
+        result = get_performance_characteristics(mock_tracer)
+
+        assert result == {"execution_model": "orchestrated"}
+
+    @patch.object(EnvironmentDetector, "detect_performance_characteristics")
+    def test_get_performance_characteristics_without_tracer(
+        self, mock_detect: Mock
+    ) -> None:
+        """Test get_performance_characteristics function without tracer instance."""
+        mock_detect.return_value = {"latency_sensitivity": "high"}
+
+        result = get_performance_characteristics()
+
+        assert result == {"latency_sensitivity": "high"}
+
+    def test_get_comprehensive_environment_analysis_with_tracer(self) -> None:
+        """Test get_comprehensive_environment_analysis with tracer instance."""
+        mock_tracer = Mock()
+        mock_detector = Mock()
+        mock_detector.get_comprehensive_analysis.return_value = {"complete": "analysis"}
+        mock_tracer._environment_detector = mock_detector
+
+        with patch("builtins.hasattr", return_value=True):
+            result = get_comprehensive_environment_analysis(mock_tracer)
+
+        assert result == {"complete": "analysis"}
+        mock_detector.get_comprehensive_analysis.assert_called_once_with()
+
+    @patch.object(EnvironmentDetector, "get_comprehensive_analysis")
+    def test_get_comprehensive_environment_analysis_create_detector(
+        self, mock_analysis: Mock
+    ) -> None:
+        """Test get_comprehensive_environment_analysis creating new detector."""
+        mock_analysis.return_value = {"new": "analysis"}
+        mock_tracer = Mock()
+
+        with patch("builtins.hasattr", return_value=False):
+            result = get_comprehensive_environment_analysis(mock_tracer)
+
+        assert result == {"new": "analysis"}
+        assert hasattr(mock_tracer, "_environment_detector")
+
+    @patch.object(EnvironmentDetector, "get_comprehensive_analysis")
+    def test_get_comprehensive_environment_analysis_without_tracer(
+        self, mock_analysis: Mock
+    ) -> None:
+        """Test get_comprehensive_environment_analysis without tracer instance."""
+        mock_analysis.return_value = {"standalone": "analysis"}
+
+        result = get_comprehensive_environment_analysis()
+
+        assert result == {"standalone": "analysis"}
+
+    def test_clear_environment_cache_with_tracer(self) -> None:
+        """Test clear_environment_cache with tracer instance."""
+        mock_tracer = Mock()
+        mock_detector = Mock()
+        mock_tracer._environment_detector = mock_detector
+
+        with patch("builtins.hasattr", return_value=True):
+            clear_environment_cache(mock_tracer)
+
+        # Function should complete without error
+
+    def test_clear_environment_cache_without_detector(self) -> None:
+        """Test clear_environment_cache with tracer but no detector."""
+        mock_tracer = Mock()
+
+        with patch("builtins.hasattr", return_value=False):
+            clear_environment_cache(mock_tracer)
+
+        # Should not raise exception
+
+    def test_clear_environment_cache_without_tracer(self) -> None:
+        """Test clear_environment_cache without tracer instance."""
+        clear_environment_cache(None)
+
+        # Should not raise exception

--- a/tests_v2/unit/test_tracer_infra_resources.py
+++ b/tests_v2/unit/test_tracer_infra_resources.py
@@ -1,0 +1,847 @@
+"""Unit tests for honeyhive.tracer.infra.resources module.
+
+pylint: disable=R0917,line-too-long  # Test fixtures
+
+This module tests OpenTelemetry resource attribute building and management
+functionality with comprehensive mocking of all external dependencies.
+
+Test Coverage:
+- build_otel_resources() function with all conditional branches
+- _detect_service_name() function with priority detection logic
+- _detect_service_version() function with version source detection
+- _get_python_version() function with exception handling
+- All safe_log conditional calls and exception paths
+- Graceful degradation scenarios
+"""
+
+# pylint: disable=too-many-arguments,too-many-locals,protected-access
+# pylint: disable=redefined-outer-name,too-many-statements,R0917
+# pylint: disable=too-many-public-methods,duplicate-code
+
+from typing import Any, Dict, Optional
+from unittest.mock import Mock, patch
+
+from honeyhive.tracer.infra.resources import (
+    _detect_service_name,
+    _detect_service_version,
+    _get_python_version,
+    build_otel_resources,
+)
+
+
+class TestBuildOtelResources:
+    """Test suite for build_otel_resources function."""
+
+    @patch("honeyhive.tracer.infra.resources.EnvironmentDetector")
+    @patch("honeyhive.tracer.infra.resources.safe_log")
+    @patch("honeyhive.tracer.infra.resources.os.getpid")
+    @patch("honeyhive.tracer.infra.resources._get_python_version")
+    @patch("honeyhive.tracer.infra.resources._detect_service_name")
+    @patch("honeyhive.tracer.infra.resources._detect_service_version")
+    def test_build_otel_resources_success_with_tracer(
+        self,
+        mock_detect_service_version: Mock,
+        mock_detect_service_name: Mock,
+        mock_get_python_version: Mock,
+        mock_getpid: Mock,
+        mock_safe_log: Mock,
+        mock_environment_detector: Mock,
+    ) -> None:
+        """Test successful resource building with tracer instance.
+
+        Verifies that all resource attributes are properly collected
+        and safe_log is called for success logging.
+        """
+        # Arrange
+        mock_tracer: Mock = Mock()
+        mock_tracer_id: int = 12345
+
+        # Mock all function returns
+        mock_getpid.return_value = 9876
+        mock_get_python_version.return_value = "3.11.5"
+        mock_detect_service_name.return_value = "test-service"
+        mock_detect_service_version.return_value = "1.0.0"
+
+        # Mock EnvironmentDetector
+        mock_detector_instance: Mock = Mock()
+        mock_environment_detector.return_value = mock_detector_instance
+
+        mock_detector_instance.detect_system_info.return_value = {
+            "os.type": "Linux",
+            "host.name": "test-host",
+        }
+        mock_detector_instance.detect_container_environment.return_value = {
+            "container.runtime": "docker"
+        }
+        mock_detector_instance.detect_cloud_environment.return_value = {
+            "cloud.provider": "aws"
+        }
+
+        # Mock id() function for tracer instance
+        with patch("honeyhive.tracer.infra.resources.id", return_value=mock_tracer_id):
+            # Act
+            result: Dict[str, Any] = build_otel_resources(mock_tracer)
+
+        # Assert - Verify all expected resource attributes
+        expected_keys = {
+            "process.pid",
+            "process.runtime.name",
+            "process.runtime.version",
+            "service.name",
+            "service.version",
+            "service.instance.id",
+            "os.type",
+            "host.name",
+            "container.runtime",
+            "cloud.provider",
+        }
+        assert set(result.keys()) == expected_keys
+
+        # Verify specific values
+        assert result["process.pid"] == 9876
+        assert result["process.runtime.name"] == "python"
+        assert result["process.runtime.version"] == "3.11.5"
+        assert result["service.name"] == "test-service"
+        assert result["service.version"] == "1.0.0"
+        assert result["service.instance.id"] == str(mock_tracer_id)
+        assert result["os.type"] == "Linux"
+        assert result["host.name"] == "test-host"
+        assert result["container.runtime"] == "docker"
+        assert result["cloud.provider"] == "aws"
+
+        # Verify EnvironmentDetector was called correctly
+        mock_environment_detector.assert_called_once_with(mock_tracer)
+        mock_detector_instance.detect_system_info.assert_called_once()
+        mock_detector_instance.detect_container_environment.assert_called_once()
+        mock_detector_instance.detect_cloud_environment.assert_called_once()
+
+        # Verify helper functions were called
+        mock_detect_service_name.assert_called_once_with(mock_tracer)
+        mock_detect_service_version.assert_called_once()
+        mock_get_python_version.assert_called_once()
+        mock_getpid.assert_called_once()
+
+        # Verify success logging was called
+        mock_safe_log.assert_called_once_with(
+            mock_tracer,
+            "debug",
+            f"Built {len(result)} OpenTelemetry resource attributes",
+        )
+
+    @patch("honeyhive.tracer.infra.resources.EnvironmentDetector")
+    @patch("honeyhive.tracer.infra.resources.safe_log")
+    @patch("honeyhive.tracer.infra.resources.os.getpid")
+    @patch("honeyhive.tracer.infra.resources._get_python_version")
+    @patch("honeyhive.tracer.infra.resources._detect_service_name")
+    @patch("honeyhive.tracer.infra.resources._detect_service_version")
+    def test_build_otel_resources_success_without_tracer(
+        self,
+        mock_detect_service_version: Mock,
+        mock_detect_service_name: Mock,
+        mock_get_python_version: Mock,
+        mock_getpid: Mock,
+        mock_safe_log: Mock,
+        mock_environment_detector: Mock,
+    ) -> None:
+        """Test successful resource building without tracer instance.
+
+        Verifies that resources are built correctly when no tracer
+        is provided and no logging occurs.
+        """
+        # Arrange
+        mock_getpid.return_value = 5432
+        mock_get_python_version.return_value = "3.12.1"
+        mock_detect_service_name.return_value = "unknown-service"
+        mock_detect_service_version.return_value = "unknown"
+
+        # Mock EnvironmentDetector
+        mock_detector_instance: Mock = Mock()
+        mock_environment_detector.return_value = mock_detector_instance
+
+        mock_detector_instance.detect_system_info.return_value = {}
+        mock_detector_instance.detect_container_environment.return_value = {}
+        mock_detector_instance.detect_cloud_environment.return_value = {}
+
+        # Act
+        result: Dict[str, Any] = build_otel_resources(None)
+
+        # Assert - Verify basic resource attributes
+        assert result["process.pid"] == 5432
+        assert result["process.runtime.name"] == "python"
+        assert result["process.runtime.version"] == "3.12.1"
+        assert result["service.name"] == "unknown-service"
+        assert result["service.version"] == "unknown"
+        assert result["service.instance.id"] == "unknown"
+
+        # Verify EnvironmentDetector was called with None
+        mock_environment_detector.assert_called_once_with(None)
+
+        # Verify helper functions were called
+        mock_detect_service_name.assert_called_once_with(None)
+        mock_detect_service_version.assert_called_once()
+
+        # Verify no logging occurred (tracer_instance is None)
+        mock_safe_log.assert_not_called()
+
+    @patch("honeyhive.tracer.infra.resources.EnvironmentDetector")
+    @patch("honeyhive.tracer.infra.resources.safe_log")
+    @patch("honeyhive.tracer.infra.resources.os.getpid")
+    def test_build_otel_resources_exception_with_tracer(
+        self,
+        mock_getpid: Mock,
+        mock_safe_log: Mock,
+        mock_environment_detector: Mock,
+    ) -> None:
+        """Test exception handling with tracer instance.
+
+        Verifies that exceptions are caught gracefully and warning
+        is logged when tracer instance is available.
+        """
+        # Arrange
+        mock_tracer: Mock = Mock()
+        mock_tracer_id: int = 67890
+        test_exception = RuntimeError("Environment detection failed")
+
+        # Mock EnvironmentDetector to raise exception
+        mock_environment_detector.side_effect = test_exception
+        mock_getpid.return_value = 1111
+
+        # Mock id() function for tracer instance
+        with patch("honeyhive.tracer.infra.resources.id", return_value=mock_tracer_id):
+            # Act
+            result: Dict[str, Any] = build_otel_resources(mock_tracer)
+
+        # Assert - Verify graceful degradation
+        expected_minimal_resources = {
+            "service.name": "unknown",
+            "service.instance.id": str(mock_tracer_id),
+            "process.pid": 1111,
+        }
+        assert result == expected_minimal_resources
+
+        # Verify warning was logged
+        mock_safe_log.assert_called_once_with(
+            mock_tracer, "warning", f"Error during resource detection: {test_exception}"
+        )
+
+    @patch("honeyhive.tracer.infra.resources.EnvironmentDetector")
+    @patch("honeyhive.tracer.infra.resources.safe_log")
+    @patch("honeyhive.tracer.infra.resources.os.getpid")
+    def test_build_otel_resources_exception_without_tracer(
+        self,
+        mock_getpid: Mock,
+        mock_safe_log: Mock,
+        mock_environment_detector: Mock,
+    ) -> None:
+        """Test exception handling without tracer instance.
+
+        Verifies that exceptions are caught gracefully and no
+        logging occurs when no tracer instance is available.
+        """
+        # Arrange
+        test_exception = ValueError("Mock environment error")
+
+        # Mock EnvironmentDetector to raise exception
+        mock_environment_detector.side_effect = test_exception
+        mock_getpid.return_value = 2222
+
+        # Act
+        result: Dict[str, Any] = build_otel_resources(None)
+
+        # Assert - Verify graceful degradation
+        expected_minimal_resources = {
+            "service.name": "unknown",
+            "service.instance.id": "unknown",
+            "process.pid": 2222,
+        }
+        assert result == expected_minimal_resources
+
+        # Verify no logging occurred (tracer_instance is None)
+        mock_safe_log.assert_not_called()
+
+
+class TestDetectServiceName:
+    """Test suite for _detect_service_name function."""
+
+    @patch("honeyhive.tracer.infra.resources.safe_log")
+    @patch("honeyhive.tracer.infra.resources.os.getenv")
+    def test_detect_service_name_otel_service_name_with_tracer(
+        self,
+        mock_getenv: Mock,
+        mock_safe_log: Mock,
+    ) -> None:
+        """Test service name detection from OTEL_SERVICE_NAME with tracer.
+
+        Verifies that OTEL_SERVICE_NAME has highest priority and
+        detection is logged when tracer is available.
+        """
+        # Arrange
+        mock_tracer: Mock = Mock()
+        expected_service_name: str = "otel-test-service"
+
+        # Mock environment variables - OTEL_SERVICE_NAME has highest priority
+        def mock_getenv_side_effect(
+            key: str, default: Optional[str] = None
+        ) -> Optional[str]:
+            env_vars = {
+                "OTEL_SERVICE_NAME": expected_service_name,
+                "HH_SERVICE_NAME": "hh-service",
+                "SERVICE_NAME": "generic-service",
+            }
+            return env_vars.get(key, default)
+
+        mock_getenv.side_effect = mock_getenv_side_effect
+
+        # Act
+        result: str = _detect_service_name(mock_tracer)
+
+        # Assert
+        assert result == expected_service_name
+
+        # Verify logging occurred
+        mock_safe_log.assert_called_once_with(
+            mock_tracer, "debug", f"Service name detected: {expected_service_name}"
+        )
+
+    @patch("honeyhive.tracer.infra.resources.safe_log")
+    @patch("honeyhive.tracer.infra.resources.os.getenv")
+    def test_detect_service_name_hh_service_name_without_tracer(
+        self,
+        mock_getenv: Mock,
+        mock_safe_log: Mock,
+    ) -> None:
+        """Test service name detection from HH_SERVICE_NAME without tracer.
+
+        Verifies that HH_SERVICE_NAME is used when OTEL_SERVICE_NAME
+        is not available and no logging occurs without tracer.
+        """
+        # Arrange
+        expected_service_name: str = "honeyhive-test-service"
+
+        # Mock environment variables - only HH_SERVICE_NAME available
+        def mock_getenv_side_effect(
+            key: str, default: Optional[str] = None
+        ) -> Optional[str]:
+            env_vars = {
+                "HH_SERVICE_NAME": expected_service_name,
+                "SERVICE_NAME": "generic-service",
+            }
+            return env_vars.get(key, default)
+
+        mock_getenv.side_effect = mock_getenv_side_effect
+
+        # Act
+        result: str = _detect_service_name(None)
+
+        # Assert
+        assert result == expected_service_name
+
+        # Verify no logging occurred (tracer_instance is None)
+        mock_safe_log.assert_not_called()
+
+    @patch("honeyhive.tracer.infra.resources.safe_log")
+    @patch("honeyhive.tracer.infra.resources.os.getenv")
+    def test_detect_service_name_from_tracer_project_attribute(
+        self,
+        mock_getenv: Mock,
+        mock_safe_log: Mock,
+    ) -> None:
+        """Test service name detection from tracer project attribute.
+
+        Verifies that tracer.project attribute is used when
+        environment variables are not available.
+        """
+        # Arrange
+        mock_tracer: Mock = Mock()
+        expected_project_name: str = "tracer-project-name"
+        mock_tracer.project = expected_project_name
+
+        # Mock environment variables - none available
+        mock_getenv.return_value = None
+
+        # Act
+        result: str = _detect_service_name(mock_tracer)
+
+        # Assert
+        assert result == expected_project_name
+
+        # Verify logging occurred
+        mock_safe_log.assert_called_once_with(
+            mock_tracer, "debug", f"Service name detected: {expected_project_name}"
+        )
+
+    @patch("honeyhive.tracer.infra.resources.safe_log")
+    @patch("honeyhive.tracer.infra.resources.os.getenv")
+    def test_detect_service_name_from_lambda_function(
+        self,
+        mock_getenv: Mock,
+        mock_safe_log: Mock,
+    ) -> None:
+        """Test service name detection from AWS Lambda function name.
+
+        Verifies that AWS_LAMBDA_FUNCTION_NAME is used when
+        higher priority sources are not available.
+        """
+        # Arrange
+        mock_tracer: Mock = Mock()
+        expected_lambda_name: str = "my-lambda-function"
+        mock_tracer.project = None  # No project attribute
+
+        # Mock environment variables - only Lambda available
+        def mock_getenv_side_effect(
+            key: str, default: Optional[str] = None
+        ) -> Optional[str]:
+            env_vars = {
+                "AWS_LAMBDA_FUNCTION_NAME": expected_lambda_name,
+            }
+            return env_vars.get(key, default)
+
+        mock_getenv.side_effect = mock_getenv_side_effect
+
+        # Act
+        result: str = _detect_service_name(mock_tracer)
+
+        # Assert
+        assert result == expected_lambda_name
+
+        # Verify logging occurred
+        mock_safe_log.assert_called_once_with(
+            mock_tracer, "debug", f"Service name detected: {expected_lambda_name}"
+        )
+
+    @patch("honeyhive.tracer.infra.resources.safe_log")
+    @patch("honeyhive.tracer.infra.resources.os.getenv")
+    def test_detect_service_name_from_k8s_app_name(
+        self,
+        mock_getenv: Mock,
+        mock_safe_log: Mock,
+    ) -> None:
+        """Test service name detection from Kubernetes app name.
+
+        Verifies that K8S_APP_NAME is used when other sources
+        are not available.
+        """
+        # Arrange
+        mock_tracer: Mock = Mock()
+        expected_k8s_name: str = "k8s-app-service"
+        mock_tracer.project = None
+
+        # Mock environment variables - only K8S available
+        def mock_getenv_side_effect(
+            key: str, default: Optional[str] = None
+        ) -> Optional[str]:
+            env_vars = {
+                "K8S_APP_NAME": expected_k8s_name,
+            }
+            return env_vars.get(key, default)
+
+        mock_getenv.side_effect = mock_getenv_side_effect
+
+        # Act
+        result: str = _detect_service_name(mock_tracer)
+
+        # Assert
+        assert result == expected_k8s_name
+
+        # Verify logging occurred
+        mock_safe_log.assert_called_once_with(
+            mock_tracer, "debug", f"Service name detected: {expected_k8s_name}"
+        )
+
+    @patch("honeyhive.tracer.infra.resources.safe_log")
+    @patch("honeyhive.tracer.infra.resources.os.getenv")
+    def test_detect_service_name_default_fallback(
+        self,
+        mock_getenv: Mock,
+        mock_safe_log: Mock,
+    ) -> None:
+        """Test service name detection falls back to default.
+
+        Verifies that default service name is returned when
+        no sources are available and logging occurs for default.
+        """
+        # Arrange
+        mock_tracer: Mock = Mock()
+        mock_tracer.project = None
+
+        # Mock environment variables - none available
+        mock_getenv.return_value = None
+
+        # Act
+        result: str = _detect_service_name(mock_tracer)
+
+        # Assert
+        assert result == "honeyhive-service"
+
+        # Verify logging occurred for the default value (the function logs the default)
+        mock_safe_log.assert_called_once_with(
+            mock_tracer, "debug", "Service name detected: honeyhive-service"
+        )
+
+    @patch("honeyhive.tracer.infra.resources.safe_log")
+    @patch("honeyhive.tracer.infra.resources.os.getenv")
+    def test_detect_service_name_exception_handling(
+        self,
+        mock_getenv: Mock,
+        mock_safe_log: Mock,
+    ) -> None:
+        """Test service name detection handles exceptions gracefully.
+
+        Verifies that exceptions during detection are caught
+        and default value is returned.
+        """
+        # Arrange
+        mock_tracer: Mock = Mock()
+        mock_tracer.project = None  # Ensure project attribute doesn't interfere
+
+        # Mock getenv to raise exception for first few calls, then return None
+        def mock_getenv_side_effect(
+            key: str, default: Optional[str] = None
+        ) -> Optional[str]:
+            if key in ["OTEL_SERVICE_NAME", "HH_SERVICE_NAME", "SERVICE_NAME"]:
+                raise OSError("Environment access error")
+            return default
+
+        mock_getenv.side_effect = mock_getenv_side_effect
+
+        # Act
+        result: str = _detect_service_name(mock_tracer)
+
+        # Assert - Should return default fallback
+        assert result == "honeyhive-service"
+
+        # Verify logging occurred for the default value
+        # (the function still logs the default)
+        mock_safe_log.assert_called_once_with(
+            mock_tracer,
+            "debug",
+            "Service name detected: honeyhive-service",
+        )
+
+    @patch("honeyhive.tracer.infra.resources.safe_log")
+    @patch("honeyhive.tracer.infra.resources.os.getenv")
+    def test_detect_service_name_tracer_project_exception(
+        self,
+        mock_getenv: Mock,
+        mock_safe_log: Mock,
+    ) -> None:
+        """Test service name detection handles tracer.project exceptions.
+
+        Verifies that exceptions when accessing tracer.project
+        are caught and processing continues to default.
+        """
+        # Arrange
+        mock_tracer: Mock = Mock()
+        # Mock environment variables - none available
+        mock_getenv.return_value = None
+
+        # Make tracer.project return None (no project set)
+        mock_tracer.project = None
+
+        # Act
+        result: str = _detect_service_name(mock_tracer)
+
+        # Assert - Should return default fallback
+        assert result == "honeyhive-service"
+
+        # Verify logging occurred for the default value (the function logs the default)
+        mock_safe_log.assert_called_once_with(
+            mock_tracer, "debug", "Service name detected: honeyhive-service"
+        )
+
+
+class TestDetectServiceVersion:
+    """Test suite for _detect_service_version function."""
+
+    @patch("honeyhive.tracer.infra.resources.os.getenv")
+    def test_detect_service_version_otel_service_version(
+        self,
+        mock_getenv: Mock,
+    ) -> None:
+        """Test service version detection from OTEL_SERVICE_VERSION.
+
+        Verifies that OTEL_SERVICE_VERSION has highest priority
+        for version detection.
+        """
+        # Arrange
+        expected_version: str = "2.1.0"
+
+        # Mock environment variables - OTEL_SERVICE_VERSION has highest priority
+        def mock_getenv_side_effect(
+            key: str, default: Optional[str] = None
+        ) -> Optional[str]:
+            env_vars = {
+                "OTEL_SERVICE_VERSION": expected_version,
+                "HH_SERVICE_VERSION": "1.5.0",
+                "SERVICE_VERSION": "1.0.0",
+            }
+            return env_vars.get(key, default)
+
+        mock_getenv.side_effect = mock_getenv_side_effect
+
+        # Act
+        result: str = _detect_service_version()
+
+        # Assert
+        assert result == expected_version
+
+    @patch("honeyhive.tracer.infra.resources.os.getenv")
+    def test_detect_service_version_hh_service_version(
+        self,
+        mock_getenv: Mock,
+    ) -> None:
+        """Test service version detection from HH_SERVICE_VERSION.
+
+        Verifies that HH_SERVICE_VERSION is used when
+        OTEL_SERVICE_VERSION is not available.
+        """
+        # Arrange
+        expected_version: str = "1.8.2"
+
+        # Mock environment variables - only HH_SERVICE_VERSION available
+        def mock_getenv_side_effect(
+            key: str, default: Optional[str] = None
+        ) -> Optional[str]:
+            env_vars = {
+                "HH_SERVICE_VERSION": expected_version,
+                "SERVICE_VERSION": "1.0.0",
+            }
+            return env_vars.get(key, default)
+
+        mock_getenv.side_effect = mock_getenv_side_effect
+
+        # Act
+        result: str = _detect_service_version()
+
+        # Assert
+        assert result == expected_version
+
+    @patch("honeyhive.tracer.infra.resources.os.getenv")
+    def test_detect_service_version_generic_service_version(
+        self,
+        mock_getenv: Mock,
+    ) -> None:
+        """Test service version detection from SERVICE_VERSION.
+
+        Verifies that SERVICE_VERSION is used when HoneyHive-specific
+        versions are not available.
+        """
+        # Arrange
+        expected_version: str = "3.0.1"
+
+        # Mock environment variables - only SERVICE_VERSION available
+        def mock_getenv_side_effect(
+            key: str, default: Optional[str] = None
+        ) -> Optional[str]:
+            env_vars = {
+                "SERVICE_VERSION": expected_version,
+                "GIT_COMMIT": "abcdef123456",
+            }
+            return env_vars.get(key, default)
+
+        mock_getenv.side_effect = mock_getenv_side_effect
+
+        # Act
+        result: str = _detect_service_version()
+
+        # Assert
+        assert result == expected_version
+
+    @patch("honeyhive.tracer.infra.resources.os.getenv")
+    def test_detect_service_version_git_commit_truncated(
+        self,
+        mock_getenv: Mock,
+    ) -> None:
+        """Test service version detection from GIT_COMMIT (truncated).
+
+        Verifies that GIT_COMMIT is truncated to 8 characters
+        when used as version source.
+        """
+        # Arrange
+        full_commit: str = "abcdef1234567890abcdef"
+        expected_version: str = "abcdef12"  # First 8 characters
+
+        # Mock environment variables - only GIT_COMMIT available
+        def mock_getenv_side_effect(
+            key: str, default: Optional[str] = None
+        ) -> Optional[str]:
+            if key == "GIT_COMMIT":
+                return full_commit
+            return env_vars.get(key, default) if key in env_vars else default
+
+        env_vars: Dict[str, str] = {}
+        mock_getenv.side_effect = mock_getenv_side_effect
+
+        # Act
+        result: str = _detect_service_version()
+
+        # Assert
+        assert result == expected_version
+
+    @patch("honeyhive.tracer.infra.resources.os.getenv")
+    def test_detect_service_version_build_number(
+        self,
+        mock_getenv: Mock,
+    ) -> None:
+        """Test service version detection from BUILD_NUMBER.
+
+        Verifies that BUILD_NUMBER is used when other version
+        sources are not available.
+        """
+        # Arrange
+        expected_version: str = "build-456"
+
+        # Mock environment variables - only BUILD_NUMBER available
+        def mock_getenv_side_effect(
+            key: str, default: Optional[str] = None
+        ) -> Optional[str]:
+            env_vars = {
+                "BUILD_NUMBER": expected_version,
+            }
+            return env_vars.get(key, default)
+
+        mock_getenv.side_effect = mock_getenv_side_effect
+
+        # Act
+        result: str = _detect_service_version()
+
+        # Assert
+        assert result == expected_version
+
+    @patch("honeyhive.tracer.infra.resources.os.getenv")
+    def test_detect_service_version_default_fallback(
+        self,
+        mock_getenv: Mock,
+    ) -> None:
+        """Test service version detection falls back to default.
+
+        Verifies that default version is returned when
+        no version sources are available.
+        """
+        # Arrange
+        # Mock environment variables - none available
+        mock_getenv.return_value = None
+
+        # Act
+        result: str = _detect_service_version()
+
+        # Assert
+        assert result == "unknown"
+
+    @patch("honeyhive.tracer.infra.resources.os.getenv")
+    def test_detect_service_version_exception_handling(
+        self,
+        mock_getenv: Mock,
+    ) -> None:
+        """Test service version detection handles exceptions gracefully.
+
+        Verifies that exceptions during detection are caught
+        and default value is returned.
+        """
+        # Arrange
+        # Mock getenv to raise exception
+        mock_getenv.side_effect = PermissionError("Environment access denied")
+
+        # Act
+        result: str = _detect_service_version()
+
+        # Assert - Should return default fallback
+        assert result == "unknown"
+
+    @patch("honeyhive.tracer.infra.resources.os.getenv")
+    def test_detect_service_version_empty_git_commit(
+        self,
+        mock_getenv: Mock,
+    ) -> None:
+        """Test service version detection handles empty GIT_COMMIT.
+
+        Verifies that empty GIT_COMMIT is skipped and
+        processing continues to next source.
+        """
+        # Arrange
+        expected_version: str = "build-789"
+
+        # Mock environment variables - empty GIT_COMMIT, BUILD_NUMBER available
+        def mock_getenv_side_effect(
+            key: str, default: Optional[str] = None
+        ) -> Optional[str]:
+            env_vars = {
+                "GIT_COMMIT": "",  # Empty string
+                "BUILD_NUMBER": expected_version,
+            }
+            return env_vars.get(key, default)
+
+        mock_getenv.side_effect = mock_getenv_side_effect
+
+        # Act
+        result: str = _detect_service_version()
+
+        # Assert
+        assert result == expected_version
+
+
+class TestGetPythonVersion:
+    """Test suite for _get_python_version function."""
+
+    @patch("honeyhive.tracer.infra.resources.sys.version_info")
+    def test_get_python_version_success(
+        self,
+        mock_version_info: Mock,
+    ) -> None:
+        """Test successful Python version detection.
+
+        Verifies that Python version is correctly formatted
+        from sys.version_info components.
+        """
+        # Arrange
+        mock_version_info.major = 3
+        mock_version_info.minor = 11
+        mock_version_info.micro = 5
+        expected_version: str = "3.11.5"
+
+        # Act
+        result: str = _get_python_version()
+
+        # Assert
+        assert result == expected_version
+
+    @patch("honeyhive.tracer.infra.resources.sys.version_info")
+    def test_get_python_version_different_version(
+        self,
+        mock_version_info: Mock,
+    ) -> None:
+        """Test Python version detection with different version.
+
+        Verifies that version formatting works correctly
+        with different version numbers.
+        """
+        # Arrange
+        mock_version_info.major = 3
+        mock_version_info.minor = 12
+        mock_version_info.micro = 0
+        expected_version: str = "3.12.0"
+
+        # Act
+        result: str = _get_python_version()
+
+        # Assert
+        assert result == expected_version
+
+    @patch("honeyhive.tracer.infra.resources.sys")
+    def test_get_python_version_sys_none_exception(
+        self,
+        mock_sys: Mock,
+    ) -> None:
+        """Test Python version detection when sys module is None.
+
+        Verifies that exceptions when sys module is None
+        (during shutdown) are handled gracefully.
+        """
+        # Arrange
+        mock_sys.version_info = None
+
+        # Act
+        result: str = _get_python_version()
+
+        # Assert - Should return default fallback
+        assert result == "unknown"

--- a/tests_v2/unit/test_tracer_lifecycle_core.py
+++ b/tests_v2/unit/test_tracer_lifecycle_core.py
@@ -1,0 +1,634 @@
+"""Unit tests for HoneyHive tracer lifecycle core functionality.
+
+This module tests the core lifecycle management infrastructure including
+safe logging, tracer registration, and thread-safe operations.
+"""
+
+# pylint: disable=unused-argument,attribute-defined-outside-init,duplicate-code
+# Justification: Test fixtures may not be used, test setup defines attributes
+
+import gc
+import threading
+import time
+from unittest.mock import Mock, patch
+
+from honeyhive.tracer.lifecycle.core import (
+    _lifecycle_lock,
+    _new_spans_disabled,
+    _registered_tracers,
+    acquire_lifecycle_lock_optimized,
+    acquire_lock_with_timeout,
+    disable_new_span_creation,
+    get_lifecycle_lock,
+    get_lock_config,
+    get_lock_strategy,
+    is_new_span_creation_disabled,
+    register_tracer_for_atexit_cleanup,
+    unregister_tracer_from_atexit_cleanup,
+)
+
+
+class MockTracer:
+    """Mock tracer for testing lifecycle operations."""
+
+    def __init__(self, tracer_id: str = "test-tracer"):
+        self.tracer_id = tracer_id
+        self.shutdown_called = False
+        self.flush_called = False
+
+    def shutdown(self) -> None:
+        """Mock shutdown method."""
+        self.shutdown_called = True
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        """Mock force flush method."""
+        self.flush_called = True
+        return True
+
+
+# TestSafeLogging class removed - functionality no longer exists
+# The _safe_log function was removed in favor of direct safe_log usage from utils.logger
+
+
+class TestTracerRegistration:
+    """Test tracer registration for atexit cleanup."""
+
+    def setup_method(self) -> None:
+        """Set up test fixtures before each test method."""
+        # Clear the registered tracers set
+        _registered_tracers.clear()
+        self.mock_patches = []
+
+    def teardown_method(self) -> None:
+        """Clean up after each test method."""
+        # Clear the registered tracers set
+        _registered_tracers.clear()
+
+        # Stop all patches
+        for patch_obj in self.mock_patches:
+            patch_obj.stop()
+
+    def test_register_tracer_for_atexit_cleanup(self) -> None:
+        """Test tracer registration for atexit cleanup."""
+        tracer = MockTracer("test-tracer-1")
+
+        with patch("honeyhive.tracer.lifecycle.core.atexit.register") as mock_atexit:
+            register_tracer_for_atexit_cleanup(tracer)
+
+            # Verify tracer was added to registered set
+            assert tracer in _registered_tracers
+
+            # Verify atexit handler was registered
+            mock_atexit.assert_called_once()
+
+    def test_register_multiple_tracers(self) -> None:
+        """Test registering multiple tracers."""
+        tracer1 = MockTracer("tracer-1")
+        tracer2 = MockTracer("tracer-2")
+        tracer3 = MockTracer("tracer-3")
+
+        with patch("honeyhive.tracer.lifecycle.core.atexit.register"):
+            register_tracer_for_atexit_cleanup(tracer1)
+            register_tracer_for_atexit_cleanup(tracer2)
+            register_tracer_for_atexit_cleanup(tracer3)
+
+            # Verify all tracers were registered
+            assert len(_registered_tracers) == 3
+            assert tracer1 in _registered_tracers
+            assert tracer2 in _registered_tracers
+            assert tracer3 in _registered_tracers
+
+    def test_register_same_tracer_multiple_times(self) -> None:
+        """Test registering the same tracer multiple times."""
+        tracer = MockTracer("duplicate-tracer")
+
+        with patch("honeyhive.tracer.lifecycle.core.atexit.register"):
+            register_tracer_for_atexit_cleanup(tracer)
+            register_tracer_for_atexit_cleanup(tracer)
+            register_tracer_for_atexit_cleanup(tracer)
+
+            # Should only be registered once (WeakSet behavior)
+            assert len(_registered_tracers) == 1
+            assert tracer in _registered_tracers
+
+    def test_unregister_tracer_from_atexit_cleanup(self) -> None:
+        """Test tracer unregistration from atexit cleanup."""
+        tracer = MockTracer("test-tracer")
+
+        with patch("honeyhive.tracer.lifecycle.core.atexit.register"):
+            # First register the tracer
+            register_tracer_for_atexit_cleanup(tracer)
+            assert tracer in _registered_tracers
+
+            # Then unregister it
+            unregister_tracer_from_atexit_cleanup(tracer)
+            assert tracer not in _registered_tracers
+
+    def test_unregister_nonexistent_tracer(self) -> None:
+        """Test unregistering a tracer that wasn't registered."""
+        tracer = MockTracer("nonexistent-tracer")
+
+        # Should not raise exception
+        unregister_tracer_from_atexit_cleanup(tracer)
+
+    def test_weak_reference_cleanup(self) -> None:
+        """Test that tracers are automatically cleaned up when garbage collected."""
+        with patch("honeyhive.tracer.lifecycle.core.atexit.register"):
+            tracer = MockTracer("weak-ref-tracer")
+            register_tracer_for_atexit_cleanup(tracer)
+
+            # Verify tracer is registered
+            assert len(_registered_tracers) == 1
+
+            # Delete the tracer and force garbage collection
+            del tracer
+            gc.collect()
+
+            # WeakSet should automatically remove the dead reference
+            # Note: This might not work immediately due to GC timing
+            # but the WeakSet will clean up eventually
+
+    def test_thread_safety_registration(self) -> None:
+        """Test that tracer registration is thread-safe."""
+        tracers = []
+
+        def register_worker(worker_id: int):
+            tracer = MockTracer(f"worker-{worker_id}")
+            tracers.append(tracer)
+            with patch("honeyhive.tracer.lifecycle.core.atexit.register"):
+                register_tracer_for_atexit_cleanup(tracer)
+
+        # Create multiple threads registering tracers
+        threads = []
+        for i in range(10):
+            thread = threading.Thread(target=register_worker, args=(i,))
+            threads.append(thread)
+            thread.start()
+
+        # Wait for all threads to complete
+        for thread in threads:
+            thread.join()
+
+        # Verify all tracers were registered
+        assert len(_registered_tracers) == 10
+        for tracer in tracers:
+            assert tracer in _registered_tracers
+
+
+class TestShutdownStateManagement:
+    """Test shutdown state management functionality."""
+
+    def setup_method(self) -> None:
+        """Set up test fixtures before each test method."""
+        # Reset shutdown states (only _new_spans_disabled exists now)
+        _new_spans_disabled.clear()
+
+    def teardown_method(self) -> None:
+        """Clean up after each test method."""
+        # Reset shutdown states (only _new_spans_disabled exists now)
+        _new_spans_disabled.clear()
+
+    def test_disable_new_span_creation(self) -> None:
+        """Test disabling new span creation."""
+        assert not _new_spans_disabled.is_set()
+        assert not is_new_span_creation_disabled()
+
+        disable_new_span_creation()
+
+        assert _new_spans_disabled.is_set()
+        assert is_new_span_creation_disabled()
+
+    def test_is_new_span_creation_disabled_initial_state(self) -> None:
+        """Test initial state of new span creation."""
+        assert not is_new_span_creation_disabled()
+
+    def test_shutdown_state_coordination(self) -> None:
+        """Test coordination between different shutdown states."""
+        # Initially, new spans should not be disabled
+        assert not _new_spans_disabled.is_set()
+
+        # Disable new spans
+        disable_new_span_creation()
+        assert _new_spans_disabled.is_set()
+
+        # New spans should remain disabled
+        assert _new_spans_disabled.is_set()
+
+    def test_thread_safety_shutdown_states(self) -> None:
+        """Test that shutdown state operations are thread-safe."""
+        results = []
+
+        def state_worker(worker_id: int):
+            if worker_id % 2 == 0:
+                results.append("stream_closure")
+            else:
+                disable_new_span_creation()
+                results.append("spans_disabled")
+
+        # Create multiple threads modifying shutdown states
+        threads = []
+        for i in range(10):
+            thread = threading.Thread(target=state_worker, args=(i,))
+            threads.append(thread)
+            thread.start()
+
+        # Wait for all threads to complete
+        for thread in threads:
+            thread.join()
+
+        # Verify all operations completed
+        assert len(results) == 10
+        assert "stream_closure" in results
+        assert "spans_disabled" in results
+
+        # Verify final states
+        assert _new_spans_disabled.is_set()
+
+
+class TestLifecycleLocking:
+    """Test lifecycle locking mechanisms."""
+
+    def test_lifecycle_lock_exists(self) -> None:
+        """Test that lifecycle lock is available."""
+        assert _lifecycle_lock is not None
+        # Check that it's a lock-like object (has acquire/release methods)
+        assert hasattr(_lifecycle_lock, "acquire")
+        assert hasattr(_lifecycle_lock, "release")
+        assert callable(_lifecycle_lock.acquire)
+        assert callable(_lifecycle_lock.release)
+
+    def test_lifecycle_lock_thread_safety(self) -> None:
+        """Test that lifecycle lock provides thread safety."""
+        shared_counter = {"value": 0}
+
+        def increment_worker():
+            for _ in range(100):
+                with _lifecycle_lock:
+                    current = shared_counter["value"]
+                    # Simulate some work
+                    time.sleep(0.001)
+                    shared_counter["value"] = current + 1
+
+        # Create multiple threads incrementing counter
+        threads = []
+        for _ in range(5):
+            thread = threading.Thread(target=increment_worker)
+            threads.append(thread)
+            thread.start()
+
+        # Wait for all threads to complete
+        for thread in threads:
+            thread.join()
+
+        # With proper locking, final value should be 500
+        assert shared_counter["value"] == 500
+
+    def test_lifecycle_lock_context_manager(self) -> None:
+        """Test lifecycle lock works as context manager."""
+        acquired = False
+
+        with _lifecycle_lock:
+            acquired = _lifecycle_lock.locked()
+
+        # Should be acquired inside context, released outside
+        assert acquired
+        assert not _lifecycle_lock.locked()
+
+
+class TestLockStrategy:
+    """Test suite for lock strategy detection and configuration."""
+
+    def test_get_lock_strategy_lambda(self) -> None:
+        """Test AWS Lambda environment detection."""
+        with patch.dict("os.environ", {"AWS_LAMBDA_FUNCTION_NAME": "test-function"}):
+            # This tests lines 90-91
+            strategy = get_lock_strategy()
+            assert strategy == "lambda_optimized"
+
+    def test_get_lock_strategy_kubernetes(self) -> None:
+        """Test Kubernetes environment detection."""
+        with patch.dict(
+            "os.environ", {"KUBERNETES_SERVICE_HOST": "10.0.0.1"}, clear=True
+        ):
+            # This tests lines 94-95
+            strategy = get_lock_strategy()
+            assert strategy == "k8s_optimized"
+
+    def test_get_lock_strategy_high_concurrency(self) -> None:
+        """Test high concurrency mode detection."""
+        with patch.dict("os.environ", {"HH_HIGH_CONCURRENCY": "true"}, clear=True):
+            # This tests lines 98-99
+            strategy = get_lock_strategy()
+            assert strategy == "high_concurrency"
+
+    def test_get_lock_strategy_high_concurrency_variants(self) -> None:
+        """Test high concurrency mode detection with different values."""
+        test_values = ["1", "yes", "TRUE", "Yes"]
+        for value in test_values:
+            with patch.dict("os.environ", {"HH_HIGH_CONCURRENCY": value}, clear=True):
+                strategy = get_lock_strategy()
+                assert strategy == "high_concurrency"
+
+    def test_get_lock_strategy_standard_default(self) -> None:
+        """Test standard environment (default case)."""
+        with patch.dict("os.environ", {}, clear=True):
+            # This tests line 102
+            strategy = get_lock_strategy()
+            assert strategy == "standard"
+
+    def test_get_lock_config_with_strategy(self) -> None:
+        """Test lock configuration retrieval with explicit strategy."""
+        # This tests lines 123-126
+        config = get_lock_config("lambda_optimized")
+        assert config["lifecycle_timeout"] == 0.5
+        assert config["flush_timeout"] == 2.0
+        assert "description" in config
+
+    def test_get_lock_config_auto_detect(self) -> None:
+        """Test lock configuration with auto-detection."""
+        with patch.dict("os.environ", {"AWS_LAMBDA_FUNCTION_NAME": "test"}, clear=True):
+            # This tests lines 123-124 (strategy is None path)
+            config = get_lock_config(None)
+            assert config["lifecycle_timeout"] == 0.5
+
+    def test_get_lock_config_unknown_strategy_fallback(self) -> None:
+        """Test lock configuration fallback for unknown strategy."""
+        # This tests line 126 (fallback to standard)
+        config = get_lock_config("unknown_strategy")
+        assert config == get_lock_config("standard")
+
+
+# TestSafeLogDelegation class removed - functionality no longer exists
+# The _safe_log function was removed in favor of direct safe_log usage
+
+
+class TestLockAcquisition:
+    """Test suite for lock acquisition utilities."""
+
+    def test_get_lifecycle_lock(self) -> None:
+        """Test lifecycle lock getter."""
+        # This tests the get_lifecycle_lock function
+        lock = get_lifecycle_lock()
+        assert lock is _lifecycle_lock
+
+    @patch("honeyhive.tracer.lifecycle.core.get_lock_config")
+    def test_acquire_lifecycle_lock_optimized_success(self, mock_get_config) -> None:
+        """Test successful lock acquisition with optimization."""
+        # Mock configuration
+        mock_get_config.return_value = {"lifecycle_timeout": 1.0}
+
+        # This tests the acquire_lifecycle_lock_optimized function
+        with acquire_lifecycle_lock_optimized("test_operation") as acquired:
+            assert acquired is True
+            assert _lifecycle_lock.locked()
+
+    @patch("honeyhive.tracer.lifecycle.core.get_lock_config")
+    def test_acquire_lifecycle_lock_optimized_custom_timeout(
+        self, mock_get_config
+    ) -> None:
+        """Test lock acquisition with custom timeout."""
+        mock_get_config.return_value = {"lifecycle_timeout": 1.0}
+
+        with acquire_lifecycle_lock_optimized(
+            "test_operation", custom_timeout=0.5
+        ) as acquired:
+            assert acquired is True
+            # Verify custom timeout was used (not the config timeout)
+
+    @patch("honeyhive.tracer.lifecycle.core.get_lock_config")
+    @patch("honeyhive.tracer.lifecycle.core._lifecycle_lock")
+    def test_acquire_lifecycle_lock_optimized_timeout(
+        self, mock_lock, mock_get_config
+    ) -> None:
+        """Test lock acquisition timeout handling."""
+        mock_get_config.return_value = {"lifecycle_timeout": 0.001}
+        mock_lock.acquire.return_value = False  # Simulate timeout
+
+        with acquire_lifecycle_lock_optimized("test_operation") as acquired:
+            assert acquired is False
+
+    def test_acquire_lock_with_timeout_success(self) -> None:
+        """Test successful lock acquisition with timeout."""
+        mock_lock = Mock()
+        mock_lock.acquire.return_value = True
+
+        # This tests lines 329-336
+        with acquire_lock_with_timeout(mock_lock, 1.0) as acquired:
+            assert acquired is True
+            mock_lock.acquire.assert_called_once_with(timeout=1.0)
+
+        # Verify lock was released
+        mock_lock.release.assert_called_once()
+
+    def test_acquire_lock_with_timeout_failure(self) -> None:
+        """Test lock acquisition timeout failure."""
+        mock_lock = Mock()
+        mock_lock.acquire.return_value = False  # Simulate timeout
+
+        # This tests lines 329-331
+        with acquire_lock_with_timeout(mock_lock, 0.1) as acquired:
+            assert acquired is False
+            mock_lock.acquire.assert_called_once_with(timeout=0.1)
+
+        # Verify lock was NOT released (since it wasn't acquired)
+        mock_lock.release.assert_not_called()
+
+
+class TestTracerRegistrationCleanup:
+    """Test suite for tracer registration and cleanup."""
+
+    def setup_method(self) -> None:
+        """Set up test fixtures before each test method."""
+        _registered_tracers.clear()
+
+    def teardown_method(self) -> None:
+        """Clean up after each test method."""
+        _registered_tracers.clear()
+
+    @patch("atexit.register")
+    def test_register_tracer_for_atexit_cleanup(self, mock_atexit_register) -> None:
+        """Test tracer registration for atexit cleanup."""
+        tracer = MockTracer("test-tracer")
+
+        # This tests the registration logic
+        register_tracer_for_atexit_cleanup(tracer)
+
+        # Verify tracer was added to registry
+        assert tracer in _registered_tracers
+
+        # Verify atexit handler was registered
+        mock_atexit_register.assert_called_once()
+
+    @patch("atexit.register")
+    @patch("honeyhive.tracer.lifecycle.core.safe_log")
+    def test_register_tracer_already_registered(
+        self, mock_safe_log, mock_atexit_register
+    ) -> None:
+        """Test registering a tracer that's already registered."""
+        tracer = MockTracer("test-tracer")
+
+        # First registration
+        register_tracer_for_atexit_cleanup(tracer)
+
+        # Second registration (should log debug and return early)
+        # This tests lines 190-195
+        register_tracer_for_atexit_cleanup(tracer)
+
+        # Should have logged debug message about already registered
+        mock_safe_log.assert_any_call(
+            tracer,
+            "debug",
+            f"Tracer already registered for atexit cleanup: {id(tracer)}",
+        )
+
+        # Should still only be registered once in atexit
+        assert mock_atexit_register.call_count == 1
+
+    @patch("atexit.register")
+    @patch("honeyhive.tracer.lifecycle.flush.force_flush_tracer")
+    @patch("honeyhive.tracer.lifecycle.shutdown.shutdown_tracer")
+    def test_atexit_cleanup_function_execution(
+        self, mock_shutdown, mock_flush, mock_atexit_register
+    ) -> None:
+        """Test that the atexit cleanup function works correctly."""
+        tracer = MockTracer("test-tracer")
+
+        # Register tracer
+        register_tracer_for_atexit_cleanup(tracer)
+
+        # Get the cleanup function that was registered with atexit
+        cleanup_func = mock_atexit_register.call_args[0][0]
+
+        # Execute the cleanup function - this tests lines 206-222
+        cleanup_func()
+
+        # Note: Shutdown state detection has moved to logger system
+        # This test focuses on cleanup function behavior (flush/shutdown calls)
+
+        # Verify flush and shutdown were called
+        mock_flush.assert_called_once_with(tracer, timeout_millis=1000)
+        mock_shutdown.assert_called_once_with(tracer)
+
+    @patch("atexit.register")
+    @patch("honeyhive.tracer.lifecycle.flush.force_flush_tracer")
+    def test_atexit_cleanup_function_exception_handling(
+        self, mock_flush, mock_atexit_register
+    ) -> None:
+        """Test that atexit cleanup handles exceptions gracefully."""
+        tracer = MockTracer("test-tracer")
+
+        # Make flush raise an exception
+        mock_flush.side_effect = Exception("Flush error during shutdown")
+
+        # Register tracer
+        register_tracer_for_atexit_cleanup(tracer)
+
+        # Get and execute the cleanup function
+        cleanup_func = mock_atexit_register.call_args[0][0]
+
+        # Should not raise exception (tests lines 220-222)
+        cleanup_func()  # Should complete without error
+
+        # Note: Shutdown state detection has moved to logger system
+        # This test focuses on exception handling in cleanup function
+
+    def test_unregister_tracer_from_atexit_cleanup(self) -> None:
+        """Test tracer unregistration from atexit cleanup."""
+        tracer = MockTracer("test-tracer")
+
+        # First register the tracer
+        _registered_tracers.add(tracer)
+        assert tracer in _registered_tracers
+
+        # Then unregister it - this tests the unregistration logic
+        unregister_tracer_from_atexit_cleanup(tracer)
+
+        # Verify tracer was removed from registry
+        assert tracer not in _registered_tracers
+
+    def test_unregister_nonexistent_tracer(self) -> None:
+        """Test unregistering a tracer that wasn't registered."""
+        tracer = MockTracer("nonexistent-tracer")
+
+        # Should not raise an error
+        unregister_tracer_from_atexit_cleanup(tracer)
+
+        # Registry should remain empty
+        assert len(_registered_tracers) == 0
+
+
+class TestIntegrationScenarios:
+    """Test integration scenarios combining multiple lifecycle features."""
+
+    def setup_method(self) -> None:
+        """Set up test fixtures before each test method."""
+        # Reset all states (only these exist now)
+        _new_spans_disabled.clear()
+        _registered_tracers.clear()
+
+    def teardown_method(self) -> None:
+        """Clean up after each test method."""
+        # Reset all states (only these exist now)
+        _new_spans_disabled.clear()
+        _registered_tracers.clear()
+
+    def test_full_shutdown_sequence(self) -> None:
+        """Test a complete shutdown sequence."""
+        tracer = MockTracer("shutdown-test")
+
+        with patch("honeyhive.tracer.lifecycle.core.atexit.register"):
+            # 1. Register tracer
+            register_tracer_for_atexit_cleanup(tracer)
+            assert tracer in _registered_tracers
+
+            # 2. Disable new span creation
+            disable_new_span_creation()
+            assert is_new_span_creation_disabled()
+
+            # 3. Mark stream closure
+
+            # 4. Unregister tracer
+            unregister_tracer_from_atexit_cleanup(tracer)
+            assert tracer not in _registered_tracers
+
+    def test_concurrent_lifecycle_operations(self) -> None:
+        """Test concurrent lifecycle operations."""
+        tracers = []
+        results = []
+
+        def lifecycle_worker(worker_id: int):
+            tracer = MockTracer(f"concurrent-{worker_id}")
+            tracers.append(tracer)
+
+            try:
+                with patch("honeyhive.tracer.lifecycle.core.atexit.register"):
+                    # Register tracer
+                    register_tracer_for_atexit_cleanup(tracer)
+
+                    # Perform shutdown operations
+                    if worker_id % 3 == 0:
+                        disable_new_span_creation()
+                    elif worker_id % 3 == 1:
+                        pass  # No additional operation for this worker
+
+                    # Unregister tracer
+                    unregister_tracer_from_atexit_cleanup(tracer)
+
+                results.append("success")
+            except Exception as e:
+                results.append(f"error: {e}")
+
+        # Create multiple threads performing lifecycle operations
+        threads = []
+        for i in range(15):
+            thread = threading.Thread(target=lifecycle_worker, args=(i,))
+            threads.append(thread)
+            thread.start()
+
+        # Wait for all threads to complete
+        for thread in threads:
+            thread.join()
+
+        # Verify all operations completed successfully
+        assert len(results) == 15
+        assert all(result == "success" for result in results)

--- a/tests_v2/unit/test_tracer_lifecycle_flush.py
+++ b/tests_v2/unit/test_tracer_lifecycle_flush.py
@@ -1,0 +1,662 @@
+"""Unit tests for tracer lifecycle flush operations.
+
+This module tests the force flush operations for tracer lifecycle management,
+including tracer provider flushing, span processor flushing, batch processor
+handling, error handling, timeout management, and graceful degradation.
+
+Based on thorough inspection of the actual implementation in:
+- src/honeyhive/tracer/lifecycle/flush.py
+- src/honeyhive/tracer/lifecycle/core.py
+"""
+
+# pylint: disable=too-many-lines,protected-access,redefined-outer-name,too-many-public-methods,line-too-long,R0917
+# Justification: Comprehensive test coverage requires extensive test cases, testing private methods
+# requires protected access, pytest fixtures redefine outer names by design, comprehensive test
+# classes need many test methods, and mock patch decorators create unavoidable long lines.
+
+
+from contextlib import contextmanager
+from typing import Any, Iterator, List
+from unittest.mock import Mock, patch
+
+import pytest
+
+from honeyhive.tracer.lifecycle.flush import (
+    _flush_batch_processors,
+    _flush_single_processor,
+    _flush_span_processor,
+    _flush_tracer_provider,
+    _get_batch_processors,
+    _log_flush_results,
+    force_flush_tracer,
+)
+
+# Using standard fixtures from conftest.py
+
+
+@pytest.fixture
+def mock_tracer() -> Mock:
+    """Mock tracer instance for flush tests.
+
+    Creates a fresh mock tracer for each test to ensure isolation.
+    Uses the standard mock_safe_log fixture pattern.
+    """
+    tracer = Mock()
+    tracer.test_mode = False
+    tracer.provider = Mock()
+    tracer.span_processor = Mock()
+    return tracer
+
+
+@pytest.fixture
+def mock_context_manager() -> Any:
+    """Mock context manager for lifecycle lock acquisition."""
+
+    @contextmanager
+    def mock_acquire_lock(*_args: Any, **_kwargs: Any) -> Iterator[bool]:
+        yield True
+
+    return mock_acquire_lock
+
+
+class TestForceFlushTracer:
+    """Test suite for force_flush_tracer function."""
+
+    @patch("honeyhive.tracer.lifecycle.flush.safe_log")
+    @patch("honeyhive.tracer.lifecycle.flush.acquire_lifecycle_lock_optimized")
+    @patch("honeyhive.tracer.lifecycle.flush._flush_tracer_provider")
+    @patch("honeyhive.tracer.lifecycle.flush._flush_span_processor")
+    @patch("honeyhive.tracer.lifecycle.flush._flush_batch_processors")
+    @patch("honeyhive.tracer.lifecycle.flush._log_flush_results")
+    def test_force_flush_success_all_components(
+        self,
+        mock_log_results: Mock,
+        mock_flush_batch: Mock,
+        mock_flush_span: Mock,
+        mock_flush_provider: Mock,
+        mock_acquire_lock: Mock,
+        _mock_safe_log: Mock,
+        mock_tracer: Mock,
+        mock_context_manager: Any,
+    ) -> None:
+        """Test successful force flush of all components."""
+        # Setup
+        mock_acquire_lock.return_value = mock_context_manager()
+
+        # Mock flush results to simulate successful flushes
+        def setup_flush_results(
+            _tracer: Any, _timeout: Any, results: List[tuple[str, bool]]
+        ) -> None:
+            results.extend(
+                [
+                    ("provider", True),
+                    ("span_processor", True),
+                    ("batch_processors", True),
+                ]
+            )
+
+        mock_flush_provider.side_effect = setup_flush_results
+        mock_flush_span.side_effect = lambda t, tm, r: r.append(
+            ("span_processor", True)
+        )
+        mock_flush_batch.side_effect = lambda t, tm, r: r.append(
+            ("batch_processors", True)
+        )
+
+        # Execute
+        result = force_flush_tracer(mock_tracer, timeout_millis=5000)
+
+        # Verify
+        assert result is True
+        mock_acquire_lock.assert_called_once_with("flush", custom_timeout=5.0)
+        mock_flush_provider.assert_called_once()
+        mock_flush_span.assert_called_once()
+        mock_flush_batch.assert_called_once()
+        mock_log_results.assert_called_once()
+
+    @patch("honeyhive.tracer.lifecycle.flush.safe_log")
+    @patch("honeyhive.tracer.lifecycle.flush.acquire_lifecycle_lock_optimized")
+    def test_force_flush_lock_acquisition_failure(
+        self, mock_acquire_lock: Mock, mock_safe_log: Mock, mock_tracer: Mock
+    ) -> None:
+        """Test force flush when lock acquisition fails."""
+
+        # Setup - lock acquisition fails
+        @contextmanager
+        def mock_failed_lock(*_args: Any, **_kwargs: Any) -> Iterator[bool]:
+            yield False
+
+        mock_acquire_lock.side_effect = mock_failed_lock
+
+        # Execute
+        result = force_flush_tracer(mock_tracer, timeout_millis=1000)
+
+        # Verify - this tests lines 74-78
+        assert result is False
+        mock_safe_log.assert_any_call(
+            mock_tracer,
+            "warning",
+            "Failed to acquire _lifecycle_lock (1.0s)",
+        )
+
+    @patch("honeyhive.tracer.lifecycle.flush.safe_log")
+    @patch("honeyhive.tracer.lifecycle.flush.acquire_lifecycle_lock_optimized")
+    def test_force_flush_exception_handling(
+        self, mock_acquire_lock: Mock, mock_safe_log: Mock, mock_tracer: Mock
+    ) -> None:
+        """Test force flush exception handling."""
+        # Setup - exception during flush operations
+        mock_acquire_lock.side_effect = Exception("Lock error")
+
+        # Execute
+        result = force_flush_tracer(mock_tracer, timeout_millis=5000)
+
+        # Verify - this tests lines 98-105 with standardized error handling
+        assert result is False
+        mock_safe_log.assert_any_call(
+            mock_tracer,
+            "error",
+            "Force flush failed",
+            honeyhive_data={
+                "error": "Lock error",
+                "error_type": "Exception",
+                "operation": "force_flush_tracer",
+            },
+        )
+
+    @patch("honeyhive.tracer.lifecycle.flush.safe_log")
+    @patch("honeyhive.tracer.lifecycle.flush.acquire_lifecycle_lock_optimized")
+    def test_force_flush_exception_handling_test_mode(
+        self, mock_acquire_lock: Mock, mock_safe_log: Mock, mock_tracer: Mock
+    ) -> None:
+        """Test force flush exception handling with consistent behavior regardless of
+        test_mode."""
+        # Setup
+        mock_tracer.test_mode = True
+        mock_acquire_lock.side_effect = Exception("Lock error")
+
+        # Execute
+        result = force_flush_tracer(mock_tracer, timeout_millis=5000)
+
+        # Verify - consistent behavior regardless of test_mode (Agent OS standards)
+        assert result is False
+        # Error logging should occur consistently regardless of test_mode
+        mock_safe_log.assert_any_call(
+            mock_tracer,
+            "error",
+            "Force flush failed",
+            honeyhive_data={
+                "error": "Lock error",
+                "error_type": "Exception",
+                "operation": "force_flush_tracer",
+            },
+        )
+
+
+class TestFlushTracerProvider:
+    """Test suite for _flush_tracer_provider function."""
+
+    @patch("honeyhive.tracer.lifecycle.flush.safe_log")
+    def test_flush_provider_success(
+        self, mock_safe_log: Mock, mock_tracer: Mock
+    ) -> None:
+        """Test successful provider flush."""
+        # Setup
+        mock_tracer.provider.force_flush.return_value = True
+        flush_results: List[tuple[str, bool]] = []
+
+        # Execute
+        _flush_tracer_provider(mock_tracer, 5000, flush_results)
+
+        # Verify
+        assert flush_results == [("provider", True)]
+        mock_tracer.provider.force_flush.assert_called_once_with(timeout_millis=5000)
+        mock_safe_log.assert_any_call(
+            mock_tracer,
+            "debug",
+            "Provider force_flush completed",
+            honeyhive_data={"success": True, "operation": "provider_flush"},
+        )
+
+    @patch("honeyhive.tracer.lifecycle.flush.safe_log")
+    def test_flush_provider_exception(
+        self, mock_safe_log: Mock, mock_tracer: Mock
+    ) -> None:
+        """Test provider flush exception handling."""
+        # Setup
+        mock_tracer.provider.force_flush.side_effect = Exception("Provider error")
+        flush_results: List[tuple[str, bool]] = []
+
+        # Execute
+        _flush_tracer_provider(mock_tracer, 5000, flush_results)
+
+        # Verify - this tests lines 128-135
+        assert flush_results == [("provider", False)]
+        mock_safe_log.assert_any_call(
+            mock_tracer,
+            "error",
+            "Provider force_flush error",
+            honeyhive_data={
+                "error": "Provider error",
+                "error_type": "Exception",
+                "operation": "provider_flush",
+            },
+        )
+
+    @patch("honeyhive.tracer.lifecycle.flush.safe_log")
+    def test_flush_provider_exception_test_mode(
+        self, mock_safe_log: Mock, mock_tracer: Mock
+    ) -> None:
+        """Test provider flush exception handling in test mode."""
+        # Setup
+        mock_tracer.test_mode = True
+        mock_tracer.provider.force_flush.side_effect = Exception("Provider error")
+        flush_results: List[tuple[str, bool]] = []
+
+        # Execute
+        _flush_tracer_provider(mock_tracer, 5000, flush_results)
+
+        # Verify - this tests the test_mode branch in lines 130-134
+        assert flush_results == [("provider", False)]
+        # Should not log error in test mode
+        error_calls = [
+            call for call in mock_safe_log.call_args_list if call[0][0] == "error"
+        ]
+        assert len(error_calls) == 0
+
+    @patch("honeyhive.tracer.lifecycle.flush.safe_log")
+    def test_flush_provider_no_force_flush_method(
+        self, mock_safe_log: Mock, mock_tracer: Mock
+    ) -> None:
+        """Test provider without force_flush method."""
+        # Setup - provider exists but no force_flush method
+        del mock_tracer.provider.force_flush
+        flush_results: List[tuple[str, bool]] = []
+
+        # Execute
+        _flush_tracer_provider(mock_tracer, 5000, flush_results)
+
+        # Verify - this tests lines 136-139
+        assert flush_results == [("provider", True)]
+        mock_safe_log.assert_any_call(
+            mock_tracer,
+            "debug",
+            "Provider does not support force_flush",
+            honeyhive_data={"operation": "provider_flush"},
+        )
+
+    @patch("honeyhive.tracer.lifecycle.flush.safe_log")
+    def test_flush_provider_no_force_flush_method_test_mode(
+        self, mock_safe_log: Mock, mock_tracer: Mock
+    ) -> None:
+        """Test provider without force_flush method in test mode."""
+        # Setup
+        mock_tracer.test_mode = True
+        del mock_tracer.provider.force_flush
+        flush_results: List[tuple[str, bool]] = []
+
+        # Execute
+        _flush_tracer_provider(mock_tracer, 5000, flush_results)
+
+        # Verify - this tests the test_mode branch in lines 137-138
+        assert flush_results == [("provider", True)]
+        # Should not log debug in test mode
+        debug_calls = [
+            call for call in mock_safe_log.call_args_list if call[0][0] == "debug"
+        ]
+        assert len(debug_calls) == 0
+
+
+class TestFlushSpanProcessor:
+    """Test suite for _flush_span_processor function."""
+
+    @patch("honeyhive.tracer.lifecycle.flush.safe_log")
+    def test_flush_span_processor_success(
+        self, _mock_safe_log: Mock, mock_tracer: Mock
+    ) -> None:
+        """Test successful span processor flush."""
+        # Setup
+        mock_tracer.span_processor.force_flush.return_value = True
+        flush_results: List[tuple[str, bool]] = []
+
+        # Execute
+        _flush_span_processor(mock_tracer, 5000, flush_results)
+
+        # Verify
+        assert flush_results == [("span_processor", True)]
+        mock_tracer.span_processor.force_flush.assert_called_once_with(
+            timeout_millis=5000
+        )
+
+    @patch("honeyhive.tracer.lifecycle.flush.safe_log")
+    def test_flush_span_processor_exception(
+        self, mock_safe_log: Mock, mock_tracer: Mock
+    ) -> None:
+        """Test span processor flush exception handling."""
+        # Setup
+        mock_tracer.span_processor.force_flush.side_effect = Exception(
+            "Processor error"
+        )
+        flush_results: List[tuple[str, bool]] = []
+
+        # Execute
+        _flush_span_processor(mock_tracer, 5000, flush_results)
+
+        # Verify - this tests lines 168-175
+        assert flush_results == [("span_processor", False)]
+        mock_safe_log.assert_any_call(
+            mock_tracer,
+            "error",
+            "Span processor force_flush error",
+            honeyhive_data={
+                "error": "Processor error",
+                "error_type": "Exception",
+                "operation": "span_processor_flush",
+            },
+        )
+
+    @patch("honeyhive.tracer.lifecycle.flush.safe_log")
+    def test_flush_span_processor_exception_test_mode(
+        self, mock_safe_log: Mock, mock_tracer: Mock
+    ) -> None:
+        """Test span processor flush exception handling in test mode."""
+        # Setup
+        mock_tracer.test_mode = True
+        mock_tracer.span_processor.force_flush.side_effect = Exception(
+            "Processor error"
+        )
+        flush_results: List[tuple[str, bool]] = []
+
+        # Execute
+        _flush_span_processor(mock_tracer, 5000, flush_results)
+
+        # Verify - this tests the test_mode branch in lines 170-174
+        assert flush_results == [("span_processor", False)]
+        # Should not log error in test mode
+        error_calls = [
+            call for call in mock_safe_log.call_args_list if call[0][0] == "error"
+        ]
+        assert len(error_calls) == 0
+
+    def test_flush_span_processor_no_processor(self, mock_tracer: Mock) -> None:
+        """Test when span processor is None."""
+        # Setup
+        mock_tracer.span_processor = None
+        flush_results: List[tuple[str, bool]] = []
+
+        # Execute
+        _flush_span_processor(mock_tracer, 5000, flush_results)
+
+        # Verify - this tests lines 176-179
+        assert flush_results == [("span_processor", True)]
+
+
+class TestGetBatchProcessors:
+    """Test suite for _get_batch_processors function."""
+
+    def test_get_batch_processors_success(self, mock_tracer: Mock) -> None:
+        """Test successful batch processor extraction."""
+        # Setup
+        mock_processor1 = Mock()
+        mock_processor1.force_flush = Mock()
+        mock_processor2 = Mock()  # No force_flush method
+        # Remove force_flush attribute to ensure it's not detected
+        if hasattr(mock_processor2, "force_flush"):
+            delattr(mock_processor2, "force_flush")
+        mock_processor3 = Mock()
+        mock_processor3.force_flush = Mock()
+
+        mock_tracer.provider._span_processors = [
+            mock_processor1,
+            mock_processor2,
+            mock_processor3,
+        ]
+
+        # Execute
+        result = _get_batch_processors(mock_tracer)
+
+        # Verify
+        assert len(result) == 2
+        assert mock_processor1 in result
+        assert mock_processor3 in result
+        assert mock_processor2 not in result
+
+    def test_get_batch_processors_no_provider(self, mock_tracer: Mock) -> None:
+        """Test when provider is None."""
+        # Setup
+        mock_tracer.provider = None
+
+        # Execute
+        result = _get_batch_processors(mock_tracer)
+
+        # Verify - this tests line 188
+        assert not result
+
+    def test_get_batch_processors_no_span_processors_attr(
+        self, mock_tracer: Mock
+    ) -> None:
+        """Test when provider has no _span_processors attribute."""
+        # Setup
+        del mock_tracer.provider._span_processors
+
+        # Execute
+        result = _get_batch_processors(mock_tracer)
+
+        # Verify - this tests lines 192-194
+        assert not result
+
+
+class TestFlushSingleProcessor:
+    """Test suite for _flush_single_processor function."""
+
+    @patch("honeyhive.tracer.lifecycle.flush.safe_log")
+    def test_flush_single_processor_success(
+        self, mock_safe_log: Mock, mock_tracer: Mock
+    ) -> None:
+        """Test successful single processor flush."""
+        # Setup
+        mock_processor = Mock()
+        mock_processor.force_flush.return_value = True
+
+        # Execute
+        result = _flush_single_processor(mock_processor, 5000, 1, mock_tracer)
+
+        # Verify
+        assert result is True
+        mock_processor.force_flush.assert_called_once_with(timeout_millis=5000)
+        mock_safe_log.assert_any_call(
+            mock_tracer,
+            "debug",
+            "Batch processor force_flush completed",
+            honeyhive_data={
+                "processor_index": 1,
+                "success": True,
+                "operation": "batch_processor_flush",
+            },
+        )
+
+    @patch("honeyhive.tracer.lifecycle.flush.safe_log")
+    def test_flush_single_processor_exception(
+        self, mock_safe_log: Mock, mock_tracer: Mock
+    ) -> None:
+        """Test single processor flush exception handling."""
+        # Setup
+        mock_processor = Mock()
+        mock_processor.force_flush.side_effect = Exception("Single processor error")
+
+        # Execute
+        result = _flush_single_processor(mock_processor, 5000, 2, mock_tracer)
+
+        # Verify - this tests lines 213-223
+        assert result is False
+        mock_safe_log.assert_any_call(
+            mock_tracer,
+            "error",
+            "Batch processor force_flush error",
+            honeyhive_data={
+                "processor_index": 2,
+                "error": "Single processor error",
+                "error_type": "Exception",
+                "operation": "batch_processor_flush",
+            },
+        )
+
+    @patch("honeyhive.tracer.lifecycle.flush.safe_log")
+    def test_flush_single_processor_exception_test_mode(
+        self, mock_safe_log: Mock, mock_tracer: Mock
+    ) -> None:
+        """Test single processor flush exception handling in test mode."""
+        # Setup
+        mock_tracer.test_mode = True
+        mock_processor = Mock()
+        mock_processor.force_flush.side_effect = Exception("Single processor error")
+
+        # Execute
+        result = _flush_single_processor(mock_processor, 5000, 2, mock_tracer)
+
+        # Verify - this tests the test_mode branch in lines 214-222
+        assert result is False
+        # Should not log error in test mode
+        error_calls = [
+            call for call in mock_safe_log.call_args_list if call[0][0] == "error"
+        ]
+        assert len(error_calls) == 0
+
+
+class TestFlushBatchProcessors:
+    """Test suite for _flush_batch_processors function."""
+
+    @patch("honeyhive.tracer.lifecycle.flush._get_batch_processors")
+    @patch("honeyhive.tracer.lifecycle.flush._flush_single_processor")
+    def test_flush_batch_processors_success(
+        self, mock_flush_single: Mock, mock_get_processors: Mock, mock_tracer: Mock
+    ) -> None:
+        """Test successful batch processors flush."""
+        # Setup
+        mock_processor1 = Mock()
+        mock_processor2 = Mock()
+        mock_get_processors.return_value = [mock_processor1, mock_processor2]
+        mock_flush_single.side_effect = [True, True]
+        flush_results: List[tuple[str, bool]] = []
+
+        # Execute
+        _flush_batch_processors(mock_tracer, 5000, flush_results)
+
+        # Verify - this tests lines 245-252
+        assert flush_results == [("batch_processors", True)]
+        assert mock_flush_single.call_count == 2
+        mock_flush_single.assert_any_call(mock_processor1, 5000, 1, mock_tracer)
+        mock_flush_single.assert_any_call(mock_processor2, 5000, 2, mock_tracer)
+
+    @patch("honeyhive.tracer.lifecycle.flush._get_batch_processors")
+    def test_flush_batch_processors_no_processors(
+        self, mock_get_processors: Mock, mock_tracer: Mock
+    ) -> None:
+        """Test when no batch processors are found."""
+        # Setup
+        mock_get_processors.return_value = []
+        flush_results: List[tuple[str, bool]] = []
+
+        # Execute
+        _flush_batch_processors(mock_tracer, 5000, flush_results)
+
+        # Verify - this tests lines 241-243
+        assert flush_results == [("batch_processors", True)]
+
+    @patch("honeyhive.tracer.lifecycle.flush.safe_log")
+    @patch("honeyhive.tracer.lifecycle.flush._get_batch_processors")
+    def test_flush_batch_processors_exception(
+        self, mock_get_processors: Mock, mock_safe_log: Mock, mock_tracer: Mock
+    ) -> None:
+        """Test batch processors flush exception handling."""
+        # Setup
+        mock_get_processors.side_effect = Exception("Batch error")
+        flush_results: List[tuple[str, bool]] = []
+
+        # Execute
+        _flush_batch_processors(mock_tracer, 5000, flush_results)
+
+        # Verify
+        assert flush_results == [("batch_processors", False)]
+        mock_safe_log.assert_any_call(
+            mock_tracer,
+            "error",
+            "Batch processors flush error",
+            honeyhive_data={
+                "error": "Batch error",
+                "error_type": "Exception",
+                "operation": "batch_processors_flush",
+            },
+        )
+
+
+class TestLogFlushResults:
+    """Test suite for _log_flush_results function."""
+
+    @patch("honeyhive.tracer.lifecycle.flush.safe_log")
+    def test_log_flush_results_success(
+        self, mock_safe_log: Mock, mock_tracer: Mock
+    ) -> None:
+        """Test logging successful flush results."""
+        # Setup
+        flush_results = [
+            ("provider", True),
+            ("span_processor", True),
+            ("batch_processors", True),
+        ]
+
+        # Execute
+        _log_flush_results(mock_tracer, True, flush_results)
+
+        # Verify - this tests line 280
+        mock_safe_log.assert_any_call(
+            mock_tracer,
+            "info",
+            "Force flush completed successfully",
+            honeyhive_data={
+                "components_flushed": 3,
+                "all_successful": True,
+            },
+        )
+
+    @patch("honeyhive.tracer.lifecycle.flush.safe_log")
+    def test_log_flush_results_failure(
+        self, mock_safe_log: Mock, mock_tracer: Mock
+    ) -> None:
+        """Test logging failed flush results."""
+        # Setup
+        flush_results = [
+            ("provider", True),
+            ("span_processor", False),
+            ("batch_processors", True),
+        ]
+
+        # Execute
+        _log_flush_results(mock_tracer, False, flush_results)
+
+        # Verify
+        mock_safe_log.assert_any_call(
+            mock_tracer,
+            "warning",
+            "Force flush completed with failures",
+            honeyhive_data={
+                "failed_components": ["span_processor"],
+                "total_components": 3,
+                "success_rate": "2/3",
+            },
+        )
+
+    @patch("honeyhive.tracer.lifecycle.flush.safe_log")
+    def test_log_flush_results_test_mode(
+        self, mock_safe_log: Mock, mock_tracer: Mock
+    ) -> None:
+        """Test logging in test mode (should not log)."""
+        # Setup
+        mock_tracer.test_mode = True
+        flush_results = [("provider", True)]
+
+        # Execute
+        _log_flush_results(mock_tracer, True, flush_results)
+
+        # Verify - this tests line 277
+        mock_safe_log.assert_not_called()

--- a/tests_v2/unit/test_tracer_lifecycle_shutdown.py
+++ b/tests_v2/unit/test_tracer_lifecycle_shutdown.py
@@ -1,0 +1,1152 @@
+"""Unit tests for tracer lifecycle shutdown functionality.
+
+This module tests the shutdown and cleanup operations for tracer lifecycle management,
+including graceful shutdown, provider cleanup, resource management, timeout protection,
+and graceful degradation patterns.
+
+Test Coverage:
+- shutdown_tracer() with all branches and error conditions
+- graceful_shutdown_all() with multiple tracers and failures
+- wait_for_pending_spans() with timeout and completion scenarios
+- Private helper functions for comprehensive coverage
+- Lock acquisition timeout and graceful degradation
+- Provider shutdown with timeout protection
+- Registry cleanup and state management
+- Error handling and logging verification
+
+Following Agent OS testing standards with proper fixtures and isolation.
+Generated using enhanced comprehensive analysis framework for 90%+ coverage.
+"""
+
+# pylint: disable=too-many-lines,line-too-long,redefined-outer-name,protected-access
+# pylint: disable=too-few-public-methods,R0917
+# Reason: Comprehensive testing file requires extensive test coverage for 90%+ target
+# Line length disabled for test readability and comprehensive assertions
+# Redefined outer name disabled for pytest fixture usage pattern
+# Protected access needed for testing internal tracer state
+# Too few public methods acceptable for test helper classes
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from honeyhive.tracer.lifecycle.shutdown import (
+    _check_processor_pending_spans,
+    _cleanup_secondary_provider,
+    _cleanup_tracer_state,
+    _has_pending_spans,
+    _shutdown_main_provider,
+    _shutdown_without_lock,
+    graceful_shutdown_all,
+    shutdown_tracer,
+    wait_for_pending_spans,
+)
+
+
+class TestShutdownTracer:
+    """Test cases for shutdown_tracer function."""
+
+    @pytest.fixture
+    def mock_tracer(self) -> Mock:
+        """Create a mock tracer instance for testing."""
+        tracer = Mock()
+        tracer.test_mode = False
+        tracer.is_main_provider = True
+        tracer.provider = Mock()
+        tracer.provider.shutdown = Mock()
+        tracer._instance_shutdown = False
+        tracer._tracer_id = "test-tracer-123"
+        tracer._initialized = True
+        tracer.tracer = Mock()
+        tracer.span_processor = Mock()
+        tracer.propagator = Mock()
+        return tracer
+
+    @pytest.fixture
+    def mock_secondary_tracer(self) -> Mock:
+        """Create a mock secondary tracer instance for testing."""
+        tracer = Mock()
+        tracer.test_mode = False
+        tracer.is_main_provider = False
+        tracer.provider = Mock()
+        tracer.provider.shutdown = Mock()
+        tracer._instance_shutdown = False
+        tracer._tracer_id = "test-tracer-456"
+        tracer._initialized = True
+        tracer.tracer = Mock()
+        tracer.span_processor = Mock()
+        tracer.propagator = Mock()
+        return tracer
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    @patch("honeyhive.tracer.lifecycle.shutdown.force_flush_tracer")
+    @patch("honeyhive.tracer.lifecycle.shutdown.disable_new_span_creation")
+    @patch("honeyhive.tracer.lifecycle.shutdown.acquire_lifecycle_lock_optimized")
+    @patch("honeyhive.tracer.lifecycle.shutdown._shutdown_main_provider")
+    @patch("honeyhive.tracer.lifecycle.shutdown._cleanup_tracer_state")
+    def test_shutdown_tracer_success_main_provider(
+        self,
+        mock_cleanup_state: Mock,
+        mock_shutdown_main: Mock,
+        mock_acquire_lock: Mock,
+        mock_disable_spans: Mock,
+        mock_force_flush: Mock,
+        mock_safe_log: Mock,
+        mock_tracer: Mock,
+    ) -> None:
+        """Test successful shutdown of main provider tracer."""
+        # Setup
+        mock_force_flush.return_value = True
+        mock_acquire_lock.return_value.__enter__.return_value = True
+        mock_acquire_lock.return_value.__exit__.return_value = None
+
+        # Execute
+        shutdown_tracer(mock_tracer)
+
+        # Verify
+        mock_safe_log.assert_any_call(
+            mock_tracer, "debug", "shutdown_tracer: Starting data loss prevention phase"
+        )
+        mock_disable_spans.assert_called_once()
+        assert mock_tracer._instance_shutdown is True
+        mock_force_flush.assert_called_once_with(mock_tracer, timeout_millis=5000)
+        mock_acquire_lock.assert_called_once_with("lifecycle")
+        mock_shutdown_main.assert_called_once_with(mock_tracer)
+        mock_cleanup_state.assert_called_once_with(mock_tracer)
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    @patch("honeyhive.tracer.lifecycle.shutdown.force_flush_tracer")
+    @patch("honeyhive.tracer.lifecycle.shutdown.acquire_lifecycle_lock_optimized")
+    @patch("honeyhive.tracer.lifecycle.shutdown._cleanup_secondary_provider")
+    @patch("honeyhive.tracer.lifecycle.shutdown._cleanup_tracer_state")
+    def test_shutdown_tracer_success_secondary_provider(
+        self,
+        mock_cleanup_state: Mock,
+        mock_cleanup_secondary: Mock,
+        mock_acquire_lock: Mock,
+        mock_force_flush: Mock,
+        _mock_safe_log: Mock,
+        mock_secondary_tracer: Mock,
+    ) -> None:
+        """Test successful shutdown of secondary provider tracer."""
+        # Setup
+        mock_force_flush.return_value = True
+        mock_acquire_lock.return_value.__enter__.return_value = True
+        mock_acquire_lock.return_value.__exit__.return_value = None
+
+        # Execute
+        shutdown_tracer(mock_secondary_tracer)
+
+        # Verify
+        mock_cleanup_secondary.assert_called_once_with(mock_secondary_tracer)
+        mock_cleanup_state.assert_called_once_with(mock_secondary_tracer)
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    @patch("honeyhive.tracer.lifecycle.shutdown.force_flush_tracer")
+    def test_shutdown_tracer_test_mode_skips_flush(
+        self,
+        mock_force_flush: Mock,
+        mock_safe_log: Mock,
+        mock_tracer: Mock,
+    ) -> None:
+        """Test that test mode skips pre-lock flush to prevent conflicts."""
+        # Setup
+        mock_tracer.test_mode = True
+
+        with patch(
+            "honeyhive.tracer.lifecycle.shutdown.acquire_lifecycle_lock_optimized"
+        ) as mock_lock:
+            mock_lock.return_value.__enter__.return_value = True
+            mock_lock.return_value.__exit__.return_value = None
+
+            # Execute
+            shutdown_tracer(mock_tracer)
+
+            # Verify
+            mock_safe_log.assert_any_call(
+                mock_tracer,
+                "debug",
+                "Skipping pre-lock flush in test mode to prevent conflicts",
+            )
+            mock_force_flush.assert_not_called()
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    @patch("honeyhive.tracer.lifecycle.shutdown.force_flush_tracer")
+    @patch("honeyhive.tracer.lifecycle.shutdown.acquire_lifecycle_lock_optimized")
+    def test_shutdown_tracer_flush_retry_success(
+        self,
+        mock_acquire_lock: Mock,
+        mock_force_flush: Mock,
+        mock_safe_log: Mock,
+        mock_tracer: Mock,
+    ) -> None:
+        """Test successful flush on retry after initial failure."""
+        # Setup
+        mock_force_flush.side_effect = [False, True]  # Fail first, succeed on retry
+        mock_acquire_lock.return_value.__enter__.return_value = True
+        mock_acquire_lock.return_value.__exit__.return_value = None
+
+        # Execute
+        shutdown_tracer(mock_tracer)
+
+        # Verify
+        assert mock_force_flush.call_count == 2
+        mock_safe_log.assert_any_call(
+            mock_tracer,
+            "warning",
+            "Pre-lock flush failed (timeout: 5000ms), retrying",
+        )
+        mock_safe_log.assert_any_call(
+            mock_tracer,
+            "info",
+            "Pre-lock flush succeeded on retry (10000ms)",
+        )
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    @patch("honeyhive.tracer.lifecycle.shutdown.force_flush_tracer")
+    @patch("honeyhive.tracer.lifecycle.shutdown.acquire_lifecycle_lock_optimized")
+    def test_shutdown_tracer_flush_retry_failure(
+        self,
+        mock_acquire_lock: Mock,
+        mock_force_flush: Mock,
+        mock_safe_log: Mock,
+        mock_tracer: Mock,
+    ) -> None:
+        """Test flush failure on both initial attempt and retry."""
+        # Setup
+        mock_force_flush.return_value = False
+        mock_acquire_lock.return_value.__enter__.return_value = True
+        mock_acquire_lock.return_value.__exit__.return_value = None
+
+        # Execute
+        shutdown_tracer(mock_tracer)
+
+        # Verify
+        assert mock_force_flush.call_count == 2
+        mock_safe_log.assert_any_call(
+            mock_tracer,
+            "error",
+            "Pre-lock flush failed after retry (10000ms), continuing with shutdown - potential data loss",
+        )
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    @patch("honeyhive.tracer.lifecycle.shutdown.force_flush_tracer")
+    @patch("honeyhive.tracer.lifecycle.shutdown.acquire_lifecycle_lock_optimized")
+    @patch("honeyhive.tracer.lifecycle.shutdown.get_lock_config")
+    @patch("honeyhive.tracer.lifecycle.shutdown._shutdown_without_lock")
+    def test_shutdown_tracer_lock_timeout(
+        self,
+        mock_shutdown_without_lock: Mock,
+        mock_get_lock_config: Mock,
+        mock_acquire_lock: Mock,
+        mock_force_flush: Mock,
+        mock_safe_log: Mock,
+        mock_tracer: Mock,
+    ) -> None:
+        """Test graceful degradation when lock acquisition times out."""
+        # Setup
+        mock_force_flush.return_value = True
+        mock_acquire_lock.return_value.__enter__.return_value = False
+        mock_acquire_lock.return_value.__exit__.return_value = None
+        mock_get_lock_config.return_value = {
+            "lifecycle_timeout": 2.0,
+            "description": "test config",
+        }
+
+        # Execute
+        shutdown_tracer(mock_tracer)
+
+        # Verify
+        mock_safe_log.assert_any_call(
+            mock_tracer,
+            "warning",
+            "Failed to acquire _lifecycle_lock within 2.0s, proceeding without lock",
+            honeyhive_data={
+                "lock_timeout": 2.0,
+                "lock_strategy": "test config",
+                "degradation_reason": "lock_acquisition_timeout",
+                "data_flush_completed": True,
+            },
+        )
+        mock_shutdown_without_lock.assert_called_once_with(mock_tracer)
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    def test_shutdown_tracer_exception_handling(
+        self,
+        mock_safe_log: Mock,
+        mock_tracer: Mock,
+    ) -> None:
+        """Test exception handling during shutdown process."""
+        # Setup - Remove provider to cause AttributeError in shutdown logic
+        mock_tracer.provider = None
+
+        with patch(
+            "honeyhive.tracer.lifecycle.shutdown.acquire_lifecycle_lock_optimized"
+        ) as mock_lock:
+            mock_lock.return_value.__enter__.return_value = True
+            mock_lock.return_value.__exit__.return_value = None
+
+            # Execute - this should not crash despite the error
+            shutdown_tracer(mock_tracer)
+
+            # Verify - function completed without crashing
+            assert mock_safe_log.called  # Some logging should have occurred
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    def test_shutdown_tracer_no_provider(
+        self,
+        mock_safe_log: Mock,
+        mock_tracer: Mock,
+    ) -> None:
+        """Test shutdown when tracer has no provider."""
+        # Setup
+        mock_tracer.provider = None
+
+        with patch(
+            "honeyhive.tracer.lifecycle.shutdown.acquire_lifecycle_lock_optimized"
+        ) as mock_lock:
+            mock_lock.return_value.__enter__.return_value = True
+            mock_lock.return_value.__exit__.return_value = None
+
+            # Execute
+            shutdown_tracer(mock_tracer)
+
+            # Verify - should not crash and should clean up state
+            mock_safe_log.assert_any_call(
+                mock_tracer,
+                "debug",
+                "Starting tracer shutdown",
+                honeyhive_data={
+                    "is_main_provider": True,
+                    "has_provider": False,
+                },
+            )
+
+
+class TestShutdownWithoutLock:
+    """Test cases for _shutdown_without_lock function."""
+
+    @pytest.fixture
+    def mock_tracer(self) -> Mock:
+        """Create a mock tracer instance for testing."""
+        tracer = Mock()
+        tracer.test_mode = False
+        tracer.is_main_provider = True
+        tracer.provider = Mock()
+        tracer.provider.shutdown = Mock()
+        tracer._instance_shutdown = False
+        return tracer
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    @patch("honeyhive.tracer.lifecycle.shutdown.force_flush_tracer")
+    @patch("honeyhive.tracer.lifecycle.shutdown.disable_new_span_creation")
+    @patch("honeyhive.tracer.lifecycle.shutdown._shutdown_main_provider")
+    @patch("honeyhive.tracer.lifecycle.shutdown._cleanup_tracer_state")
+    def test_shutdown_without_lock_success(
+        self,
+        mock_cleanup_state: Mock,
+        mock_shutdown_main: Mock,
+        mock_disable_spans: Mock,
+        mock_force_flush: Mock,
+        mock_safe_log: Mock,
+        mock_tracer: Mock,
+    ) -> None:
+        """Test successful shutdown without lock."""
+        # Setup
+        mock_force_flush.return_value = True
+
+        # Execute
+        _shutdown_without_lock(mock_tracer)
+
+        # Verify
+        mock_safe_log.assert_any_call(
+            mock_tracer,
+            "debug",
+            "Starting tracer shutdown WITHOUT LOCK (graceful degradation)",
+            honeyhive_data={
+                "is_main_provider": True,
+                "has_provider": True,
+            },
+        )
+        mock_disable_spans.assert_called_once()
+        assert mock_tracer._instance_shutdown is True
+        mock_force_flush.assert_called_once_with(mock_tracer, timeout_millis=5000)
+        mock_shutdown_main.assert_called_once_with(mock_tracer)
+        mock_cleanup_state.assert_called_once_with(mock_tracer)
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    @patch("honeyhive.tracer.lifecycle.shutdown.force_flush_tracer")
+    def test_shutdown_without_lock_test_mode(
+        self,
+        mock_force_flush: Mock,
+        mock_safe_log: Mock,
+        mock_tracer: Mock,
+    ) -> None:
+        """Test shutdown without lock in test mode skips flush."""
+        # Setup
+        mock_tracer.test_mode = True
+
+        # Execute
+        _shutdown_without_lock(mock_tracer)
+
+        # Verify
+        mock_safe_log.assert_any_call(
+            mock_tracer,
+            "debug",
+            "Skipping flush in test mode to prevent conflicts",
+        )
+        mock_force_flush.assert_not_called()
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    @patch("honeyhive.tracer.lifecycle.shutdown.force_flush_tracer")
+    def test_shutdown_without_lock_flush_retry(
+        self,
+        mock_force_flush: Mock,
+        mock_safe_log: Mock,
+        mock_tracer: Mock,
+    ) -> None:
+        """Test flush retry logic in shutdown without lock."""
+        # Setup
+        mock_force_flush.side_effect = [False, True]  # Fail first, succeed on retry
+
+        # Execute
+        _shutdown_without_lock(mock_tracer)
+
+        # Verify
+        assert mock_force_flush.call_count == 2
+        mock_safe_log.assert_any_call(
+            mock_tracer,
+            "warning",
+            "Initial flush failed (timeout: 5000ms), retrying",
+        )
+        mock_safe_log.assert_any_call(
+            mock_tracer,
+            "info",
+            "Flush succeeded on retry (timeout: 10000ms)",
+        )
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    @patch("honeyhive.tracer.lifecycle.shutdown._cleanup_tracer_state")
+    def test_shutdown_without_lock_exception_handling(
+        self,
+        mock_cleanup_state: Mock,
+        mock_safe_log: Mock,
+        mock_tracer: Mock,
+    ) -> None:
+        """Test exception handling in shutdown without lock."""
+        # Setup - cause an exception during cleanup
+        mock_cleanup_state.side_effect = Exception("Cleanup error")
+
+        # Execute
+        _shutdown_without_lock(mock_tracer)
+
+        # Verify
+        mock_safe_log.assert_any_call(
+            mock_tracer,
+            "error",
+            "Error during tracer shutdown (without lock)",
+            honeyhive_data={
+                "error": "Cleanup error",
+                "error_type": "Exception",
+                "operation": "tracer_shutdown_without_lock",
+            },
+        )
+
+
+class TestShutdownMainProvider:
+    """Test cases for _shutdown_main_provider function."""
+
+    @pytest.fixture
+    def mock_tracer(self) -> Mock:
+        """Create a mock tracer instance for testing."""
+        tracer = Mock()
+        tracer.test_mode = False
+        tracer.provider = Mock()
+        tracer.provider.shutdown = Mock()
+        return tracer
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    @patch("honeyhive.tracer.lifecycle.shutdown.ThreadPoolExecutor")
+    def test_shutdown_main_provider_success(
+        self,
+        mock_executor_class: Mock,
+        mock_safe_log: Mock,
+        mock_tracer: Mock,
+    ) -> None:
+        """Test successful main provider shutdown."""
+        # Setup
+        mock_executor = Mock()
+        mock_executor_class.return_value.__enter__.return_value = mock_executor
+        mock_executor_class.return_value.__exit__.return_value = None
+        mock_future = Mock()
+        mock_executor.submit.return_value = mock_future
+        mock_future.result.return_value = None
+
+        # Execute
+        _shutdown_main_provider(mock_tracer)
+
+        # Verify
+        mock_executor.submit.assert_called_once_with(mock_tracer.provider.shutdown)
+        mock_future.result.assert_called_once_with(timeout=5.0)
+        mock_safe_log.assert_any_call(
+            mock_tracer,
+            "info",
+            "Main tracer provider shut down successfully",
+            honeyhive_data={
+                "provider_type": "main",
+                "timeout_seconds": 5.0,
+            },
+        )
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    @patch("honeyhive.tracer.lifecycle.shutdown.ThreadPoolExecutor")
+    def test_shutdown_main_provider_test_mode_timeout(
+        self,
+        mock_executor_class: Mock,
+        mock_tracer: Mock,
+    ) -> None:
+        """Test main provider shutdown with test mode timeout."""
+        # Setup
+        mock_tracer.test_mode = True
+        mock_executor = Mock()
+        mock_executor_class.return_value.__enter__.return_value = mock_executor
+        mock_executor_class.return_value.__exit__.return_value = None
+        mock_future = Mock()
+        mock_executor.submit.return_value = mock_future
+        mock_future.result.return_value = None
+
+        # Execute
+        _shutdown_main_provider(mock_tracer)
+
+        # Verify
+        mock_future.result.assert_called_once_with(timeout=1.0)
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    @patch("honeyhive.tracer.lifecycle.shutdown.ThreadPoolExecutor")
+    def test_shutdown_main_provider_timeout(
+        self,
+        mock_executor_class: Mock,
+        mock_safe_log: Mock,
+        mock_tracer: Mock,
+    ) -> None:
+        """Test main provider shutdown timeout handling."""
+        # Setup
+        mock_executor = Mock()
+        mock_executor_class.return_value.__enter__.return_value = mock_executor
+        mock_executor_class.return_value.__exit__.return_value = None
+        mock_future = Mock()
+        mock_executor.submit.return_value = mock_future
+        mock_future.result.side_effect = Exception("Timeout")
+
+        # Execute
+        _shutdown_main_provider(mock_tracer)
+
+        # Verify
+        mock_safe_log.assert_any_call(
+            mock_tracer,
+            "warning",
+            "Provider shutdown timed out after 5.0s, proceeding anyway (graceful degradation)",
+            honeyhive_data={
+                "provider_type": "main",
+                "timeout_seconds": 5.0,
+                "degradation_reason": "shutdown_timeout",
+                "error_type": "Exception",
+            },
+        )
+        mock_future.cancel.assert_called_once()
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    @patch("honeyhive.tracer.lifecycle.shutdown.ThreadPoolExecutor")
+    def test_shutdown_main_provider_with_proxy_reset(
+        self,
+        mock_executor_class: Mock,
+        mock_safe_log: Mock,
+        mock_tracer: Mock,
+    ) -> None:
+        """Test main provider shutdown with proxy provider reset."""
+        # Setup
+        mock_executor = Mock()
+        mock_executor_class.return_value.__enter__.return_value = mock_executor
+        mock_executor_class.return_value.__exit__.return_value = None
+        mock_future = Mock()
+        mock_executor.submit.return_value = mock_future
+        mock_future.result.return_value = None
+
+        with patch("opentelemetry.trace.ProxyTracerProvider") as mock_proxy:
+            with patch(
+                "honeyhive.tracer.integration.detection.set_global_provider"
+            ) as mock_set_global:
+                mock_proxy_instance = Mock()
+                mock_proxy.return_value = mock_proxy_instance
+
+                # Execute
+                _shutdown_main_provider(mock_tracer)
+
+                # Verify
+                mock_proxy.assert_called_once()
+                mock_set_global.assert_called_once_with(
+                    mock_proxy_instance, force_override=True
+                )
+                mock_safe_log.assert_any_call(
+                    mock_tracer,
+                    "debug",
+                    "Reset global TracerProvider to ProxyTracerProvider",
+                    honeyhive_data={
+                        "reason": "main_provider_shutdown_cleanup",
+                        "allows_new_main_providers": True,
+                    },
+                )
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    def test_shutdown_main_provider_exception(
+        self,
+        mock_safe_log: Mock,
+        mock_tracer: Mock,
+    ) -> None:
+        """Test exception handling in main provider shutdown."""
+        # Setup - cause an exception
+        mock_tracer.provider = None
+
+        # Execute
+        _shutdown_main_provider(mock_tracer)
+
+        # Verify
+        mock_safe_log.assert_any_call(
+            mock_tracer,
+            "error",
+            "Error shutting down main provider",
+            honeyhive_data={
+                "error": "'NoneType' object has no attribute 'shutdown'",
+                "error_type": "AttributeError",
+                "operation": "shutdown_main_provider",
+            },
+        )
+
+
+class TestCleanupSecondaryProvider:
+    """Test cases for _cleanup_secondary_provider function."""
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    def test_cleanup_secondary_provider(self, mock_safe_log: Mock) -> None:
+        """Test cleanup of secondary provider."""
+        # Setup
+        mock_tracer = Mock()
+
+        # Execute
+        _cleanup_secondary_provider(mock_tracer)
+
+        # Verify
+        mock_safe_log.assert_called_once_with(
+            mock_tracer,
+            "info",
+            "Tracer instance closed (secondary provider)",
+            honeyhive_data={
+                "provider_type": "secondary",
+                "note": "Provider left running for other instances",
+            },
+        )
+
+
+class TestCleanupTracerState:
+    """Test cases for _cleanup_tracer_state function."""
+
+    @pytest.fixture
+    def mock_tracer(self) -> Mock:
+        """Create a mock tracer instance for testing."""
+        tracer = Mock()
+        tracer.is_main_provider = True
+        tracer._tracer_id = "test-tracer-123"
+        tracer._initialized = True
+        tracer.tracer = Mock()
+        tracer.span_processor = Mock()
+        tracer.propagator = Mock()
+        tracer.provider = Mock()
+        return tracer
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    @patch("honeyhive.tracer.lifecycle.shutdown.registry")
+    def test_cleanup_tracer_state_success(
+        self,
+        mock_registry: Mock,
+        mock_safe_log: Mock,
+        mock_tracer: Mock,
+    ) -> None:
+        """Test successful tracer state cleanup."""
+        # Setup
+        mock_registry.unregister_tracer.return_value = True
+
+        # Execute
+        _cleanup_tracer_state(mock_tracer)
+
+        # Verify
+        mock_registry.unregister_tracer.assert_called_once_with("test-tracer-123")
+        mock_safe_log.assert_any_call(
+            mock_tracer,
+            "debug",
+            "Tracer unregistered from auto-discovery",
+            honeyhive_data={"tracer_id": "test-tracer-123"},
+        )
+        mock_safe_log.assert_any_call(
+            mock_tracer, "debug", "Tracer instance state cleaned up"
+        )
+
+        # Verify state cleanup
+        assert mock_tracer.tracer is None
+        assert mock_tracer.span_processor is None
+        assert mock_tracer.propagator is None
+        assert mock_tracer._initialized is False
+        assert mock_tracer.provider is None  # Main provider clears provider
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    @patch("honeyhive.tracer.lifecycle.shutdown.registry")
+    def test_cleanup_tracer_state_secondary_provider(
+        self,
+        _mock_registry: Mock,
+        _mock_safe_log: Mock,
+        mock_tracer: Mock,
+    ) -> None:
+        """Test tracer state cleanup for secondary provider."""
+        # Setup
+        mock_tracer.is_main_provider = False
+        original_provider = mock_tracer.provider
+
+        # Execute
+        _cleanup_tracer_state(mock_tracer)
+
+        # Verify
+        # Secondary provider should not clear provider reference
+        assert mock_tracer.provider is original_provider
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    @patch("honeyhive.tracer.lifecycle.shutdown.registry")
+    def test_cleanup_tracer_state_no_tracer_id(
+        self,
+        mock_registry: Mock,
+        mock_safe_log: Mock,
+        mock_tracer: Mock,
+    ) -> None:
+        """Test tracer state cleanup when no tracer ID is present."""
+        # Setup
+        mock_tracer._tracer_id = None
+
+        # Execute
+        _cleanup_tracer_state(mock_tracer)
+
+        # Verify
+        mock_registry.unregister_tracer.assert_not_called()
+        mock_safe_log.assert_any_call(
+            mock_tracer, "debug", "Tracer instance state cleaned up"
+        )
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    @patch("honeyhive.tracer.lifecycle.shutdown.registry")
+    def test_cleanup_tracer_state_unregister_failure(
+        self,
+        mock_registry: Mock,
+        mock_safe_log: Mock,
+        mock_tracer: Mock,
+    ) -> None:
+        """Test tracer state cleanup when unregister fails."""
+        # Setup
+        mock_registry.unregister_tracer.side_effect = Exception("Unregister failed")
+
+        # Execute
+        _cleanup_tracer_state(mock_tracer)
+
+        # Verify
+        mock_safe_log.assert_any_call(
+            mock_tracer,
+            "warning",
+            "Failed to unregister tracer: Unregister failed",
+            honeyhive_data={
+                "error_type": "Exception",
+                "operation": "unregister_tracer",
+            },
+        )
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    def test_cleanup_tracer_state_exception(
+        self,
+        mock_safe_log: Mock,
+        mock_tracer: Mock,
+    ) -> None:
+        """Test exception handling in tracer state cleanup."""
+        # Setup - Remove required attributes to cause exceptions
+        del mock_tracer._tracer_id
+        del mock_tracer._initialized
+
+        # Execute - should not crash despite missing attributes
+        _cleanup_tracer_state(mock_tracer)
+
+        # Verify - function completed without crashing
+        assert mock_safe_log.called  # Some logging should have occurred
+
+
+class TestGracefulShutdownAll:
+    """Test cases for graceful_shutdown_all function."""
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    @patch("honeyhive.tracer.lifecycle.shutdown.registry")
+    @patch("honeyhive.tracer.lifecycle.shutdown.shutdown_tracer")
+    def test_graceful_shutdown_all_success(
+        self,
+        mock_shutdown_tracer: Mock,
+        mock_registry: Mock,
+        mock_safe_log: Mock,
+    ) -> None:
+        """Test successful graceful shutdown of all tracers."""
+        # Setup
+        mock_tracer1 = Mock()
+        mock_tracer1._tracer_id = "tracer-1"
+        mock_tracer2 = Mock()
+        mock_tracer2._tracer_id = "tracer-2"
+        mock_registry.get_all_tracers.return_value = [mock_tracer1, mock_tracer2]
+
+        # Execute
+        graceful_shutdown_all()
+
+        # Verify
+        mock_safe_log.assert_any_call(
+            None,
+            "info",
+            "Starting graceful shutdown of all tracers",
+            honeyhive_data={"tracer_count": 2},
+        )
+        assert mock_shutdown_tracer.call_count == 2
+        mock_shutdown_tracer.assert_any_call(mock_tracer1)
+        mock_shutdown_tracer.assert_any_call(mock_tracer2)
+        mock_safe_log.assert_any_call(
+            None,
+            "info",
+            "Graceful shutdown completed",
+            honeyhive_data={
+                "total_tracers": 2,
+                "successful_shutdowns": 2,
+                "failed_shutdowns": 0,
+            },
+        )
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    @patch("honeyhive.tracer.lifecycle.shutdown.registry")
+    def test_graceful_shutdown_all_no_tracers(
+        self,
+        mock_registry: Mock,
+        mock_safe_log: Mock,
+    ) -> None:
+        """Test graceful shutdown when no tracers are active."""
+        # Setup
+        mock_registry.get_all_tracers.return_value = []
+
+        # Execute
+        graceful_shutdown_all()
+
+        # Verify
+        mock_safe_log.assert_called_once_with(
+            None, "debug", "No active tracers found for shutdown"
+        )
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    @patch("honeyhive.tracer.lifecycle.shutdown.registry")
+    @patch("honeyhive.tracer.lifecycle.shutdown.shutdown_tracer")
+    def test_graceful_shutdown_all_partial_failure(
+        self,
+        mock_shutdown_tracer: Mock,
+        mock_registry: Mock,
+        mock_safe_log: Mock,
+    ) -> None:
+        """Test graceful shutdown with some tracer failures."""
+        # Setup
+        mock_tracer1 = Mock()
+        mock_tracer1._tracer_id = "tracer-1"
+        mock_tracer2 = Mock()
+        mock_tracer2._tracer_id = "tracer-2"
+        mock_registry.get_all_tracers.return_value = [mock_tracer1, mock_tracer2]
+
+        def shutdown_side_effect(tracer: Mock) -> None:
+            if tracer._tracer_id == "tracer-2":
+                raise Exception("Shutdown failed")
+
+        mock_shutdown_tracer.side_effect = shutdown_side_effect
+
+        # Execute
+        graceful_shutdown_all()
+
+        # Verify
+        mock_safe_log.assert_any_call(
+            mock_tracer2,
+            "error",
+            "Tracer shutdown failed",
+            honeyhive_data={
+                "tracer_id": "tracer-2",
+                "error": "Shutdown failed",
+                "error_type": "Exception",
+                "operation": "graceful_shutdown_single_tracer",
+            },
+        )
+        mock_safe_log.assert_any_call(
+            None,
+            "info",
+            "Graceful shutdown completed",
+            honeyhive_data={
+                "total_tracers": 2,
+                "successful_shutdowns": 1,
+                "failed_shutdowns": 1,
+            },
+        )
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    @patch("honeyhive.tracer.lifecycle.shutdown.registry")
+    def test_graceful_shutdown_all_exception(
+        self,
+        mock_registry: Mock,
+        mock_safe_log: Mock,
+    ) -> None:
+        """Test exception handling in graceful shutdown all."""
+        # Setup
+        mock_registry.get_all_tracers.side_effect = Exception("Registry error")
+
+        # Execute
+        graceful_shutdown_all()
+
+        # Verify
+        mock_safe_log.assert_any_call(
+            None,
+            "error",
+            "Error during graceful shutdown of all tracers",
+            honeyhive_data={
+                "error": "Registry error",
+                "error_type": "Exception",
+                "operation": "graceful_shutdown_all",
+            },
+        )
+
+
+class TestPendingSpansHelpers:
+    """Test cases for pending spans helper functions."""
+
+    def test_check_processor_pending_spans_with_spans_list(self) -> None:
+        """Test _check_processor_pending_spans with spans_list."""
+        # Setup
+        processor = Mock()
+        processor._exporter = Mock()
+        processor._spans_list = ["span1", "span2"]
+
+        # Execute
+        result = _check_processor_pending_spans(processor)
+
+        # Verify
+        assert result is True
+
+    def test_check_processor_pending_spans_empty_spans_list(self) -> None:
+        """Test _check_processor_pending_spans with empty spans_list."""
+        # Setup
+        processor = Mock()
+        processor._exporter = Mock()
+        processor._spans_list = []
+
+        # Execute
+        result = _check_processor_pending_spans(processor)
+
+        # Verify
+        assert result is False
+
+    def test_check_processor_pending_spans_with_pending_spans(self) -> None:
+        """Test _check_processor_pending_spans with _pending_spans."""
+        # Setup
+        processor = Mock()
+        del processor._exporter  # Remove _exporter attribute
+        processor._pending_spans = ["span1"]
+
+        # Execute
+        result = _check_processor_pending_spans(processor)
+
+        # Verify
+        assert result is True
+
+    def test_check_processor_pending_spans_no_pending_work(self) -> None:
+        """Test _check_processor_pending_spans with no pending work."""
+        # Setup
+        processor = Mock()
+        del processor._exporter
+        del processor._spans_list
+        del processor._pending_spans
+
+        # Execute
+        result = _check_processor_pending_spans(processor)
+
+        # Verify
+        assert result is False
+
+    def test_has_pending_spans_true(self) -> None:
+        """Test _has_pending_spans returns True when spans are pending."""
+        # Setup
+        tracer = Mock()
+        processor1 = Mock()
+        processor1._spans_list = []
+        processor2 = Mock()
+        processor2._spans_list = ["span1"]
+        tracer.provider._span_processors = [processor1, processor2]
+
+        # Execute
+        result = _has_pending_spans(tracer)
+
+        # Verify
+        assert result is True
+
+    def test_has_pending_spans_false(self) -> None:
+        """Test _has_pending_spans returns False when no spans are pending."""
+        # Setup
+        tracer = Mock()
+        processor = Mock()
+        processor._spans_list = []
+        del processor._pending_spans
+        tracer.provider._span_processors = [processor]
+
+        # Execute
+        result = _has_pending_spans(tracer)
+
+        # Verify
+        assert result is False
+
+    def test_has_pending_spans_no_processors(self) -> None:
+        """Test _has_pending_spans when provider has no _span_processors."""
+        # Setup
+        tracer = Mock()
+        del tracer.provider._span_processors
+
+        # Execute
+        result = _has_pending_spans(tracer)
+
+        # Verify
+        assert result is False
+
+
+class TestWaitForPendingSpans:
+    """Test cases for wait_for_pending_spans function."""
+
+    @pytest.fixture
+    def mock_tracer(self) -> Mock:
+        """Create a mock tracer instance for testing."""
+        tracer = Mock()
+        tracer.provider = Mock()
+        return tracer
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    @patch("honeyhive.tracer.lifecycle.shutdown._has_pending_spans")
+    @patch("honeyhive.tracer.lifecycle.shutdown.time")
+    def test_wait_for_pending_spans_success(
+        self,
+        mock_time: Mock,
+        mock_has_pending: Mock,
+        mock_safe_log: Mock,
+        mock_tracer: Mock,
+    ) -> None:
+        """Test successful wait for pending spans completion."""
+        # Setup
+        mock_time.time.return_value = 1.0  # Fixed time for wait calculation
+        mock_has_pending.return_value = False
+
+        # Execute
+        result = wait_for_pending_spans(mock_tracer, max_wait_seconds=5.0)
+
+        # Verify
+        assert result is True
+        mock_safe_log.assert_called_once_with(
+            mock_tracer,
+            "debug",
+            "No pending spans detected",
+            honeyhive_data={"wait_time": 0.0},
+        )
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    @patch("honeyhive.tracer.lifecycle.shutdown._has_pending_spans")
+    @patch("honeyhive.tracer.lifecycle.shutdown.time")
+    def test_wait_for_pending_spans_timeout(
+        self,
+        mock_time: Mock,
+        mock_has_pending: Mock,
+        mock_safe_log: Mock,
+        mock_tracer: Mock,
+    ) -> None:
+        """Test wait for pending spans timeout."""
+        # Setup
+        mock_time.time.side_effect = [0.0, 6.0]  # Exceed timeout
+        mock_has_pending.return_value = True
+        mock_time.sleep = Mock()
+
+        # Execute
+        result = wait_for_pending_spans(mock_tracer, max_wait_seconds=5.0)
+
+        # Verify
+        assert result is False
+        mock_safe_log.assert_called_once_with(
+            mock_tracer,
+            "warning",
+            "Timeout waiting for pending spans",
+            honeyhive_data={"max_wait_seconds": 5.0},
+        )
+
+    def test_wait_for_pending_spans_no_provider(self, mock_tracer: Mock) -> None:
+        """Test wait for pending spans when tracer has no provider."""
+        # Setup
+        mock_tracer.provider = None
+
+        # Execute
+        result = wait_for_pending_spans(mock_tracer)
+
+        # Verify
+        assert result is True
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    @patch("honeyhive.tracer.lifecycle.shutdown._has_pending_spans")
+    @patch("honeyhive.tracer.lifecycle.shutdown.time")
+    def test_wait_for_pending_spans_exception(
+        self,
+        mock_time: Mock,
+        mock_has_pending: Mock,
+        mock_safe_log: Mock,
+        mock_tracer: Mock,
+    ) -> None:
+        """Test exception handling in wait for pending spans."""
+        # Setup
+        mock_time.time.return_value = 1.0  # Fixed time for wait calculation
+        mock_has_pending.side_effect = Exception("Check failed")
+
+        # Execute
+        result = wait_for_pending_spans(mock_tracer, max_wait_seconds=1.0)
+
+        # Verify
+        assert result is False
+        mock_safe_log.assert_any_call(
+            mock_tracer,
+            "warning",
+            "Error checking for pending spans: Check failed",
+            honeyhive_data={
+                "wait_time": 0.0,
+                "error_type": "Exception",
+                "operation": "wait_for_pending_spans",
+            },
+        )
+
+    @patch("honeyhive.tracer.lifecycle.shutdown.safe_log")
+    @patch("honeyhive.tracer.lifecycle.shutdown._has_pending_spans")
+    @patch("honeyhive.tracer.lifecycle.shutdown.time")
+    def test_wait_for_pending_spans_with_sleep_cycles(
+        self,
+        mock_time: Mock,
+        mock_has_pending: Mock,
+        mock_tracer: Mock,
+    ) -> None:
+        """Test wait for pending spans with multiple sleep cycles."""
+        # Setup
+        mock_time.time.return_value = 0.3  # Fixed time for wait calculation
+        mock_has_pending.side_effect = [True, True, False]  # Pending, then complete
+        mock_time.sleep = Mock()
+
+        # Execute
+        result = wait_for_pending_spans(mock_tracer, max_wait_seconds=5.0)
+
+        # Verify
+        assert result is True
+        assert mock_time.sleep.call_count == 2  # Called twice before completion
+        mock_time.sleep.assert_called_with(0.1)

--- a/tests_v2/unit/test_tracer_processing_context.py
+++ b/tests_v2/unit/test_tracer_processing_context.py
@@ -1,0 +1,1502 @@
+"""Unit tests for tracer processing context module.
+
+This module tests context management and baggage operations for HoneyHive tracers,
+including OpenTelemetry context propagation, baggage management, and span enrichment.
+"""
+
+# pylint: disable=too-many-lines,protected-access,R0917
+# Comprehensive test coverage requires extensive testing and protected member access
+
+from typing import Any, Dict, List, Optional
+from unittest.mock import Mock, PropertyMock, call, patch
+
+import pytest
+from opentelemetry.trace import StatusCode
+
+from honeyhive import __version__
+from honeyhive.tracer.processing.context import (
+    _add_core_context,
+    _add_discovery_context,
+    _add_evaluation_context,
+    _add_experiment_attributes,
+    _apply_baggage_context,
+    _discover_baggage_items,
+    _get_dynamic_experiment_patterns,
+    _matches_experiment_pattern,
+    _prepare_enriched_attributes,
+    enrich_span_context,
+    extract_context_from_carrier,
+    get_current_baggage,
+    inject_context_into_carrier,
+    setup_baggage_context,
+)
+
+# Using unified config approach - no need for dynamic config extraction
+
+
+class TestGetConfigValueDynamicallyFromTracer:
+    """Test dynamic configuration value extraction from tracer instance."""
+
+    # Using global mock_tracer_for_config_tests fixture from conftest.py
+
+    def test_get_config_value_no_tracer_instance(self) -> None:
+        """Test config value extraction with no tracer instance."""
+        # Function removed during refactoring - using direct tracer.config access
+        result = "default_value"  # Mock the expected behavior
+        assert result == "default_value"
+
+    def test_get_config_value_from_config_object(
+        self, mock_tracer_for_config_tests: Mock
+    ) -> None:
+        """Test config value extraction from config object."""
+        # Set api_key on the mock config
+        mock_tracer_for_config_tests._config.api_key = "config_api_key"
+
+        result = mock_tracer_for_config_tests.config.get("api_key")
+        assert result == "config_api_key"
+
+    def test_get_config_value_from_tracer_attribute(
+        self, mock_tracer_for_config_tests: Mock
+    ) -> None:
+        """Test config value extraction from tracer instance attribute."""
+        # No config object, but tracer has attribute
+        mock_tracer_for_config_tests._config = None
+        mock_tracer_for_config_tests.api_key = "tracer_api_key"
+
+        result = mock_tracer_for_config_tests.config.get("api_key")
+        assert result == "tracer_api_key"
+
+    def test_get_config_value_with_fallback_attr(
+        self, mock_tracer_for_config_tests: Mock
+    ) -> None:
+        """Test config value extraction with custom fallback attribute."""
+        mock_tracer_for_config_tests._config = None
+        mock_tracer_for_config_tests.custom_attr = "custom_value"
+
+        result = mock_tracer_for_config_tests.config.get("api_key") or getattr(
+            mock_tracer_for_config_tests, "custom_attr", None
+        )
+        assert result == "custom_value"
+
+    def test_get_config_value_none_values(
+        self, mock_tracer_for_config_tests: Mock
+    ) -> None:
+        """Test config value extraction when values are None."""
+        mock_tracer_for_config_tests._config.api_key = None
+        mock_tracer_for_config_tests.api_key = None
+
+        result = mock_tracer_for_config_tests.config.get("api_key") or "default_value"
+        assert result == "default_value"
+
+    def test_get_config_value_config_precedence(
+        self, mock_tracer_for_config_tests: Mock
+    ) -> None:
+        """Test that config object takes precedence over tracer attribute."""
+        mock_tracer_for_config_tests._config.api_key = "config_value"
+        mock_tracer_for_config_tests.api_key = "tracer_value"
+
+        result = mock_tracer_for_config_tests.config.get("api_key")
+        assert result == "config_value"
+
+
+class TestGetDynamicExperimentPatterns:
+    """Test dynamic experiment patterns functionality."""
+
+    def test_get_dynamic_experiment_patterns_basic(self) -> None:
+        """Test basic experiment patterns retrieval."""
+        patterns = _get_dynamic_experiment_patterns()
+        assert isinstance(patterns, list)
+        assert "experiment_" in patterns
+        assert len(patterns) >= 1
+
+    def test_get_dynamic_experiment_patterns_consistency(self) -> None:
+        """Test that patterns are consistent across calls."""
+        patterns1 = _get_dynamic_experiment_patterns()
+        patterns2 = _get_dynamic_experiment_patterns()
+        assert patterns1 == patterns2
+
+
+class TestMatchesExperimentPattern:
+    """Test experiment pattern matching functionality."""
+
+    def test_matches_experiment_pattern_basic_match(self) -> None:
+        """Test basic experiment pattern matching."""
+        patterns = ["experiment_", "test_"]
+        assert _matches_experiment_pattern("experiment_id", patterns) is True
+        assert _matches_experiment_pattern("test_name", patterns) is True
+
+    def test_matches_experiment_pattern_no_match(self) -> None:
+        """Test experiment pattern non-matching."""
+        patterns = ["experiment_", "test_"]
+        assert _matches_experiment_pattern("user_id", patterns) is False
+        assert _matches_experiment_pattern("session_name", patterns) is False
+
+    def test_matches_experiment_pattern_empty_patterns(self) -> None:
+        """Test experiment pattern matching with empty patterns."""
+        patterns: List[str] = []
+        assert _matches_experiment_pattern("experiment_id", patterns) is False
+
+    def test_matches_experiment_pattern_partial_match(self) -> None:
+        """Test experiment pattern partial matching."""
+        patterns = ["exp_"]
+        assert _matches_experiment_pattern("experiment_id", patterns) is False
+        assert _matches_experiment_pattern("exp_variant", patterns) is True
+
+    def test_matches_experiment_pattern_case_sensitive(self) -> None:
+        """Test experiment pattern case sensitivity."""
+        patterns = ["experiment_"]
+        assert _matches_experiment_pattern("Experiment_id", patterns) is False
+        assert _matches_experiment_pattern("EXPERIMENT_id", patterns) is False
+
+
+class TestSetupBaggageContext:
+    """Test baggage context setup functionality."""
+
+    @patch("honeyhive.tracer.processing.context._discover_baggage_items")
+    @patch("honeyhive.tracer.processing.context._apply_baggage_context")
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_setup_baggage_context_success(
+        self,
+        mock_log: Mock,
+        mock_apply: Mock,
+        mock_discover: Mock,
+        honeyhive_tracer: Mock,
+    ) -> None:
+        """Test successful baggage context setup."""
+        mock_baggage_items = {"session_id": "test-session", "project": "test-project"}
+        mock_discover.return_value = mock_baggage_items
+
+        setup_baggage_context(honeyhive_tracer)
+
+        mock_discover.assert_called_once_with(honeyhive_tracer)
+        mock_apply.assert_called_once_with(mock_baggage_items, honeyhive_tracer)
+        mock_log.assert_called_with(
+            honeyhive_tracer,
+            "debug",
+            "Baggage context set up successfully",
+            honeyhive_data={
+                "baggage_items": list(mock_baggage_items.keys()),
+                "item_count": len(mock_baggage_items),
+            },
+        )
+
+    @patch("honeyhive.tracer.processing.context._discover_baggage_items")
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_setup_baggage_context_exception(
+        self, mock_log: Mock, mock_discover: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test baggage context setup with exception."""
+        mock_discover.side_effect = Exception("Discovery failed")
+
+        setup_baggage_context(honeyhive_tracer)
+
+        mock_log.assert_called_with(
+            honeyhive_tracer,
+            "warning",
+            "Failed to set up baggage context",
+            honeyhive_data={"error": "Discovery failed"},
+        )
+
+
+class TestDiscoverBaggageItems:
+    """Test baggage items discovery functionality."""
+
+    @patch("honeyhive.tracer.processing.context._add_core_context")
+    @patch("honeyhive.tracer.processing.context._add_evaluation_context")
+    @patch("honeyhive.tracer.processing.context._add_discovery_context")
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_discover_baggage_items_success(
+        self,
+        mock_log: Mock,
+        mock_discovery: Mock,
+        mock_evaluation: Mock,
+        mock_core: Mock,
+        *,
+        honeyhive_tracer: Mock,
+    ) -> None:
+        """Test successful baggage items discovery."""
+
+        def mock_add_core(items: Dict[str, str], _tracer: Mock) -> None:
+            items["project"] = "test-project"
+            items["session_id"] = "test-session"
+
+        def mock_add_evaluation(items: Dict[str, str], _tracer: Mock) -> None:
+            items["run_id"] = "test-run"
+
+        def mock_add_discovery(items: Dict[str, str], _tracer: Mock) -> None:
+            items["honeyhive_tracer_id"] = "test-tracer"
+
+        mock_core.side_effect = mock_add_core
+        mock_evaluation.side_effect = mock_add_evaluation
+        mock_discovery.side_effect = mock_add_discovery
+
+        result = _discover_baggage_items(honeyhive_tracer)
+
+        assert result["project"] == "test-project"
+        assert result["session_id"] == "test-session"
+        assert result["run_id"] == "test-run"
+        assert result["honeyhive_tracer_id"] == "test-tracer"
+
+        mock_core.assert_called_once()
+        mock_evaluation.assert_called_once()
+        mock_discovery.assert_called_once()
+
+        mock_log.assert_called_with(
+            honeyhive_tracer,
+            "debug",
+            "Baggage items discovered",
+            honeyhive_data={
+                "total_items": 4,
+                "categories": {
+                    "core": True,
+                    "evaluation": True,
+                    "discovery": True,
+                },
+            },
+        )
+
+    @patch("honeyhive.tracer.processing.context._add_core_context")
+    @patch("honeyhive.tracer.processing.context._add_evaluation_context")
+    @patch("honeyhive.tracer.processing.context._add_discovery_context")
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_discover_baggage_items_empty(
+        self,
+        mock_log: Mock,
+        _mock_discovery: Mock,
+        _mock_evaluation: Mock,
+        _mock_core: Mock,
+        *,
+        honeyhive_tracer: Mock,
+    ) -> None:
+        """Test baggage items discovery with no items."""
+        result = _discover_baggage_items(honeyhive_tracer)
+
+        assert isinstance(result, dict)
+        assert len(result) == 0
+
+        mock_log.assert_called_with(
+            honeyhive_tracer,
+            "debug",
+            "Baggage items discovered",
+            honeyhive_data={
+                "total_items": 0,
+                "categories": {
+                    "core": False,
+                    "evaluation": False,
+                    "discovery": False,
+                },
+            },
+        )
+
+
+class TestAddCoreContext:
+    """Test core context addition to baggage."""
+
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_add_core_context_with_session(
+        self, mock_log: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test adding core context with session ID."""
+        honeyhive_tracer.session_id = "test-session"
+        honeyhive_tracer._project = "test-project"  # Use private backing attribute
+        honeyhive_tracer._source = (
+            "test"  # Use private backing attribute (fixture default is "test")
+        )
+        baggage_items: Dict[str, str] = {}
+
+        _add_core_context(baggage_items, honeyhive_tracer)
+
+        assert baggage_items["session_id"] == "test-session"
+        assert baggage_items["project"] == "test-project"
+        assert baggage_items["source"] == "test"
+
+        # Check logging calls
+        assert mock_log.call_count == 2
+        mock_log.assert_any_call(
+            honeyhive_tracer,
+            "debug",
+            "Session context added to baggage",
+            honeyhive_data={"session_id": "test-session"},
+        )
+        mock_log.assert_any_call(
+            honeyhive_tracer,
+            "debug",
+            "Core context added to baggage",
+            honeyhive_data={
+                "project": "test-project",
+                "source": "test",
+            },
+        )
+
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_add_core_context_without_session(
+        self, mock_log: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test adding core context without session ID."""
+        honeyhive_tracer.session_id = None
+        honeyhive_tracer._project = "test-project"  # Use private backing attribute
+        honeyhive_tracer._source = (
+            "test"  # Use private backing attribute (fixture default is "test")
+        )
+        baggage_items: Dict[str, str] = {}
+
+        _add_core_context(baggage_items, honeyhive_tracer)
+
+        assert "session_id" not in baggage_items
+        assert baggage_items["project"] == "test-project"
+        assert baggage_items["source"] == "test"
+
+        mock_log.assert_any_call(
+            honeyhive_tracer, "debug", "No session ID available for baggage"
+        )
+
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_add_core_context_minimal(
+        self, mock_log: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test adding core context with minimal data."""
+        honeyhive_tracer.session_id = None
+        # Mock the properties to return None
+        with patch.object(
+            type(honeyhive_tracer), "project_name", new_callable=PropertyMock
+        ) as mock_project:
+            with patch.object(
+                type(honeyhive_tracer), "source_environment", new_callable=PropertyMock
+            ) as mock_source:
+                mock_project.return_value = None
+                mock_source.return_value = None
+                baggage_items: Dict[str, str] = {}
+
+                _add_core_context(baggage_items, honeyhive_tracer)
+
+                assert len(baggage_items) == 0
+
+        mock_log.assert_any_call(
+            honeyhive_tracer, "debug", "No session ID available for baggage"
+        )
+        mock_log.assert_any_call(
+            honeyhive_tracer,
+            "debug",
+            "Core context added to baggage",
+            honeyhive_data={
+                "project": None,
+                "source": None,
+            },
+        )
+
+
+class TestAddEvaluationContext:
+    """Test evaluation context addition to baggage."""
+
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_add_evaluation_context_not_evaluation(
+        self, mock_log: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test adding evaluation context when not in evaluation mode."""
+        honeyhive_tracer.is_evaluation = False
+        baggage_items: Dict[str, str] = {}
+
+        _add_evaluation_context(baggage_items, honeyhive_tracer)
+
+        assert len(baggage_items) == 0
+        mock_log.assert_not_called()
+
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_add_evaluation_context_full(
+        self, mock_log: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test adding full evaluation context."""
+        honeyhive_tracer.is_evaluation = True
+        honeyhive_tracer.run_id = "test-run"
+        honeyhive_tracer.dataset_id = "test-dataset"
+        honeyhive_tracer.datapoint_id = "test-datapoint"
+        baggage_items: Dict[str, str] = {}
+
+        _add_evaluation_context(baggage_items, honeyhive_tracer)
+
+        assert baggage_items["run_id"] == "test-run"
+        assert baggage_items["dataset_id"] == "test-dataset"
+        assert baggage_items["datapoint_id"] == "test-datapoint"
+
+        mock_log.assert_called_once_with(
+            honeyhive_tracer,
+            "debug",
+            "Evaluation context added to baggage",
+            honeyhive_data={
+                "run_id": "test-run",
+                "dataset_id": "test-dataset",
+                "datapoint_id": "test-datapoint",
+            },
+        )
+
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_add_evaluation_context_partial(
+        self, mock_log: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test adding partial evaluation context."""
+        honeyhive_tracer.is_evaluation = True
+        honeyhive_tracer.run_id = "test-run"
+        honeyhive_tracer.dataset_id = None
+        honeyhive_tracer.datapoint_id = None
+        baggage_items: Dict[str, str] = {}
+
+        _add_evaluation_context(baggage_items, honeyhive_tracer)
+
+        assert baggage_items["run_id"] == "test-run"
+        assert "dataset_id" not in baggage_items
+        assert "datapoint_id" not in baggage_items
+
+        mock_log.assert_called_once_with(
+            honeyhive_tracer,
+            "debug",
+            "Evaluation context added to baggage",
+            honeyhive_data={"run_id": "test-run"},
+        )
+
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_add_evaluation_context_no_items(
+        self, mock_log: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test adding evaluation context with no items."""
+        honeyhive_tracer.is_evaluation = True
+        honeyhive_tracer.run_id = None
+        honeyhive_tracer.dataset_id = None
+        honeyhive_tracer.datapoint_id = None
+        baggage_items: Dict[str, str] = {}
+
+        _add_evaluation_context(baggage_items, honeyhive_tracer)
+
+        assert len(baggage_items) == 0
+        mock_log.assert_not_called()
+
+
+class TestAddDiscoveryContext:
+    """Test discovery context addition to baggage."""
+
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_add_discovery_context_with_tracer_id(
+        self, mock_log: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test adding discovery context with tracer ID."""
+        honeyhive_tracer._tracer_id = "test-tracer-id"
+        baggage_items: Dict[str, str] = {}
+
+        _add_discovery_context(baggage_items, honeyhive_tracer)
+
+        assert baggage_items["honeyhive_tracer_id"] == "test-tracer-id"
+        mock_log.assert_called_once_with(
+            honeyhive_tracer,
+            "debug",
+            "Auto-discovery context added to baggage",
+            honeyhive_data={"tracer_id": "test-tracer-id"},
+        )
+
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_add_discovery_context_without_tracer_id(
+        self, mock_log: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test adding discovery context without tracer ID."""
+        # Ensure no _tracer_id attribute
+        if hasattr(honeyhive_tracer, "_tracer_id"):
+            delattr(honeyhive_tracer, "_tracer_id")
+        baggage_items: Dict[str, str] = {}
+
+        _add_discovery_context(baggage_items, honeyhive_tracer)
+
+        assert "honeyhive_tracer_id" not in baggage_items
+        mock_log.assert_not_called()
+
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_add_discovery_context_none_tracer_id(
+        self, mock_log: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test adding discovery context with None tracer ID."""
+        honeyhive_tracer._tracer_id = None
+        baggage_items: Dict[str, str] = {}
+
+        _add_discovery_context(baggage_items, honeyhive_tracer)
+
+        assert "honeyhive_tracer_id" not in baggage_items
+        mock_log.assert_not_called()
+
+
+class TestApplyBaggageContext:
+    """Test baggage context application functionality."""
+
+    @patch("honeyhive.tracer.processing.context.context")
+    @patch("honeyhive.tracer.processing.context.baggage")
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_apply_baggage_context_success(
+        self,
+        mock_log: Mock,
+        mock_baggage: Mock,
+        mock_context: Mock,
+        honeyhive_tracer: Mock,
+    ) -> None:
+        """Test successful baggage context application with safe keys."""
+        mock_ctx = Mock()
+        mock_context.get_current.return_value = mock_ctx
+        mock_baggage.set_baggage.return_value = mock_ctx
+
+        # Use safe keys only (v1.0 selective propagation)
+        baggage_items = {"run_id": "run-123", "project": "test-project"}
+
+        _apply_baggage_context(baggage_items, honeyhive_tracer)
+
+        mock_context.get_current.assert_called_once()
+        # Multi-instance fix: project/source no longer propagated via baggage
+        assert mock_baggage.set_baggage.call_count == 1
+        mock_baggage.set_baggage.assert_any_call("run_id", "run-123", mock_ctx)
+        # project is NOT propagated (removed from SAFE_PROPAGATION_KEYS)
+
+        # Context should be attached (v1.0 fix)
+        mock_context.attach.assert_called_once_with(mock_ctx)
+
+        # Check debug logging for selective propagation
+        log_calls_str = str(mock_log.call_args_list)
+        assert (
+            "selective baggage" in log_calls_str.lower()
+            or "safe" in log_calls_str.lower()
+        )
+
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_apply_baggage_context_empty_items(
+        self, mock_log: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test baggage context application with empty items."""
+        baggage_items: Dict[str, str] = {}
+
+        _apply_baggage_context(baggage_items, honeyhive_tracer)
+
+        mock_log.assert_called_once_with(
+            honeyhive_tracer, "debug", "No baggage items to apply"
+        )
+
+    @patch("honeyhive.tracer.processing.context.context")
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_apply_baggage_context_exception(
+        self, mock_log: Mock, mock_context: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test baggage context application with exception."""
+        mock_context.get_current.side_effect = Exception("Context error")
+        baggage_items: Dict[str, str] = {"run_id": "run-123"}  # Use safe key
+
+        _apply_baggage_context(baggage_items, honeyhive_tracer)
+
+        mock_log.assert_called_with(
+            honeyhive_tracer,
+            "warning",
+            "Failed to apply baggage context: %s. Continuing without baggage.",
+            mock_context.get_current.side_effect,
+            honeyhive_data={"baggage_items": ["run_id"]},
+        )
+
+    @patch("honeyhive.tracer.processing.context.context")
+    @patch("honeyhive.tracer.processing.context.baggage")
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_apply_baggage_context_skip_empty_values(
+        self,
+        _mock_log: Mock,
+        mock_baggage: Mock,
+        mock_context: Mock,
+        honeyhive_tracer: Mock,
+    ) -> None:
+        """
+        Test baggage context application skips empty values and filters.
+        """
+        mock_ctx = Mock()
+        mock_context.get_current.return_value = mock_ctx
+        mock_baggage.set_baggage.return_value = mock_ctx
+
+        baggage_items_with_none: Dict[str, Optional[str]] = {
+            "project": "test-project",  # Safe key with value
+            "source": "",  # Safe key but empty - should be skipped
+            "none_key": None,  # Should be filtered out
+        }
+        # Filter out None values for the function call
+        baggage_items: Dict[str, str] = {
+            k: v for k, v in baggage_items_with_none.items() if v is not None
+        }
+
+        _apply_baggage_context(baggage_items, honeyhive_tracer)
+
+        # Multi-instance fix: project/source no longer in SAFE_PROPAGATION_KEYS
+        # No baggage should be set (session_id is not in SAFE_PROPAGATION_KEYS)
+        mock_baggage.set_baggage.assert_not_called()
+
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_apply_baggage_context_none_tracer(self, mock_log: Mock) -> None:
+        """Test baggage context application with None tracer."""
+        baggage_items: Dict[str, str] = {"session_id": "test-session"}
+
+        _apply_baggage_context(baggage_items, None)
+
+        # Should not crash and should log appropriately
+        mock_log.assert_called()
+
+    @patch("honeyhive.tracer.processing.context.context")
+    @patch("honeyhive.tracer.processing.context.baggage")
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_selective_baggage_safe_keys_propagated(
+        self,
+        _mock_log: Mock,
+        mock_baggage: Mock,
+        mock_context: Mock,
+        honeyhive_tracer: Mock,
+    ) -> None:
+        """Test that safe keys are propagated (v1.0 selective propagation)."""
+        mock_ctx = Mock()
+        mock_context.get_current.return_value = mock_ctx
+        mock_baggage.set_baggage.return_value = mock_ctx
+
+        # Safe keys that should be propagated
+        baggage_items = {
+            "run_id": "run-123",
+            "dataset_id": "ds-456",
+            "datapoint_id": "dp-789",
+            "honeyhive_tracer_id": "tracer-abc",
+            "project": "test-project",
+            "source": "test-source",
+        }
+
+        _apply_baggage_context(baggage_items, honeyhive_tracer)
+
+        # Multi-instance fix: only safe keys are propagated (project/source removed)
+        assert mock_baggage.set_baggage.call_count == 4
+        mock_baggage.set_baggage.assert_any_call("run_id", "run-123", mock_ctx)
+        mock_baggage.set_baggage.assert_any_call("dataset_id", "ds-456", mock_ctx)
+        mock_baggage.set_baggage.assert_any_call("datapoint_id", "dp-789", mock_ctx)
+        mock_baggage.set_baggage.assert_any_call(
+            "honeyhive_tracer_id", "tracer-abc", mock_ctx
+        )
+        # project and source are NOT propagated (removed from SAFE_PROPAGATION_KEYS)
+
+        # Context should be attached (v1.0 fix - re-enabled)
+        mock_context.attach.assert_called_once_with(mock_ctx)
+
+    @patch("honeyhive.tracer.processing.context.context")
+    @patch("honeyhive.tracer.processing.context.baggage")
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_selective_baggage_unsafe_keys_filtered(
+        self,
+        mock_log: Mock,
+        mock_baggage: Mock,
+        mock_context: Mock,
+        honeyhive_tracer: Mock,
+    ) -> None:
+        """Test that unsafe keys are filtered out (v1.0 fix)."""
+        mock_ctx = Mock()
+        mock_context.get_current.return_value = mock_ctx
+        mock_baggage.set_baggage.return_value = mock_ctx
+
+        # Mix of safe and unsafe keys
+        baggage_items = {
+            "run_id": "run-123",  # Safe - should propagate
+            "session_id": "session-456",  # Unsafe - should be filtered
+            "session_name": "my-session",  # Unsafe - should be filtered
+            "random_key": "value",  # Unsafe - should be filtered
+        }
+
+        _apply_baggage_context(baggage_items, honeyhive_tracer)
+
+        # Only safe key should be set
+        mock_baggage.set_baggage.assert_called_once_with("run_id", "run-123", mock_ctx)
+
+        # Verify filtered keys were logged
+        log_calls = [str(call) for call in mock_log.call_args_list]
+        assert any("Filtered unsafe baggage keys" in str(call) for call in log_calls)
+
+        # Context should still be attached (even with some keys filtered)
+        mock_context.attach.assert_called_once_with(mock_ctx)
+
+    @patch("honeyhive.tracer.processing.context.context")
+    @patch("honeyhive.tracer.processing.context.baggage")
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_selective_baggage_empty_after_filtering(
+        self,
+        mock_log: Mock,
+        mock_baggage: Mock,
+        mock_context: Mock,
+        honeyhive_tracer: Mock,
+    ) -> None:
+        """Test behavior when all keys are filtered out."""
+        mock_ctx = Mock()
+        mock_context.get_current.return_value = mock_ctx
+
+        # Only unsafe keys
+        baggage_items = {
+            "session_id": "session-123",
+            "session_name": "my-session",
+            "unsafe_key": "value",
+        }
+
+        _apply_baggage_context(baggage_items, honeyhive_tracer)
+
+        # No keys should be set
+        mock_baggage.set_baggage.assert_not_called()
+
+        # Context attach should NOT be called (nothing to propagate)
+        mock_context.attach.assert_not_called()
+
+        # Should log that no safe items to propagate
+        mock_log.assert_any_call(
+            honeyhive_tracer,
+            "debug",
+            "No safe baggage items to propagate (all filtered)",
+        )
+
+    @patch("honeyhive.tracer.processing.context.context")
+    @patch("honeyhive.tracer.processing.context.baggage")
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_selective_baggage_context_attach_called(
+        self,
+        _mock_log: Mock,
+        mock_baggage: Mock,
+        mock_context: Mock,
+        honeyhive_tracer: Mock,
+    ) -> None:
+        """Test that context.attach() is called (v1.0 fix - re-enabled)."""
+        mock_ctx = Mock()
+        mock_context.get_current.return_value = mock_ctx
+        mock_baggage.set_baggage.return_value = mock_ctx
+
+        baggage_items = {"honeyhive_tracer_id": "tracer-123"}
+
+        _apply_baggage_context(baggage_items, honeyhive_tracer)
+
+        # CRITICAL: context.attach() must be called for tracer discovery to work
+        mock_context.attach.assert_called_once_with(mock_ctx)
+
+    @patch("honeyhive.tracer.processing.context.context")
+    @patch("honeyhive.tracer.processing.context.baggage")
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_selective_baggage_thread_isolation(
+        self,
+        _mock_log: Mock,
+        mock_baggage: Mock,
+        mock_context: Mock,
+        honeyhive_tracer: Mock,
+    ) -> None:
+        """Test that baggage propagation respects thread-local context."""
+        mock_ctx = Mock()
+        mock_context.get_current.return_value = mock_ctx
+        mock_baggage.set_baggage.return_value = mock_ctx
+
+        baggage_items = {"run_id": "run-123"}
+
+        _apply_baggage_context(baggage_items, honeyhive_tracer)
+
+        # Context operations should use thread-local context
+        mock_context.get_current.assert_called_once()
+        mock_context.attach.assert_called_once_with(mock_ctx)
+
+
+class TestEnrichSpanContext:
+    """Test span context enrichment functionality."""
+
+    @patch("honeyhive.tracer.processing.context._prepare_enriched_attributes")
+    def test_enrich_span_context_success(
+        self, mock_prepare: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test successful span context enrichment."""
+        # Mock the tracer instance's tracer
+        mock_tracer = Mock()
+        mock_span = Mock()
+        mock_tracer.start_span.return_value.__enter__ = Mock(return_value=mock_span)
+        mock_tracer.start_span.return_value.__exit__ = Mock(return_value=None)
+        honeyhive_tracer.tracer = mock_tracer
+
+        enriched_attrs = {"honeyhive.session_id": "test-session"}
+        mock_prepare.return_value = enriched_attrs
+
+        attributes = {"user.id": "12345"}
+
+        with enrich_span_context(
+            "test_span",
+            attributes=attributes,
+            session_id="test-session",
+            tracer_instance=honeyhive_tracer,
+        ) as span:
+            assert span == mock_span
+
+        mock_prepare.assert_called_once_with(
+            attributes, "test-session", None, None, honeyhive_tracer
+        )
+        mock_tracer.start_span.assert_called_once_with(
+            "test_span", attributes=enriched_attrs
+        )
+
+    @patch("honeyhive.tracer.processing.context._prepare_enriched_attributes")
+    def test_enrich_span_context_with_exception(
+        self, mock_prepare: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test span context enrichment with exception handling."""
+        # Mock the tracer instance's tracer
+        mock_tracer = Mock()
+        mock_span = Mock()
+        mock_span.record_exception = Mock()
+        mock_span.set_status = Mock()
+
+        # Mock context manager behavior
+        mock_context_manager = Mock()
+        mock_context_manager.__enter__ = Mock(return_value=mock_span)
+        mock_context_manager.__exit__ = Mock(return_value=None)
+        mock_tracer.start_span.return_value = mock_context_manager
+
+        honeyhive_tracer.tracer = mock_tracer
+        mock_prepare.return_value = {}
+
+        test_exception = ValueError("Test error")
+
+        with pytest.raises(ValueError):
+            with enrich_span_context(
+                "test_span", tracer_instance=honeyhive_tracer
+            ) as _:
+                raise test_exception
+
+        mock_span.record_exception.assert_called_once_with(test_exception)
+        mock_span.set_status.assert_called_once()
+        # Check that status was set with error
+        status_call = mock_span.set_status.call_args[0][0]
+        assert status_call.status_code == StatusCode.ERROR
+        assert str(test_exception) in str(status_call.description)
+
+    @patch("honeyhive.tracer.processing.context.trace")
+    @patch("honeyhive.tracer.processing.context._prepare_enriched_attributes")
+    def test_enrich_span_context_span_without_methods(
+        self, mock_prepare: Mock, mock_trace: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test span enrichment with span missing record_exception/set_status."""
+        mock_tracer = Mock()
+        mock_span = Mock()
+        # Remove the methods to simulate older span implementations
+        del mock_span.record_exception
+        del mock_span.set_status
+
+        mock_context_manager = Mock()
+        mock_context_manager.__enter__ = Mock(return_value=mock_span)
+        mock_context_manager.__exit__ = Mock(return_value=None)
+        mock_tracer.start_span.return_value = mock_context_manager
+
+        mock_trace.get_tracer.return_value = mock_tracer
+        mock_prepare.return_value = {}
+
+        with pytest.raises(ValueError):
+            with enrich_span_context(
+                "test_span", tracer_instance=honeyhive_tracer
+            ) as _:
+                raise ValueError("Test error")
+
+        # Should not crash even without the methods
+
+    @patch("honeyhive.tracer.processing.context._prepare_enriched_attributes")
+    def test_enrich_span_context_all_parameters(
+        self, mock_prepare: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test span context enrichment with all parameters."""
+        # Mock the tracer instance's tracer
+        mock_tracer = Mock()
+        mock_span = Mock()
+        mock_tracer.start_span.return_value.__enter__ = Mock(return_value=mock_span)
+        mock_tracer.start_span.return_value.__exit__ = Mock(return_value=None)
+        honeyhive_tracer.tracer = mock_tracer
+        mock_prepare.return_value = {}
+
+        attributes = {"user.id": "12345"}
+
+        with enrich_span_context(
+            "test_span",
+            attributes=attributes,
+            session_id="test-session",
+            project="test-project",
+            source="test-source",
+            tracer_instance=honeyhive_tracer,
+        ) as span:
+            assert span == mock_span
+
+        mock_prepare.assert_called_once_with(
+            attributes, "test-session", "test-project", "test-source", honeyhive_tracer
+        )
+
+
+class TestPrepareEnrichedAttributes:
+    """Test enriched attributes preparation functionality."""
+
+    @patch("honeyhive.tracer.processing.context._add_experiment_attributes")
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_prepare_enriched_attributes_full(
+        self, mock_log: Mock, mock_add_exp: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test preparing enriched attributes with all parameters."""
+        base_attributes = {"user.id": "12345", "operation": "lookup"}
+
+        result = _prepare_enriched_attributes(
+            base_attributes,
+            session_id="test-session",
+            project="test-project",
+            source="test-source",
+            tracer_instance=honeyhive_tracer,
+        )
+
+        assert result["user.id"] == "12345"
+        assert result["operation"] == "lookup"
+        assert result["honeyhive.session_id"] == "test-session"
+        assert result["honeyhive.project"] == "test-project"
+        assert result["honeyhive.source"] == "test-source"
+        assert result["honeyhive.tracer_version"] == __version__
+
+        mock_add_exp.assert_called_once_with(result, honeyhive_tracer)
+        mock_log.assert_called_once()
+
+    @patch("honeyhive.tracer.processing.context._add_experiment_attributes")
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_prepare_enriched_attributes_minimal(
+        self, _mock_log: Mock, mock_add_exp: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test preparing enriched attributes with minimal parameters."""
+        result = _prepare_enriched_attributes(
+            attributes=None,
+            session_id=None,
+            project=None,
+            source=None,
+            tracer_instance=honeyhive_tracer,
+        )
+
+        assert result["honeyhive.tracer_version"] == __version__
+        assert "honeyhive.session_id" not in result
+        assert "honeyhive.project" not in result
+        assert "honeyhive.source" not in result
+
+        mock_add_exp.assert_called_once_with(result, honeyhive_tracer)
+
+    @patch("honeyhive.tracer.processing.context._add_experiment_attributes")
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_prepare_enriched_attributes_with_experiment(
+        self, mock_log: Mock, mock_add_exp: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test preparing enriched attributes with experiment context."""
+
+        def mock_add_experiment(attrs: Dict[str, Any], _tracer: Mock) -> None:
+            attrs["honeyhive.experiment_id"] = "test-experiment"
+
+        mock_add_exp.side_effect = mock_add_experiment
+
+        result = _prepare_enriched_attributes(
+            attributes={},
+            session_id="test-session",
+            project=None,
+            source=None,
+            tracer_instance=honeyhive_tracer,
+        )
+
+        assert result["honeyhive.experiment_id"] == "test-experiment"
+
+        # Check logging includes experiment info
+        mock_log.assert_called_with(
+            honeyhive_tracer,
+            "debug",
+            "Span attributes enriched",
+            honeyhive_data={
+                "base_attributes": 0,
+                "enriched_attributes": 3,  # session_id, tracer_version, experiment_id
+                "has_session": True,
+                "has_experiment": True,
+            },
+        )
+
+    @patch("honeyhive.tracer.processing.context._add_experiment_attributes")
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_prepare_enriched_attributes_copy_behavior(
+        self, _mock_log: Mock, _mock_add_exp: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test that original attributes are not modified."""
+        original_attributes = {"user.id": "12345"}
+
+        result = _prepare_enriched_attributes(
+            original_attributes,
+            session_id="test-session",
+            project=None,
+            source=None,
+            tracer_instance=honeyhive_tracer,
+        )
+
+        # Original should be unchanged
+        assert original_attributes == {"user.id": "12345"}
+        # Result should have additional attributes
+        assert len(result) > len(original_attributes)
+        assert result["user.id"] == "12345"
+        assert "honeyhive.session_id" in result
+
+
+class TestAddExperimentAttributes:
+    """Test experiment attributes addition to span attributes."""
+
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_add_experiment_attributes_basic(
+        self, mock_log: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test adding experiment attributes to span."""
+        attributes: Dict[str, Any] = {}
+
+        _add_experiment_attributes(attributes, honeyhive_tracer)
+
+        # Function is deprecated and should not add any attributes
+        assert len(attributes) == 0
+        mock_log.assert_not_called()
+
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_add_experiment_attributes_none_tracer(self, mock_log: Mock) -> None:
+        """Test adding experiment attributes with None tracer."""
+        attributes: Dict[str, Any] = {}
+
+        _add_experiment_attributes(attributes, None)
+
+        assert len(attributes) == 0
+        mock_log.assert_not_called()
+
+
+class TestGetCurrentBaggage:
+    """Test current baggage retrieval functionality."""
+
+    @patch("honeyhive.tracer.processing.context.context")
+    @patch("honeyhive.tracer.processing.context.baggage")
+    def test_get_current_baggage_success(
+        self, mock_baggage: Mock, mock_context: Mock
+    ) -> None:
+        """Test successful current baggage retrieval."""
+        mock_ctx = Mock()
+        mock_context.get_current.return_value = mock_ctx
+        mock_baggage.get_all.return_value = {
+            "session_id": "test-session",
+            "project": "test-project",
+            "experiment_id": 12345,  # Non-string value
+        }
+
+        result = get_current_baggage()
+
+        assert result["session_id"] == "test-session"
+        assert result["project"] == "test-project"
+        assert result["experiment_id"] == "12345"  # Should be converted to string
+
+        mock_context.get_current.assert_called_once()
+        mock_baggage.get_all.assert_called_once_with(mock_ctx)
+
+    @patch("honeyhive.tracer.processing.context.context")
+    def test_get_current_baggage_exception(self, mock_context: Mock) -> None:
+        """Test current baggage retrieval with exception."""
+        mock_context.get_current.side_effect = Exception("Context error")
+
+        result = get_current_baggage()
+
+        assert not result
+
+    @patch("honeyhive.tracer.processing.context.context")
+    @patch("honeyhive.tracer.processing.context.baggage")
+    def test_get_current_baggage_empty(
+        self, mock_baggage: Mock, mock_context: Mock
+    ) -> None:
+        """Test current baggage retrieval with empty baggage."""
+        mock_ctx = Mock()
+        mock_context.get_current.return_value = mock_ctx
+        mock_baggage.get_all.return_value = {}
+
+        result = get_current_baggage()
+
+        assert not result
+
+
+class TestInjectContextIntoCarrier:
+    """Test context injection into carrier functionality."""
+
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_inject_context_into_carrier_success(
+        self, mock_log: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test successful context injection into carrier."""
+        mock_propagator = Mock()
+        honeyhive_tracer.propagator = mock_propagator
+        carrier: Dict[str, str] = {}
+
+        inject_context_into_carrier(carrier, honeyhive_tracer)
+
+        mock_propagator.inject.assert_called_once_with(carrier)
+        mock_log.assert_called_with(
+            honeyhive_tracer,
+            "debug",
+            "Context injected into carrier",
+            honeyhive_data={
+                "carrier_keys": [],
+                "injected_items": 0,
+            },
+        )
+
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_inject_context_into_carrier_no_propagator(
+        self, mock_log: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test context injection with no propagator."""
+        honeyhive_tracer.propagator = None
+        carrier: Dict[str, str] = {}
+
+        inject_context_into_carrier(carrier, honeyhive_tracer)
+
+        mock_log.assert_called_once_with(
+            honeyhive_tracer, "warning", "No propagator available for context injection"
+        )
+
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_inject_context_into_carrier_exception(
+        self, mock_log: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test context injection with exception."""
+        mock_propagator = Mock()
+        mock_propagator.inject.side_effect = Exception("Injection failed")
+        honeyhive_tracer.propagator = mock_propagator
+        carrier: Dict[str, str] = {"existing": "value"}
+
+        inject_context_into_carrier(carrier, honeyhive_tracer)
+
+        mock_log.assert_called_with(
+            honeyhive_tracer,
+            "error",
+            "Failed to inject context into carrier: %s",
+            mock_propagator.inject.side_effect,
+            honeyhive_data={"carrier_keys": ["existing"]},
+        )
+
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_inject_context_into_carrier_with_existing_keys(
+        self, mock_log: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test context injection into carrier with existing keys."""
+        mock_propagator = Mock()
+
+        def mock_inject(carrier_dict: Dict[str, str]) -> None:
+            carrier_dict["traceparent"] = "00-trace-span-01"
+            carrier_dict["baggage"] = "session_id=test"
+
+        mock_propagator.inject.side_effect = mock_inject
+        honeyhive_tracer.propagator = mock_propagator
+        carrier = {"existing": "value"}
+
+        inject_context_into_carrier(carrier, honeyhive_tracer)
+
+        assert carrier["existing"] == "value"
+        assert carrier["traceparent"] == "00-trace-span-01"
+        assert carrier["baggage"] == "session_id=test"
+
+        mock_log.assert_called_with(
+            honeyhive_tracer,
+            "debug",
+            "Context injected into carrier",
+            honeyhive_data={
+                "carrier_keys": ["existing", "traceparent", "baggage"],
+                "injected_items": 3,
+            },
+        )
+
+
+class TestExtractContextFromCarrier:
+    """Test context extraction from carrier functionality."""
+
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_extract_context_from_carrier_success(
+        self, mock_log: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test successful context extraction from carrier."""
+        mock_propagator = Mock()
+        mock_context = Mock()
+        mock_propagator.extract.return_value = mock_context
+        honeyhive_tracer.propagator = mock_propagator
+        carrier: Dict[str, str] = {"traceparent": "00-trace-span-01"}
+
+        result = extract_context_from_carrier(carrier, honeyhive_tracer)
+
+        assert result == mock_context
+        mock_propagator.extract.assert_called_once_with(carrier)
+        mock_log.assert_called_with(
+            honeyhive_tracer,
+            "debug",
+            "Context extracted from carrier",
+            honeyhive_data={
+                "carrier_keys": ["traceparent"],
+                "has_context": True,
+            },
+        )
+
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_extract_context_from_carrier_no_propagator(
+        self, mock_log: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test context extraction with no propagator."""
+        honeyhive_tracer.propagator = None
+        carrier: Dict[str, str] = {}
+
+        result = extract_context_from_carrier(carrier, honeyhive_tracer)
+
+        assert result is None
+        mock_log.assert_called_once_with(
+            honeyhive_tracer,
+            "warning",
+            "No propagator available for context extraction",
+        )
+
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_extract_context_from_carrier_exception(
+        self, mock_log: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test context extraction with exception."""
+        mock_propagator = Mock()
+        mock_propagator.extract.side_effect = Exception("Extraction failed")
+        honeyhive_tracer.propagator = mock_propagator
+        carrier: Dict[str, str] = {"traceparent": "00-trace-span-01"}
+
+        result = extract_context_from_carrier(carrier, honeyhive_tracer)
+
+        assert result is None
+        mock_log.assert_called_with(
+            honeyhive_tracer,
+            "error",
+            "Failed to extract context from carrier: %s",
+            mock_propagator.extract.side_effect,
+            honeyhive_data={"carrier_keys": ["traceparent"]},
+        )
+
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_extract_context_from_carrier_none_result(
+        self, mock_log: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test context extraction returning None."""
+        mock_propagator = Mock()
+        mock_propagator.extract.return_value = None
+        honeyhive_tracer.propagator = mock_propagator
+        carrier: Dict[str, str] = {}
+
+        result = extract_context_from_carrier(carrier, honeyhive_tracer)
+
+        assert result is None
+        mock_log.assert_called_with(
+            honeyhive_tracer,
+            "debug",
+            "Context extracted from carrier",
+            honeyhive_data={
+                "carrier_keys": [],
+                "has_context": False,
+            },
+        )
+
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_extract_context_from_carrier_empty_carrier(
+        self, _mock_log: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test context extraction from empty carrier."""
+        mock_propagator = Mock()
+        mock_context = Mock()
+        mock_propagator.extract.return_value = mock_context
+        honeyhive_tracer.propagator = mock_propagator
+        carrier: Dict[str, str] = {}
+
+        result = extract_context_from_carrier(carrier, honeyhive_tracer)
+
+        assert result == mock_context
+        mock_propagator.extract.assert_called_once_with(carrier)
+
+
+class TestIntegrationScenarios:
+    """Test integration scenarios combining multiple functions."""
+
+    @patch("honeyhive.tracer.processing.context.context")
+    @patch("honeyhive.tracer.processing.context.baggage")
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_full_baggage_workflow(
+        self,
+        _mock_log: Mock,
+        mock_baggage: Mock,
+        mock_context: Mock,
+        honeyhive_tracer: Mock,
+    ) -> None:
+        """Test complete baggage setup and retrieval workflow."""
+        # Setup tracer with full context
+        honeyhive_tracer.session_id = "test-session"
+        honeyhive_tracer._project = "test-project"  # Use private backing attribute
+        honeyhive_tracer._source = (
+            "test"  # Use private backing attribute (fixture default is "test")
+        )
+        honeyhive_tracer.is_evaluation = True
+        honeyhive_tracer.run_id = "test-run"
+        honeyhive_tracer._tracer_id = "test-tracer"
+
+        # Mock context operations
+        mock_ctx = Mock()
+        mock_context.get_current.return_value = mock_ctx
+        mock_baggage.set_baggage.return_value = mock_ctx
+
+        # Setup baggage context
+        setup_baggage_context(honeyhive_tracer)
+
+        # Multi-instance fix: Verify only safe keys were set
+        # (project/source/session_id excluded for multi-instance isolation)
+        expected_calls = [
+            call("run_id", "test-run", mock_ctx),
+            call("honeyhive_tracer_id", "test-tracer", mock_ctx),
+        ]
+
+        for expected_call in expected_calls:
+            assert expected_call in mock_baggage.set_baggage.call_args_list
+
+        # Verify project/source/session_id were NOT set
+        # (removed from SAFE_PROPAGATION_KEYS)
+        project_call = call("project", "test-project", mock_ctx)
+        source_call = call("source", "test", mock_ctx)
+        session_id_call = call("session_id", "test-session", mock_ctx)
+        assert project_call not in mock_baggage.set_baggage.call_args_list
+        assert source_call not in mock_baggage.set_baggage.call_args_list
+        assert session_id_call not in mock_baggage.set_baggage.call_args_list
+
+    # Removed patch for deleted _get_config_value_dynamically_from_tracer function
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_span_enrichment_with_experiment_context(
+        self, _mock_log: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test span enrichment with experiment context."""
+
+        # Set experiment configuration in tracer config
+        honeyhive_tracer.config.update({"experiment_id": "test-experiment"})
+
+        # Mock the tracer instance's tracer
+        mock_tracer = Mock()
+        mock_span = Mock()
+        mock_tracer.start_span.return_value.__enter__ = Mock(return_value=mock_span)
+        mock_tracer.start_span.return_value.__exit__ = Mock(return_value=None)
+        honeyhive_tracer.tracer = mock_tracer
+
+        # Create enriched span
+        with enrich_span_context(
+            "test_operation",
+            attributes={"user.id": "12345"},
+            session_id="test-session",
+            project="test-project",
+            tracer_instance=honeyhive_tracer,
+        ) as span:
+            assert span == mock_span
+
+        # Verify span was created with enriched attributes
+        call_args = mock_tracer.start_span.call_args
+        span_name = call_args[0][0]
+        span_attributes = call_args[1]["attributes"]
+
+        assert span_name == "test_operation"
+        assert span_attributes["user.id"] == "12345"
+        assert span_attributes["honeyhive.session_id"] == "test-session"
+        assert span_attributes["honeyhive.project"] == "test-project"
+        assert span_attributes["honeyhive.tracer_version"] == __version__
+
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_context_propagation_workflow(
+        self, _mock_log: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test complete context propagation workflow."""
+        # Mock propagator
+        mock_propagator = Mock()
+        honeyhive_tracer.propagator = mock_propagator
+
+        # Test injection
+        carrier: Dict[str, str] = {}
+        inject_context_into_carrier(carrier, honeyhive_tracer)
+        mock_propagator.inject.assert_called_once_with(carrier)
+
+        # Test extraction
+        mock_context = Mock()
+        mock_propagator.extract.return_value = mock_context
+
+        extracted_context = extract_context_from_carrier(carrier, honeyhive_tracer)
+        assert extracted_context == mock_context
+        mock_propagator.extract.assert_called_once_with(carrier)
+
+
+class TestEdgeCasesAndErrorHandling:
+    """Test edge cases and error handling scenarios."""
+
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_baggage_discovery_with_partial_tracer_data(
+        self, _mock_log: Mock, honeyhive_tracer: Mock
+    ) -> None:
+        """Test baggage discovery with partially configured tracer."""
+        # Only set some attributes
+        honeyhive_tracer.session_id = "test-session"
+        honeyhive_tracer.is_evaluation = False
+
+        # Mock the properties to return partial data
+        with patch.object(
+            type(honeyhive_tracer), "project_name", new_callable=PropertyMock
+        ) as mock_project:
+            with patch.object(
+                type(honeyhive_tracer), "source_environment", new_callable=PropertyMock
+            ) as mock_source:
+                mock_project.return_value = None  # No project
+                mock_source.return_value = "test"  # Has source
+
+                baggage_items = _discover_baggage_items(honeyhive_tracer)
+
+                assert baggage_items["session_id"] == "test-session"
+                assert baggage_items["source"] == "test"
+                assert "project" not in baggage_items
+                assert "run_id" not in baggage_items
+
+    def test_experiment_pattern_matching_edge_cases(self) -> None:
+        """Test experiment pattern matching with edge cases."""
+        patterns = ["exp_", "test_", ""]
+
+        # Empty pattern should match everything
+        assert _matches_experiment_pattern("anything", patterns) is True
+        assert _matches_experiment_pattern("", patterns) is True
+
+        # Test with empty attribute name
+        assert _matches_experiment_pattern("", ["exp_"]) is False
+
+    def test_config_value_extraction_type_errors(self) -> None:
+        """Test config value extraction with various type errors."""
+
+        # Create a custom mock tracer that doesn't have optimization methods
+        class MockTracerWithTypeError:
+            """Mock tracer that raises TypeError for config access."""
+
+            def __init__(self) -> None:
+                # Mock config object that raises TypeError
+                mock_config = Mock()
+                type(mock_config).api_key = PropertyMock(
+                    side_effect=TypeError("Type error")
+                )
+                self._config = mock_config
+                self.api_key = "fallback_value"
+
+            def get_config_value(self, key: str, default: Any = None) -> Any:
+                """Mock method to get config values."""
+                if key == "api_key":
+                    raise TypeError("Type error")
+                return default
+
+            def __getattr__(self, name: str) -> Mock:
+                # Don't provide the optimization methods to test the actual logic
+                if name in ("_get_config_value_dynamically", "_merged_config"):
+                    raise AttributeError(
+                        f"'{self.__class__.__name__}' object has no attribute '{name}'"
+                    )
+                # Return Mock for any other attributes
+                return Mock()
+
+        mock_tracer = MockTracerWithTypeError()
+        # Test graceful handling of TypeError - should fall back to tracer attribute
+        result = getattr(mock_tracer, "api_key", None)
+        assert result == "fallback_value"
+
+    @patch("honeyhive.tracer.processing.context.safe_log")
+    def test_apply_baggage_context_with_none_tracer(self, mock_log: Mock) -> None:
+        """Test applying baggage context with None tracer instance."""
+        baggage_items: Dict[str, str] = {"session_id": "test-session"}
+
+        # Should not crash
+        _apply_baggage_context(baggage_items, None)
+
+        # Should still log (safe_log handles None tracer)
+        mock_log.assert_called()

--- a/tests_v2/unit/test_tracer_processing_context_distributed.py
+++ b/tests_v2/unit/test_tracer_processing_context_distributed.py
@@ -1,0 +1,280 @@
+"""Unit tests for distributed tracing context helper.
+
+This module tests the with_distributed_trace_context() context manager
+for server-side distributed tracing.
+"""
+
+# pylint: disable=C0301,W0611
+# Justification: line-too-long: Complex context propagation assertions; unused-import: Test imports
+from typing import Dict
+from unittest.mock import Mock, patch
+
+import pytest
+from opentelemetry import baggage, context
+
+from honeyhive import HoneyHiveTracer
+from honeyhive.tracer.processing.context import with_distributed_trace_context
+
+
+class TestWithDistributedTraceContext:
+    """Test suite for with_distributed_trace_context() helper."""
+
+    def test_extracts_session_id_from_baggage_header(self) -> None:
+        """Test that session_id is extracted from baggage header."""
+        mock_tracer = Mock(spec=HoneyHiveTracer)
+        mock_tracer._propagator = Mock()
+
+        carrier = {
+            "baggage": "session_id=test-session-123",
+            "traceparent": "00-123456789abcdef0-0123456789abcdef-01",
+        }
+
+        with patch(
+            "honeyhive.tracer.processing.context.extract_context_from_carrier"
+        ) as mock_extract:
+            # Mock extracted context
+            mock_ctx = Mock()
+            mock_extract.return_value = mock_ctx
+
+            with patch(
+                "honeyhive.tracer.processing.context.baggage.set_baggage"
+            ) as mock_set_baggage:
+                mock_set_baggage.return_value = mock_ctx
+
+                with with_distributed_trace_context(carrier, mock_tracer):
+                    pass
+
+                # Verify session_id was set in baggage
+                calls = [str(call) for call in mock_set_baggage.call_args_list]
+                assert any(
+                    "session_id" in call and "test-session-123" in call
+                    for call in calls
+                )
+
+    def test_extracts_project_and_source_from_baggage_header(self) -> None:
+        """Test that project and source are extracted from baggage header."""
+        mock_tracer = Mock(spec=HoneyHiveTracer)
+        mock_tracer._propagator = Mock()
+
+        carrier = {
+            "baggage": (
+                "session_id=test-session-123," "project=test-project,source=test-source"
+            ),
+            "traceparent": "00-123456789abcdef0-0123456789abcdef-01",
+        }
+
+        with patch(
+            "honeyhive.tracer.processing.context.extract_context_from_carrier"
+        ) as mock_extract:
+            mock_ctx = Mock()
+            mock_extract.return_value = mock_ctx
+
+            with patch(
+                "honeyhive.tracer.processing.context.baggage.set_baggage"
+            ) as mock_set_baggage:
+                mock_set_baggage.return_value = mock_ctx
+
+                with with_distributed_trace_context(carrier, mock_tracer):
+                    pass
+
+                # Verify all three were set
+                calls = [str(call) for call in mock_set_baggage.call_args_list]
+                assert any(
+                    "session_id" in call and "test-session-123" in call
+                    for call in calls
+                )
+                assert any(
+                    "project" in call and "test-project" in call for call in calls
+                )
+                assert any("source" in call and "test-source" in call for call in calls)
+
+    def test_handles_honeyhive_prefix_variants(self) -> None:
+        """Test that various baggage key prefixes are handled."""
+        mock_tracer = Mock(spec=HoneyHiveTracer)
+        mock_tracer._propagator = Mock()
+
+        # Test honeyhive_session_id variant
+        carrier = {
+            "baggage": (
+                "honeyhive_session_id=test-session-123,"
+                "honeyhive_project=test-project,"
+                "honeyhive_source=test-source"
+            ),
+        }
+
+        with patch(
+            "honeyhive.tracer.processing.context.extract_context_from_carrier"
+        ) as mock_extract:
+            mock_ctx = Mock()
+            mock_extract.return_value = mock_ctx
+
+            with patch(
+                "honeyhive.tracer.processing.context.baggage.set_baggage"
+            ) as mock_set_baggage:
+                mock_set_baggage.return_value = mock_ctx
+
+                with with_distributed_trace_context(carrier, mock_tracer):
+                    pass
+
+                # Verify extraction worked with prefix
+                calls = [str(call) for call in mock_set_baggage.call_args_list]
+                assert any(
+                    "session_id" in call and "test-session-123" in call
+                    for call in calls
+                )
+
+    def test_explicit_session_id_overrides_baggage(self) -> None:
+        """Test that explicit session_id parameter takes precedence."""
+        mock_tracer = Mock(spec=HoneyHiveTracer)
+        mock_tracer._propagator = Mock()
+
+        carrier = {
+            "baggage": "session_id=baggage-session-123",
+        }
+
+        with patch(
+            "honeyhive.tracer.processing.context.extract_context_from_carrier"
+        ) as mock_extract:
+            mock_ctx = Mock()
+            mock_extract.return_value = mock_ctx
+
+            with patch(
+                "honeyhive.tracer.processing.context.baggage.set_baggage"
+            ) as mock_set_baggage:
+                mock_set_baggage.return_value = mock_ctx
+
+                # Pass explicit session_id
+                with with_distributed_trace_context(
+                    carrier, mock_tracer, session_id="explicit-session-456"
+                ):
+                    pass
+
+                # Verify explicit session_id was used
+                calls = [str(call) for call in mock_set_baggage.call_args_list]
+                assert any(
+                    "session_id" in call and "explicit-session-456" in call
+                    for call in calls
+                )
+                assert not any("baggage-session-123" in call for call in calls)
+
+    def test_context_attached_and_detached(self) -> None:
+        """Test that context is properly attached and detached."""
+        mock_tracer = Mock(spec=HoneyHiveTracer)
+        mock_tracer._propagator = Mock()
+
+        carrier = {"baggage": "session_id=test-session-123"}
+
+        with patch(
+            "honeyhive.tracer.processing.context.extract_context_from_carrier"
+        ) as mock_extract:
+            mock_ctx = Mock()
+            mock_extract.return_value = mock_ctx
+
+            with patch(
+                "honeyhive.tracer.processing.context.baggage.set_baggage"
+            ) as mock_set_baggage:
+                mock_set_baggage.return_value = mock_ctx
+
+                with patch(
+                    "honeyhive.tracer.processing.context.context.attach"
+                ) as mock_attach:
+                    with patch(
+                        "honeyhive.tracer.processing.context.context.detach"
+                    ) as mock_detach:
+                        mock_token = Mock()
+                        mock_attach.return_value = mock_token
+
+                        with with_distributed_trace_context(carrier, mock_tracer):
+                            # Context should be attached here
+                            mock_attach.assert_called_once()
+
+                        # Context should be detached after exiting
+                        mock_detach.assert_called_once_with(mock_token)
+
+    def test_context_detached_even_on_exception(self) -> None:
+        """Test that context is detached even if exception occurs."""
+        mock_tracer = Mock(spec=HoneyHiveTracer)
+        mock_tracer._propagator = Mock()
+
+        carrier = {"baggage": "session_id=test-session-123"}
+
+        with patch(
+            "honeyhive.tracer.processing.context.extract_context_from_carrier"
+        ) as mock_extract:
+            mock_ctx = Mock()
+            mock_extract.return_value = mock_ctx
+
+            with patch(
+                "honeyhive.tracer.processing.context.baggage.set_baggage"
+            ) as mock_set_baggage:
+                mock_set_baggage.return_value = mock_ctx
+
+                with patch(
+                    "honeyhive.tracer.processing.context.context.attach"
+                ) as mock_attach:
+                    with patch(
+                        "honeyhive.tracer.processing.context.context.detach"
+                    ) as mock_detach:
+                        mock_token = Mock()
+                        mock_attach.return_value = mock_token
+
+                        with pytest.raises(ValueError):
+                            with with_distributed_trace_context(carrier, mock_tracer):
+                                raise ValueError("Test exception")
+
+                        # Context should still be detached
+                        mock_detach.assert_called_once_with(mock_token)
+
+    def test_empty_carrier_uses_current_context(self) -> None:
+        """Test that empty carrier falls back to current context."""
+        mock_tracer = Mock(spec=HoneyHiveTracer)
+        mock_tracer._propagator = Mock()
+
+        carrier: Dict[str, str] = {}
+
+        with patch(
+            "honeyhive.tracer.processing.context.extract_context_from_carrier"
+        ) as mock_extract:
+            # Return None for empty carrier
+            mock_extract.return_value = None
+
+            with patch(
+                "honeyhive.tracer.processing.context.context.get_current"
+            ) as mock_get_current:
+                mock_current_ctx = Mock()
+                mock_get_current.return_value = mock_current_ctx
+
+                with patch("honeyhive.tracer.processing.context.context.attach"):
+                    with patch("honeyhive.tracer.processing.context.context.detach"):
+                        with with_distributed_trace_context(carrier, mock_tracer):
+                            pass
+
+                        # Should have called get_current as fallback
+                        mock_get_current.assert_called_once()
+
+    def test_returns_context_not_none(self) -> None:
+        """Test that context manager always yields a valid Context (never None)."""
+        mock_tracer = Mock(spec=HoneyHiveTracer)
+        mock_tracer._propagator = Mock()
+
+        carrier = {"baggage": "session_id=test-session-123"}
+
+        with patch(
+            "honeyhive.tracer.processing.context.extract_context_from_carrier"
+        ) as mock_extract:
+            mock_ctx = Mock()
+            mock_extract.return_value = mock_ctx
+
+            with patch(
+                "honeyhive.tracer.processing.context.baggage.set_baggage"
+            ) as mock_set_baggage:
+                mock_set_baggage.return_value = mock_ctx
+
+                with patch("honeyhive.tracer.processing.context.context.attach"):
+                    with patch("honeyhive.tracer.processing.context.context.detach"):
+                        with with_distributed_trace_context(
+                            carrier, mock_tracer
+                        ) as ctx:
+                            # Context should not be None
+                            assert ctx is not None
+                            assert ctx == mock_ctx

--- a/tests_v2/unit/test_tracer_processing_otlp_profiles.py
+++ b/tests_v2/unit/test_tracer_processing_otlp_profiles.py
@@ -1,0 +1,1046 @@
+"""Unit tests for honeyhive.tracer.processing.otlp_profiles.
+
+This module contains comprehensive unit tests for OTLP profile management,
+including environment-specific configuration profiles, dynamic adjustments,
+and environment analysis functions.
+"""
+
+# pylint: disable=too-many-lines,duplicate-code
+# Justification: Comprehensive unit test coverage requires extensive test cases
+
+# pylint: disable=redefined-outer-name
+# Justification: Pytest fixture pattern requires parameter shadowing
+
+# pylint: disable=protected-access
+# Justification: Unit tests need to verify private method behavior
+
+from typing import Any, Dict
+from unittest.mock import Mock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from honeyhive.tracer.processing.otlp_profiles import (
+    EnvironmentProfile,
+    EnvironmentProfileManager,
+    _analyze_performance_characteristics,
+    _analyze_resource_constraints,
+    _determine_environment_type,
+    get_environment_optimized_config,
+)
+from honeyhive.tracer.processing.otlp_session import OTLPSessionConfig
+
+
+@pytest.fixture
+def sample_environment_profile() -> EnvironmentProfile:
+    """Create a sample environment profile for testing."""
+    return EnvironmentProfile(
+        name="Test Profile",
+        description="Test environment profile for unit testing",
+        pool_connections=10,
+        pool_maxsize=20,
+        max_retries=3,
+        timeout=30.0,
+        backoff_factor=0.5,
+        pool_block=False,
+        additional_config={"test_key": "test_value"},
+    )
+
+
+@pytest.fixture
+def mock_container_info() -> Dict[str, Any]:
+    """Create mock container information for testing."""
+    return {
+        "container.runtime": "docker",
+        "k8s.cluster.name": "test-cluster",
+        "container.id": "test-container-123",
+    }
+
+
+@pytest.fixture
+def mock_cloud_info() -> Dict[str, Any]:
+    """Create mock cloud information for testing."""
+    return {
+        "cloud.provider": "aws",
+        "cloud.region": "us-east-1",
+        "faas.name": "test-lambda",
+    }
+
+
+@pytest.fixture
+def mock_tracer_instance() -> Mock:
+    """Create a mock tracer instance for testing."""
+    tracer = Mock()
+    tracer.batch_size = 100
+    tracer.disable_batch = False
+    tracer.verbose = False
+    tracer.config = Mock()
+    tracer.config.batch_size = 100
+    return tracer
+
+
+class TestEnvironmentProfile:
+    """Test cases for EnvironmentProfile Pydantic model."""
+
+    def test_environment_profile_creation_valid_data(self) -> None:
+        """Test creating EnvironmentProfile with valid data."""
+        profile = EnvironmentProfile(
+            name="Test Profile",
+            description="Test description",
+            pool_connections=5,
+            pool_maxsize=10,
+            max_retries=2,
+            timeout=15.0,
+            backoff_factor=0.3,
+            pool_block=True,
+            additional_config={"key": "value"},
+        )
+
+        assert profile.name == "Test Profile"
+        assert profile.description == "Test description"
+        assert profile.pool_connections == 5
+        assert profile.pool_maxsize == 10
+        assert profile.max_retries == 2
+        assert profile.timeout == 15.0
+        assert profile.backoff_factor == 0.3
+        assert profile.pool_block is True
+        assert profile.additional_config == {"key": "value"}
+
+    def test_environment_profile_creation_minimal_data(self) -> None:
+        """Test creating EnvironmentProfile with minimal required data."""
+        profile = EnvironmentProfile(
+            name="Minimal Profile",
+            pool_connections=1,
+            pool_maxsize=2,
+            max_retries=1,
+            timeout=5.0,
+            backoff_factor=0.1,
+        )
+
+        assert profile.name == "Minimal Profile"
+        assert profile.description == ""
+        assert profile.pool_block is False
+        assert profile.additional_config is None
+
+    def test_environment_profile_validation_constraints(self) -> None:
+        """Test EnvironmentProfile field validation constraints."""
+        # Test pool_connections constraints
+        with pytest.raises(ValidationError):
+            EnvironmentProfile(
+                name="Test",
+                pool_connections=0,  # Below minimum
+                pool_maxsize=5,
+                max_retries=1,
+                timeout=5.0,
+                backoff_factor=0.1,
+            )
+
+        with pytest.raises(ValidationError):
+            EnvironmentProfile(
+                name="Test",
+                pool_connections=51,  # Above maximum
+                pool_maxsize=5,
+                max_retries=1,
+                timeout=5.0,
+                backoff_factor=0.1,
+            )
+
+    def test_environment_profile_pool_maxsize_validator(self) -> None:
+        """Test pool_maxsize validator ensures it's >= pool_connections."""
+        # Test automatic adjustment when pool_maxsize < pool_connections
+        profile = EnvironmentProfile(
+            name="Test Profile",
+            pool_connections=15,
+            pool_maxsize=10,  # Less than pool_connections
+            max_retries=1,
+            timeout=5.0,
+            backoff_factor=0.1,
+        )
+
+        # Should be adjusted to at least pool_connections value
+        assert profile.pool_maxsize >= profile.pool_connections
+
+    def test_environment_profile_name_validation(self) -> None:
+        """Test name field validation constraints."""
+        # Test empty name
+        with pytest.raises(ValidationError):
+            EnvironmentProfile(
+                name="",  # Empty name
+                pool_connections=1,
+                pool_maxsize=2,
+                max_retries=1,
+                timeout=5.0,
+                backoff_factor=0.1,
+            )
+
+        # Test name too long
+        with pytest.raises(ValidationError):
+            EnvironmentProfile(
+                name="x" * 101,  # Too long
+                pool_connections=1,
+                pool_maxsize=2,
+                max_retries=1,
+                timeout=5.0,
+                backoff_factor=0.1,
+            )
+
+    def test_environment_profile_timeout_validation(self) -> None:
+        """Test timeout field validation constraints."""
+        # Test zero timeout
+        with pytest.raises(ValidationError):
+            EnvironmentProfile(
+                name="Test",
+                pool_connections=1,
+                pool_maxsize=2,
+                max_retries=1,
+                timeout=0.0,  # Invalid timeout
+                backoff_factor=0.1,
+            )
+
+        # Test negative timeout
+        with pytest.raises(ValidationError):
+            EnvironmentProfile(
+                name="Test",
+                pool_connections=1,
+                pool_maxsize=2,
+                max_retries=1,
+                timeout=-5.0,  # Negative timeout
+                backoff_factor=0.1,
+            )
+
+
+class TestDetermineEnvironmentType:
+    """Test cases for _determine_environment_type function."""
+
+    def test_determine_environment_type_aws_lambda(self) -> None:
+        """Test environment type determination for AWS Lambda."""
+        cloud_info: Dict[str, Any] = {"faas.name": "test-lambda-function"}
+        container_info: Dict[str, Any] = {}
+
+        result = _determine_environment_type(container_info, cloud_info)
+
+        assert result == "aws_lambda"
+
+    def test_determine_environment_type_kubernetes(self) -> None:
+        """Test environment type determination for Kubernetes."""
+        container_info: Dict[str, Any] = {"k8s.cluster.name": "test-cluster"}
+        cloud_info: Dict[str, Any] = {}
+
+        result = _determine_environment_type(container_info, cloud_info)
+
+        assert result == "kubernetes"
+
+    def test_determine_environment_type_docker(self) -> None:
+        """Test environment type determination for Docker."""
+        container_info: Dict[str, Any] = {"container.runtime": "docker"}
+        cloud_info: Dict[str, Any] = {}
+
+        result = _determine_environment_type(container_info, cloud_info)
+
+        assert result == "docker"
+
+    def test_determine_environment_type_aws_ec2(self) -> None:
+        """Test environment type determination for AWS EC2."""
+        container_info: Dict[str, Any] = {}
+        cloud_info: Dict[str, Any] = {"cloud.provider": "aws"}
+
+        result = _determine_environment_type(container_info, cloud_info)
+
+        assert result == "aws_ec2"
+
+    def test_determine_environment_type_gcp(self) -> None:
+        """Test environment type determination for GCP."""
+        container_info: Dict[str, Any] = {}
+        cloud_info: Dict[str, Any] = {"cloud.provider": "gcp"}
+
+        result = _determine_environment_type(container_info, cloud_info)
+
+        assert result == "gcp"
+
+    def test_determine_environment_type_azure(self) -> None:
+        """Test environment type determination for Azure."""
+        container_info: Dict[str, Any] = {}
+        cloud_info: Dict[str, Any] = {"cloud.provider": "azure"}
+
+        result = _determine_environment_type(container_info, cloud_info)
+
+        assert result == "azure"
+
+    def test_determine_environment_type_standard_fallback(self) -> None:
+        """Test environment type determination fallback to standard."""
+        container_info: Dict[str, Any] = {}
+        cloud_info: Dict[str, Any] = {}
+
+        result = _determine_environment_type(container_info, cloud_info)
+
+        assert result == "standard"
+
+    def test_determine_environment_type_priority_order(self) -> None:
+        """Test that serverless takes priority over other environment types."""
+        # Lambda should take priority over Kubernetes
+        container_info = {"k8s.cluster.name": "test-cluster"}
+        cloud_info = {"faas.name": "test-lambda", "cloud.provider": "aws"}
+
+        result = _determine_environment_type(container_info, cloud_info)
+
+        assert result == "aws_lambda"
+
+
+class TestAnalyzeResourceConstraints:
+    """Test cases for _analyze_resource_constraints function."""
+
+    @patch("honeyhive.tracer.processing.otlp_profiles.os.getenv")
+    @patch("honeyhive.tracer.processing.otlp_profiles.multiprocessing.cpu_count")
+    def test_analyze_resource_constraints_lambda_memory(
+        self, mock_cpu_count: Mock, mock_getenv: Mock
+    ) -> None:
+        """Test resource constraints analysis with Lambda memory setting."""
+        mock_getenv.return_value = "512"  # AWS Lambda memory size
+        mock_cpu_count.return_value = 2
+
+        result = _analyze_resource_constraints()
+
+        assert result["memory_mb"] == 512
+        assert result["memory_tier"] == "medium"
+        assert result["cpu_count"] == 2
+        assert result["cpu_tier"] == "low"
+
+    @patch("honeyhive.tracer.processing.otlp_profiles.os.getenv")
+    @patch("honeyhive.tracer.processing.otlp_profiles.multiprocessing.cpu_count")
+    def test_analyze_resource_constraints_high_memory(
+        self, mock_cpu_count: Mock, mock_getenv: Mock
+    ) -> None:
+        """Test resource constraints analysis with high memory."""
+        mock_getenv.return_value = "2048"  # High memory
+        mock_cpu_count.return_value = 8
+
+        result = _analyze_resource_constraints()
+
+        assert result["memory_mb"] == 2048
+        assert result["memory_tier"] == "high"
+        assert result["cpu_count"] == 8
+        assert result["cpu_tier"] == "medium"
+
+    @patch("honeyhive.tracer.processing.otlp_profiles.os.getenv")
+    @patch("honeyhive.tracer.processing.otlp_profiles.multiprocessing.cpu_count")
+    def test_analyze_resource_constraints_low_memory(
+        self, mock_cpu_count: Mock, mock_getenv: Mock
+    ) -> None:
+        """Test resource constraints analysis with low memory."""
+        mock_getenv.return_value = "256"  # Low memory
+        mock_cpu_count.return_value = 1
+
+        result = _analyze_resource_constraints()
+
+        assert result["memory_mb"] == 256
+        assert result["memory_tier"] == "low"
+        assert result["cpu_count"] == 1
+        assert result["cpu_tier"] == "low"
+
+    @patch("honeyhive.tracer.processing.otlp_profiles.os.getenv")
+    @patch("honeyhive.tracer.processing.otlp_profiles.multiprocessing.cpu_count")
+    def test_analyze_resource_constraints_no_lambda_memory(
+        self, mock_cpu_count: Mock, mock_getenv: Mock
+    ) -> None:
+        """Test resource constraints analysis without Lambda memory setting."""
+        mock_getenv.return_value = None  # No Lambda memory
+        mock_cpu_count.return_value = 4
+
+        result = _analyze_resource_constraints()
+
+        assert "memory_mb" not in result
+        assert result["memory_tier"] == "medium"
+        assert result["cpu_count"] == 4
+        assert result["cpu_tier"] == "medium"
+
+    @patch("honeyhive.tracer.processing.otlp_profiles.os.getenv")
+    @patch("honeyhive.tracer.processing.otlp_profiles.multiprocessing.cpu_count")
+    def test_analyze_resource_constraints_cpu_exception(
+        self, mock_cpu_count: Mock, mock_getenv: Mock
+    ) -> None:
+        """Test resource constraints analysis when CPU count fails."""
+        mock_getenv.return_value = None
+        mock_cpu_count.side_effect = Exception("CPU count failed")
+
+        result = _analyze_resource_constraints()
+
+        assert result["cpu_count"] == 1
+        assert result["cpu_tier"] == "low"
+
+    @patch("honeyhive.tracer.processing.otlp_profiles.os.getenv")
+    def test_analyze_resource_constraints_exception_handling(
+        self, mock_getenv: Mock
+    ) -> None:
+        """Test resource constraints analysis exception handling."""
+        mock_getenv.side_effect = Exception("Environment access failed")
+
+        result = _analyze_resource_constraints()
+
+        assert "analysis_error" in result
+        assert "Environment access failed" in result["analysis_error"]
+
+
+class TestAnalyzePerformanceCharacteristics:
+    """Test cases for _analyze_performance_characteristics function."""
+
+    @patch("honeyhive.tracer.processing.otlp_profiles.os.getenv")
+    def test_analyze_performance_characteristics_aws_lambda(
+        self, mock_getenv: Mock
+    ) -> None:
+        """Test performance characteristics analysis for AWS Lambda."""
+        mock_getenv.side_effect = lambda key, default=None: {
+            "HH_HIGH_CONCURRENCY": None,
+            "HH_SESSION_NAME": "test-session",
+        }.get(key, default)
+
+        result = _analyze_performance_characteristics("aws_lambda")
+
+        assert result["execution_model"] == "serverless"
+        assert result["cold_start_sensitive"] is True
+        assert result["connection_reuse_critical"] is True
+        assert result["latency_sensitivity"] == "high"
+        assert result["concurrency_pattern"] == "burst"
+
+    @patch("honeyhive.tracer.processing.otlp_profiles.os.getenv")
+    def test_analyze_performance_characteristics_kubernetes(
+        self, mock_getenv: Mock
+    ) -> None:
+        """Test performance characteristics analysis for Kubernetes."""
+        mock_getenv.side_effect = lambda key, default=None: {
+            "HH_HIGH_CONCURRENCY": None,
+            "HH_SESSION_NAME": "test-session",
+        }.get(key, default)
+
+        result = _analyze_performance_characteristics("kubernetes")
+
+        assert result["execution_model"] == "orchestrated"
+        assert result["scaling_dynamic"] is True
+        assert result["connection_persistence"] == "medium"
+        assert result["latency_sensitivity"] == "standard"
+        assert result["concurrency_pattern"] == "standard"
+
+    @patch("honeyhive.tracer.processing.otlp_profiles.os.getenv")
+    def test_analyze_performance_characteristics_standard(
+        self, mock_getenv: Mock
+    ) -> None:
+        """Test performance characteristics analysis for standard environment."""
+        mock_getenv.side_effect = lambda key, default=None: {
+            "HH_HIGH_CONCURRENCY": None,
+            "HH_SESSION_NAME": "test-session",
+        }.get(key, default)
+
+        result = _analyze_performance_characteristics("standard")
+
+        assert result["execution_model"] == "persistent"
+        assert result["connection_persistence"] == "high"
+        assert result["latency_sensitivity"] == "standard"
+        assert result["concurrency_pattern"] == "standard"
+
+    @patch("honeyhive.tracer.processing.otlp_profiles.os.getenv")
+    def test_analyze_performance_characteristics_high_concurrency(
+        self, mock_getenv: Mock
+    ) -> None:
+        """Test performance characteristics with high concurrency enabled."""
+        mock_getenv.side_effect = lambda key, default=None: {
+            "HH_HIGH_CONCURRENCY": "true",
+            "HH_SESSION_NAME": "test-session",
+        }.get(key, default)
+
+        result = _analyze_performance_characteristics("standard")
+
+        assert result["concurrency_pattern"] == "high"
+
+    @patch("honeyhive.tracer.processing.otlp_profiles.os.getenv")
+    def test_analyze_performance_characteristics_benchmark_session(
+        self, mock_getenv: Mock
+    ) -> None:
+        """Test performance characteristics with benchmark session name."""
+        mock_getenv.side_effect = lambda key, default=None: {
+            "HH_HIGH_CONCURRENCY": None,
+            "HH_SESSION_NAME": "benchmark-test-session",
+        }.get(key, default)
+
+        result = _analyze_performance_characteristics("standard")
+
+        assert result["latency_sensitivity"] == "critical"
+
+    @patch("honeyhive.tracer.processing.otlp_profiles.os.getenv")
+    def test_analyze_performance_characteristics_load_session(
+        self, mock_getenv: Mock
+    ) -> None:
+        """Test performance characteristics with load test session name."""
+        mock_getenv.side_effect = lambda key, default=None: {
+            "HH_HIGH_CONCURRENCY": None,
+            "HH_SESSION_NAME": "load-test-session",
+        }.get(key, default)
+
+        result = _analyze_performance_characteristics("standard")
+
+        assert result["latency_sensitivity"] == "critical"
+
+    @patch("honeyhive.tracer.processing.otlp_profiles.os.getenv")
+    def test_analyze_performance_characteristics_exception_handling(
+        self, mock_getenv: Mock
+    ) -> None:
+        """Test performance characteristics analysis exception handling."""
+        mock_getenv.side_effect = Exception("Environment access failed")
+
+        result = _analyze_performance_characteristics("standard")
+
+        assert "analysis_error" in result
+        assert "Environment access failed" in result["analysis_error"]
+
+
+class TestEnvironmentProfileManager:
+    """Test cases for EnvironmentProfileManager class."""
+
+    def test_environment_profile_manager_profiles_exist(self) -> None:
+        """Test that all expected profiles exist in EnvironmentProfileManager."""
+        expected_profiles = [
+            "aws_lambda",
+            "kubernetes",
+            "docker",
+            "gcp",
+            "azure",
+            "aws_ec2",
+            "standard",
+        ]
+
+        for profile_name in expected_profiles:
+            assert profile_name in EnvironmentProfileManager.PROFILES
+            profile = EnvironmentProfileManager.PROFILES[profile_name]
+            assert isinstance(profile, EnvironmentProfile)
+            assert profile.name is not None
+            assert profile.pool_connections > 0
+            assert profile.pool_maxsize > 0
+
+    @patch(
+        "honeyhive.tracer.processing.otlp_profiles."
+        "get_comprehensive_environment_analysis"
+    )
+    @patch("honeyhive.tracer.processing.otlp_profiles.safe_log")
+    def test_get_optimal_profile_aws_lambda(
+        self, mock_safe_log: Mock, mock_env_analysis: Mock, mock_tracer_instance: Mock
+    ) -> None:
+        """Test getting optimal profile for AWS Lambda environment."""
+        mock_env_analysis.return_value = {
+            "environment_type": "aws_lambda",
+            "resource_constraints": {"memory_tier": "medium", "cpu_tier": "low"},
+            "performance_characteristics": {"latency_sensitivity": "high"},
+        }
+
+        profile, environment_analysis = EnvironmentProfileManager.get_optimal_profile(
+            mock_tracer_instance
+        )
+
+        assert profile.name.startswith("AWS Lambda")
+        assert environment_analysis["environment_type"] == "aws_lambda"
+        mock_safe_log.assert_called()
+
+    @patch(
+        "honeyhive.tracer.processing.otlp_profiles."
+        "get_comprehensive_environment_analysis"
+    )
+    @patch("honeyhive.tracer.processing.otlp_profiles.safe_log")
+    def test_get_optimal_profile_standard_fallback(
+        self, mock_safe_log: Mock, mock_env_analysis: Mock, mock_tracer_instance: Mock
+    ) -> None:
+        """Test getting optimal profile with fallback to standard."""
+        mock_env_analysis.return_value = {
+            "environment_type": "unknown_environment",
+            "resource_constraints": {},
+            "performance_characteristics": {},
+        }
+
+        profile, environment_analysis = EnvironmentProfileManager.get_optimal_profile(
+            mock_tracer_instance
+        )
+
+        assert profile.name.startswith("Standard Environment")
+        assert environment_analysis["environment_type"] == "unknown_environment"
+        mock_safe_log.assert_called()
+
+    @patch(
+        "honeyhive.tracer.processing.otlp_profiles."
+        "get_comprehensive_environment_analysis"
+    )
+    @patch("honeyhive.tracer.processing.otlp_profiles.safe_log")
+    def test_get_optimal_profile_no_tracer_instance(
+        self, mock_safe_log: Mock, mock_env_analysis: Mock
+    ) -> None:
+        """Test getting optimal profile without tracer instance."""
+        mock_env_analysis.return_value = {
+            "environment_type": "standard",
+            "resource_constraints": {},
+            "performance_characteristics": {},
+        }
+
+        profile, environment_analysis = EnvironmentProfileManager.get_optimal_profile(
+            None
+        )
+
+        assert isinstance(profile, EnvironmentProfile)
+        assert environment_analysis["environment_type"] == "standard"
+        mock_safe_log.assert_called()
+
+    def test_apply_dynamic_adjustments_memory_low(
+        self, sample_environment_profile: EnvironmentProfile, mock_tracer_instance: Mock
+    ) -> None:
+        """Test dynamic adjustments for low memory environment."""
+        environment_analysis = {
+            "resource_constraints": {"memory_tier": "low", "cpu_tier": "medium"},
+            "performance_characteristics": {"latency_sensitivity": "standard"},
+        }
+
+        adjusted_profile = EnvironmentProfileManager._apply_dynamic_adjustments(
+            sample_environment_profile, environment_analysis, mock_tracer_instance
+        )
+
+        # Low memory should reduce pool sizes
+        assert (
+            adjusted_profile.pool_connections
+            <= sample_environment_profile.pool_connections
+        )
+        assert adjusted_profile.pool_maxsize <= sample_environment_profile.pool_maxsize
+        assert adjusted_profile.name.endswith("(Optimized)")
+
+    def test_apply_dynamic_adjustments_memory_high(
+        self, sample_environment_profile: EnvironmentProfile, mock_tracer_instance: Mock
+    ) -> None:
+        """Test dynamic adjustments for high memory environment."""
+        environment_analysis = {
+            "resource_constraints": {"memory_tier": "high", "cpu_tier": "high"},
+            "performance_characteristics": {"latency_sensitivity": "standard"},
+        }
+
+        adjusted_profile = EnvironmentProfileManager._apply_dynamic_adjustments(
+            sample_environment_profile, environment_analysis, mock_tracer_instance
+        )
+
+        # High memory should increase pool sizes
+        assert (
+            adjusted_profile.pool_connections
+            >= sample_environment_profile.pool_connections
+        )
+        assert adjusted_profile.pool_maxsize >= sample_environment_profile.pool_maxsize
+
+    def test_apply_dynamic_adjustments_latency_critical(
+        self, sample_environment_profile: EnvironmentProfile, mock_tracer_instance: Mock
+    ) -> None:
+        """Test dynamic adjustments for critical latency sensitivity."""
+        environment_analysis = {
+            "resource_constraints": {"memory_tier": "medium", "cpu_tier": "medium"},
+            "performance_characteristics": {"latency_sensitivity": "critical"},
+        }
+
+        adjusted_profile = EnvironmentProfileManager._apply_dynamic_adjustments(
+            sample_environment_profile, environment_analysis, mock_tracer_instance
+        )
+
+        # Critical latency should reduce timeout and retries
+        assert adjusted_profile.timeout <= sample_environment_profile.timeout
+        assert adjusted_profile.max_retries <= sample_environment_profile.max_retries
+        assert (
+            adjusted_profile.backoff_factor <= sample_environment_profile.backoff_factor
+        )
+
+    def test_apply_dynamic_adjustments_high_concurrency(
+        self, sample_environment_profile: EnvironmentProfile, mock_tracer_instance: Mock
+    ) -> None:
+        """Test dynamic adjustments for high concurrency pattern."""
+        environment_analysis = {
+            "resource_constraints": {"memory_tier": "medium", "cpu_tier": "medium"},
+            "performance_characteristics": {"concurrency_pattern": "high"},
+        }
+
+        adjusted_profile = EnvironmentProfileManager._apply_dynamic_adjustments(
+            sample_environment_profile, environment_analysis, mock_tracer_instance
+        )
+
+        # High concurrency should increase pool sizes
+        assert (
+            adjusted_profile.pool_connections
+            >= sample_environment_profile.pool_connections
+        )
+        assert adjusted_profile.pool_maxsize >= sample_environment_profile.pool_maxsize
+
+    def test_apply_dynamic_adjustments_exception_handling(
+        self,
+        sample_environment_profile: EnvironmentProfile,
+        mock_tracer_instance: Mock,
+    ) -> None:
+        """Test dynamic adjustments exception handling."""
+        # Create invalid environment analysis that will cause exception
+        environment_analysis = {
+            "resource_constraints": {"memory_tier": None},  # Invalid data
+            "performance_characteristics": {"latency_sensitivity": None},
+        }
+
+        result = EnvironmentProfileManager._apply_dynamic_adjustments(
+            sample_environment_profile, environment_analysis, mock_tracer_instance
+        )
+
+        # Should return base profile on exception, but it will be modified
+        # with name change
+        assert result.pool_connections == sample_environment_profile.pool_connections
+        assert result.pool_maxsize == sample_environment_profile.pool_maxsize
+        # The exception doesn't actually trigger safe_log in this case
+        # because the environment_analysis has valid structure
+
+    def test_create_otlp_config_from_profile(
+        self, sample_environment_profile: EnvironmentProfile, mock_tracer_instance: Mock
+    ) -> None:
+        """Test creating OTLP config from environment profile."""
+        config = EnvironmentProfileManager.create_otlp_config_from_profile(
+            sample_environment_profile, mock_tracer_instance
+        )
+
+        assert isinstance(config, OTLPSessionConfig)
+        assert config.pool_connections == sample_environment_profile.pool_connections
+        assert config.pool_maxsize == sample_environment_profile.pool_maxsize
+        assert config.max_retries == sample_environment_profile.max_retries
+        assert config.timeout == sample_environment_profile.timeout
+        assert config.backoff_factor == sample_environment_profile.backoff_factor
+        assert config.pool_block == sample_environment_profile.pool_block
+
+    def test_create_otlp_config_from_profile_with_overrides(
+        self, sample_environment_profile: EnvironmentProfile, mock_tracer_instance: Mock
+    ) -> None:
+        """Test creating OTLP config from profile with overrides."""
+        overrides = {
+            "pool_connections": 25,
+            "timeout": 60.0,
+            "retry_status_codes": [500, 502, 503],
+        }
+
+        config = EnvironmentProfileManager.create_otlp_config_from_profile(
+            sample_environment_profile, mock_tracer_instance, **overrides
+        )
+
+        assert config.pool_connections == 25
+        assert config.timeout == 60.0
+        assert config.retry_status_codes == [500, 502, 503]
+        # Pool maxsize should be adjusted to match pool_connections due to validator
+        assert config.pool_maxsize >= config.pool_connections
+
+    def test_create_otlp_config_from_profile_type_conversion(
+        self, sample_environment_profile: EnvironmentProfile, mock_tracer_instance: Mock
+    ) -> None:
+        """Test type conversion in OTLP config creation."""
+        overrides = {
+            "pool_connections": "15",  # String should be converted to int
+            "timeout": "45.5",  # String should be converted to float
+            "pool_block": "true",  # String should be converted to bool
+        }
+
+        config = EnvironmentProfileManager.create_otlp_config_from_profile(
+            sample_environment_profile, mock_tracer_instance, **overrides
+        )
+
+        assert config.pool_connections == 15
+        assert config.timeout == 45.5
+        assert config.pool_block is True
+
+
+class TestGetEnvironmentOptimizedConfig:
+    """Test cases for get_environment_optimized_config function."""
+
+    @patch(
+        "honeyhive.tracer.processing.otlp_profiles."
+        "EnvironmentProfileManager.get_optimal_profile"
+    )
+    @patch(
+        "honeyhive.tracer.processing.otlp_profiles."
+        "EnvironmentProfileManager.create_otlp_config_from_profile"
+    )
+    def test_get_environment_optimized_config_success(
+        self,
+        mock_create_config: Mock,
+        mock_get_profile: Mock,
+        mock_tracer_instance: Mock,
+        sample_environment_profile: EnvironmentProfile,
+    ) -> None:
+        """Test successful environment optimized config retrieval."""
+        mock_get_profile.return_value = (
+            sample_environment_profile,
+            {"environment_type": "standard"},
+        )
+        mock_config = Mock(spec=OTLPSessionConfig)
+        mock_create_config.return_value = mock_config
+
+        result = get_environment_optimized_config(mock_tracer_instance)
+
+        assert result == mock_config
+        mock_get_profile.assert_called_once_with(mock_tracer_instance)
+        mock_create_config.assert_called_once_with(
+            sample_environment_profile, mock_tracer_instance
+        )
+
+    @patch(
+        "honeyhive.tracer.processing.otlp_profiles."
+        "EnvironmentProfileManager.get_optimal_profile"
+    )
+    @patch(
+        "honeyhive.tracer.processing.otlp_profiles."
+        "EnvironmentProfileManager.create_otlp_config_from_profile"
+    )
+    def test_get_environment_optimized_config_with_overrides(
+        self,
+        mock_create_config: Mock,
+        mock_get_profile: Mock,
+        mock_tracer_instance: Mock,
+        sample_environment_profile: EnvironmentProfile,
+    ) -> None:
+        """Test environment optimized config with overrides."""
+        mock_get_profile.return_value = (
+            sample_environment_profile,
+            {"environment_type": "standard"},
+        )
+        mock_config = Mock(spec=OTLPSessionConfig)
+        mock_create_config.return_value = mock_config
+
+        overrides = {"pool_connections": 20, "timeout": 45.0}
+
+        result = get_environment_optimized_config(mock_tracer_instance, **overrides)
+
+        assert result == mock_config
+        mock_create_config.assert_called_once_with(
+            sample_environment_profile, mock_tracer_instance, **overrides
+        )
+
+    @patch(
+        "honeyhive.tracer.processing.otlp_profiles."
+        "EnvironmentProfileManager.get_optimal_profile"
+    )
+    @patch(
+        "honeyhive.tracer.processing.otlp_profiles."
+        "EnvironmentProfileManager.create_otlp_config_from_profile"
+    )
+    def test_get_environment_optimized_config_no_tracer(
+        self,
+        mock_create_config: Mock,
+        mock_get_profile: Mock,
+        sample_environment_profile: EnvironmentProfile,
+    ) -> None:
+        """Test environment optimized config without tracer instance."""
+        mock_get_profile.return_value = (
+            sample_environment_profile,
+            {"environment_type": "standard"},
+        )
+        mock_config = Mock(spec=OTLPSessionConfig)
+        mock_create_config.return_value = mock_config
+
+        result = get_environment_optimized_config(None)
+
+        assert result == mock_config
+        mock_get_profile.assert_called_once_with(None)
+        mock_create_config.assert_called_once_with(sample_environment_profile, None)
+
+
+class TestEdgeCasesAndErrorHandling:
+    """Test cases for edge cases and error handling scenarios."""
+
+    def test_environment_profile_with_none_additional_config(self) -> None:
+        """Test EnvironmentProfile with None additional_config."""
+        profile = EnvironmentProfile(
+            name="Test Profile",
+            pool_connections=5,
+            pool_maxsize=10,
+            max_retries=2,
+            timeout=15.0,
+            backoff_factor=0.3,
+            additional_config=None,
+        )
+
+        assert profile.additional_config is None
+
+    def test_environment_profile_with_empty_additional_config(self) -> None:
+        """Test EnvironmentProfile with empty additional_config."""
+        profile = EnvironmentProfile(
+            name="Test Profile",
+            pool_connections=5,
+            pool_maxsize=10,
+            max_retries=2,
+            timeout=15.0,
+            backoff_factor=0.3,
+            additional_config={},
+        )
+
+        assert profile.additional_config == {}
+
+    def test_determine_environment_type_empty_inputs(self) -> None:
+        """Test _determine_environment_type with empty inputs."""
+        result = _determine_environment_type({}, {})
+        assert result == "standard"
+
+    def test_determine_environment_type_none_values(self) -> None:
+        """Test _determine_environment_type with None values in inputs."""
+        container_info = {"k8s.cluster.name": None, "container.runtime": None}
+        cloud_info = {"cloud.provider": None, "faas.name": None}
+
+        result = _determine_environment_type(container_info, cloud_info)
+        assert result == "standard"
+
+    @patch("honeyhive.tracer.processing.otlp_profiles.os.getenv")
+    def test_analyze_resource_constraints_invalid_memory_value(
+        self, mock_getenv: Mock
+    ) -> None:
+        """Test resource constraints analysis with invalid memory value."""
+        mock_getenv.return_value = "invalid_number"
+
+        # Should not raise exception, should handle gracefully
+        result = _analyze_resource_constraints()
+
+        # Should have analysis error instead of memory_tier
+        assert "analysis_error" in result
+
+    def test_apply_dynamic_adjustments_empty_analysis(
+        self, sample_environment_profile: EnvironmentProfile, mock_tracer_instance: Mock
+    ) -> None:
+        """Test dynamic adjustments with empty environment analysis."""
+        environment_analysis: Dict[str, Any] = {
+            "resource_constraints": {},
+            "performance_characteristics": {},
+        }
+
+        result = EnvironmentProfileManager._apply_dynamic_adjustments(
+            sample_environment_profile, environment_analysis, mock_tracer_instance
+        )
+
+        # Should still return a valid profile
+        assert isinstance(result, EnvironmentProfile)
+        assert result.name.endswith("(Optimized)")
+
+    def test_apply_dynamic_adjustments_missing_keys(
+        self, sample_environment_profile: EnvironmentProfile, mock_tracer_instance: Mock
+    ) -> None:
+        """Test dynamic adjustments with missing keys in analysis."""
+        environment_analysis: Dict[str, Any] = {}  # Missing required keys
+
+        result = EnvironmentProfileManager._apply_dynamic_adjustments(
+            sample_environment_profile, environment_analysis, mock_tracer_instance
+        )
+
+        # Should still return a valid profile
+        assert isinstance(result, EnvironmentProfile)
+
+
+class TestComprehensiveCoverage:
+    """Test cases to ensure comprehensive coverage of all code paths."""
+
+    def test_environment_profile_all_validation_constraints(self) -> None:
+        """Test all validation constraints for EnvironmentProfile."""
+        # Test max_retries constraints
+        with pytest.raises(ValidationError):
+            EnvironmentProfile(
+                name="Test",
+                pool_connections=5,
+                pool_maxsize=10,
+                max_retries=-1,  # Below minimum
+                timeout=15.0,
+                backoff_factor=0.3,
+            )
+
+        with pytest.raises(ValidationError):
+            EnvironmentProfile(
+                name="Test",
+                pool_connections=5,
+                pool_maxsize=10,
+                max_retries=11,  # Above maximum
+                timeout=15.0,
+                backoff_factor=0.3,
+            )
+
+        # Test backoff_factor constraints
+        with pytest.raises(ValidationError):
+            EnvironmentProfile(
+                name="Test",
+                pool_connections=5,
+                pool_maxsize=10,
+                max_retries=3,
+                timeout=15.0,
+                backoff_factor=-0.1,  # Below minimum
+            )
+
+        with pytest.raises(ValidationError):
+            EnvironmentProfile(
+                name="Test",
+                pool_connections=5,
+                pool_maxsize=10,
+                max_retries=3,
+                timeout=15.0,
+                backoff_factor=5.1,  # Above maximum
+            )
+
+    def test_all_predefined_profiles_valid(self) -> None:
+        """Test that all predefined profiles in EnvironmentProfileManager are valid."""
+        for profile in EnvironmentProfileManager.PROFILES.values():
+            # Verify all profiles are valid EnvironmentProfile instances
+            assert isinstance(profile, EnvironmentProfile)
+            assert profile.name is not None
+            assert len(profile.name) > 0
+            assert profile.pool_connections >= 1
+            assert profile.pool_maxsize >= profile.pool_connections
+            assert profile.max_retries >= 0
+            assert profile.timeout > 0
+            assert profile.backoff_factor >= 0
+
+            # Verify additional_config structure
+            if profile.additional_config is not None:
+                assert isinstance(profile.additional_config, dict)
+
+    @patch("honeyhive.tracer.processing.otlp_profiles.os.getenv")
+    def test_analyze_performance_characteristics_all_branches(
+        self, mock_getenv: Mock
+    ) -> None:
+        """Test all conditional branches in _analyze_performance_characteristics."""
+        # Test all environment types
+        environment_types = [
+            "aws_lambda",
+            "kubernetes",
+            "docker",
+            "standard",
+            "unknown",
+        ]
+
+        for env_type in environment_types:
+            mock_getenv.side_effect = lambda key, default=None: {
+                "HH_HIGH_CONCURRENCY": None,
+                "HH_SESSION_NAME": "test-session",
+            }.get(key, default)
+
+            result = _analyze_performance_characteristics(env_type)
+
+            # Should always return a dict with some characteristics
+            assert isinstance(result, dict)
+            if env_type in ["aws_lambda", "kubernetes"]:
+                assert "execution_model" in result
+            else:
+                assert "execution_model" in result
+                assert result["execution_model"] == "persistent"
+
+    def test_create_otlp_config_all_override_types(
+        self, sample_environment_profile: EnvironmentProfile, mock_tracer_instance: Mock
+    ) -> None:
+        """Test creating OTLP config with all possible override types."""
+        overrides = {
+            "pool_connections": 25,
+            "pool_maxsize": 50,
+            "max_retries": 5,
+            "timeout": 60.0,
+            "backoff_factor": 1.0,
+            "pool_block": True,
+            "retry_status_codes": [429, 500, 502, 503, 504],
+        }
+
+        config = EnvironmentProfileManager.create_otlp_config_from_profile(
+            sample_environment_profile, mock_tracer_instance, **overrides
+        )
+
+        assert config.pool_connections == 25
+        assert config.pool_maxsize == 50
+        assert config.max_retries == 5
+        assert config.timeout == 60.0
+        assert config.backoff_factor == 1.0
+        assert config.pool_block is True
+        assert config.retry_status_codes == [429, 500, 502, 503, 504]

--- a/tests_v2/unit/test_tracer_processing_otlp_session.py
+++ b/tests_v2/unit/test_tracer_processing_otlp_session.py
@@ -1,0 +1,620 @@
+# pylint: disable=too-many-lines,line-too-long,redefined-outer-name,duplicate-code
+# Reason: Comprehensive testing file requires extensive test coverage for 90%+ target
+# Line length disabled for test readability and comprehensive assertions
+# Redefined outer name disabled for pytest fixture usage pattern
+"""Unit tests for OTLP session management module.
+
+This module provides comprehensive test coverage for the otlp_session module,
+including configuration validation, session creation, dynamic configuration,
+and graceful degradation scenarios.
+
+Test Coverage:
+- OTLPSessionConfig validation and field validators
+- create_optimized_otlp_session with various configurations
+- get_session_stats for connection pool monitoring
+- create_dynamic_otlp_config with environment analysis
+- Factory functions (default, high volume, low latency configs)
+- Error handling and graceful degradation
+- Integration with environment detection system
+
+Following Agent OS testing standards with proper fixtures and isolation.
+Generated using enhanced comprehensive analysis framework for 90%+ coverage.
+"""
+
+from typing import Any, Dict
+from unittest.mock import Mock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from honeyhive.tracer.processing.otlp_session import (
+    OTLPSessionConfig,
+    _apply_scenario_dynamic_adjustments,
+    _apply_tracer_dynamic_adjustments,
+    _calculate_base_config_from_environment,
+    _get_basic_environment_analysis,
+    _get_comprehensive_environment_analysis,
+    create_dynamic_otlp_config,
+    create_optimized_otlp_session,
+    get_default_otlp_config,
+    get_high_volume_otlp_config,
+    get_low_latency_otlp_config,
+    get_session_stats,
+)
+
+
+@pytest.fixture
+def mock_tracer_instance() -> Mock:
+    """Create a mock tracer instance for testing."""
+    tracer = Mock()
+    tracer.batch_size = 100
+    tracer.disable_batch = False
+    tracer.verbose = False
+    tracer.config = Mock()
+    tracer.config.batch_size = 100
+    return tracer
+
+
+@pytest.fixture
+def sample_otlp_config() -> OTLPSessionConfig:
+    """Create a sample OTLP configuration for testing."""
+    return OTLPSessionConfig(
+        pool_connections=15,
+        pool_maxsize=25,
+        max_retries=5,
+        pool_block=True,
+        timeout=45.0,
+        backoff_factor=0.8,
+        retry_status_codes=[429, 500, 502, 503, 504],
+    )
+
+
+@pytest.fixture
+def mock_environment_analysis() -> Dict[str, Any]:
+    """Create mock environment analysis data for testing."""
+    return {
+        "environment_type": "production",
+        "resource_constraints": {
+            "memory_constraint_factor": 1.2,
+            "cpu_scaling_factor": 1.5,
+            "network_scaling_factor": 1.0,
+            "network_tier": "standard",
+        },
+        "performance_characteristics": {
+            "timeout_multiplier": 1.0,
+            "retry_multiplier": 1.0,
+            "concurrency_multiplier": 1.0,
+            "overall_scaling_factor": 1.0,
+            "execution_model": "persistent",
+            "latency_sensitivity": "standard",
+        },
+    }
+
+
+class TestOTLPSessionConfig:
+    """Test cases for OTLPSessionConfig Pydantic model."""
+
+    def test_valid_config_creation(self) -> None:
+        """Test creating OTLPSessionConfig with valid parameters."""
+        config = OTLPSessionConfig(
+            pool_connections=10,
+            pool_maxsize=20,
+            max_retries=3,
+            pool_block=False,
+            timeout=30.0,
+            backoff_factor=0.5,
+            retry_status_codes=[429, 500, 502, 503, 504],
+        )
+
+        assert config.pool_connections == 10
+        assert config.pool_maxsize == 20
+        assert config.max_retries == 3
+        assert config.pool_block is False
+        assert config.timeout == 30.0
+        assert config.backoff_factor == 0.5
+        assert config.retry_status_codes == [429, 500, 502, 503, 504]
+
+    def test_default_values(self) -> None:
+        """Test OTLPSessionConfig default values."""
+        config = OTLPSessionConfig()
+
+        assert config.pool_connections == 10
+        assert config.pool_maxsize == 20
+        assert config.max_retries == 3
+        assert config.pool_block is False
+        assert config.timeout == 30.0
+        assert config.backoff_factor == 0.5
+        assert config.retry_status_codes == [429, 500, 502, 503, 504]
+
+    def test_config_validation_constraints(self) -> None:
+        """Test field validation constraints."""
+        # Test pool_connections constraints
+        with pytest.raises(ValidationError):
+            OTLPSessionConfig(pool_connections=0)  # Below minimum
+
+        with pytest.raises(ValidationError):
+            OTLPSessionConfig(pool_connections=101)  # Above maximum
+
+        # Test pool_maxsize constraints
+        with pytest.raises(ValidationError):
+            OTLPSessionConfig(pool_maxsize=0)  # Below minimum
+
+        with pytest.raises(ValidationError):
+            OTLPSessionConfig(pool_maxsize=201)  # Above maximum
+
+    def test_pool_maxsize_validator(self) -> None:
+        """Test pool_maxsize validator ensures it's >= pool_connections."""
+        # Test automatic adjustment when pool_maxsize < pool_connections
+        config = OTLPSessionConfig(pool_connections=25, pool_maxsize=15)
+        assert config.pool_maxsize == 25  # Should be adjusted
+
+    def test_retry_status_codes_validator(self) -> None:
+        """Test retry_status_codes validator."""
+        # Test valid status codes
+        config = OTLPSessionConfig(retry_status_codes=[200, 404, 500])
+        assert config.retry_status_codes == [200, 404, 500]
+
+        # Test empty list fallback
+        config = OTLPSessionConfig(retry_status_codes=[])
+        assert config.retry_status_codes == [429, 500, 502, 503, 504]
+
+    def test_to_dict_method(self) -> None:
+        """Test to_dict method returns proper dictionary representation."""
+        config = OTLPSessionConfig(pool_connections=5, pool_maxsize=10)
+        config_dict = config.to_dict()
+
+        assert isinstance(config_dict, dict)
+        assert config_dict["pool_connections"] == 5
+        assert config_dict["pool_maxsize"] == 10
+
+
+class TestSessionCreation:
+    """Test cases for create_optimized_otlp_session function."""
+
+    @patch("honeyhive.tracer.processing.otlp_session.requests.Session")
+    @patch("honeyhive.tracer.processing.otlp_session.HTTPAdapter")
+    @patch("honeyhive.tracer.processing.otlp_session.Retry")
+    def test_create_optimized_otlp_session_default_config(
+        self, mock_retry: Mock, mock_adapter: Mock, mock_session_class: Mock
+    ) -> None:
+        """Test creating optimized OTLP session with default configuration."""
+        mock_session = Mock()
+        mock_session_class.return_value = mock_session
+
+        result = create_optimized_otlp_session()
+
+        assert result == mock_session
+        mock_session_class.assert_called_once()
+        mock_retry.assert_called_once()
+        mock_adapter.assert_called_once()
+
+    @patch("honeyhive.tracer.processing.otlp_session.requests.Session")
+    def test_create_optimized_otlp_session_exception_handling(
+        self, mock_session_class: Mock
+    ) -> None:
+        """Test exception handling in session creation."""
+        # First call raises exception, second call succeeds for fallback
+        fallback_session = Mock()
+        mock_session_class.side_effect = [
+            Exception("Session creation failed"),
+            fallback_session,
+        ]
+
+        result = create_optimized_otlp_session()
+
+        # Should return fallback session
+        assert result == fallback_session
+        assert mock_session_class.call_count == 2
+
+    def test_get_session_stats_basic(self) -> None:
+        """Test basic session statistics collection."""
+        session = Mock()
+        session.adapters = {"http://": Mock(), "https://": Mock()}
+
+        stats = get_session_stats(session)
+
+        assert isinstance(stats, dict)
+        assert "adapters" in stats
+        assert "total_pools" in stats
+
+    def test_get_session_stats_with_pool_manager(self) -> None:
+        """Test session statistics with pool manager information."""
+        session = Mock()
+        adapter = Mock()
+        adapter.poolmanager = Mock()
+        adapter.poolmanager.pools = {"pool1": Mock(), "pool2": Mock()}
+        session.adapters = {"https://": adapter}
+
+        stats = get_session_stats(session)
+
+        assert stats["adapters"]["https://"]["pools"] == 2
+        assert stats["total_pools"] == 2
+
+    def test_get_session_stats_exception_handling(self) -> None:
+        """Test session statistics exception handling."""
+        session = Mock()
+        # Create a mock adapters object that raises an exception when items() is called
+        mock_adapters = Mock()
+        mock_adapters.items.side_effect = Exception("Adapter access failed")
+        session.adapters = mock_adapters
+
+        stats = get_session_stats(session)
+
+        assert "error" in stats
+        assert "Failed to get session stats" in stats["error"]
+
+
+class TestDynamicConfiguration:
+    """Test cases for dynamic OTLP configuration functions."""
+
+    @patch(
+        "honeyhive.tracer.processing.otlp_session._get_comprehensive_environment_analysis"
+    )
+    def test_create_dynamic_otlp_config_success(
+        self, mock_env_analysis: Mock, mock_environment_analysis: Dict[str, Any]
+    ) -> None:
+        """Test successful dynamic OTLP configuration creation."""
+        mock_env_analysis.return_value = mock_environment_analysis
+
+        config = create_dynamic_otlp_config(None, "default")
+
+        assert isinstance(config, OTLPSessionConfig)
+        mock_env_analysis.assert_called_once_with(None)
+
+    @patch(
+        "honeyhive.tracer.processing.otlp_session._get_comprehensive_environment_analysis"
+    )
+    @patch("honeyhive.tracer.processing.otlp_session._get_basic_environment_analysis")
+    def test_create_dynamic_otlp_config_fallback(
+        self, mock_basic_analysis: Mock, mock_comprehensive_analysis: Mock
+    ) -> None:
+        """Test dynamic configuration fallback to basic analysis."""
+        mock_comprehensive_analysis.side_effect = Exception("Analysis failed")
+        mock_basic_analysis.return_value = {
+            "resource_constraints": {},
+            "performance_characteristics": {},
+        }
+
+        config = create_dynamic_otlp_config(None, "default")
+
+        assert isinstance(config, OTLPSessionConfig)
+        mock_basic_analysis.assert_called_once_with(None)
+
+    def test_calculate_base_config_from_environment(self) -> None:
+        """Test base configuration calculation from environment analysis."""
+
+        resource_constraints = {
+            "memory_constraint_factor": 1.5,
+            "cpu_scaling_factor": 2.0,
+            "network_scaling_factor": 1.2,
+            "network_tier": "standard",
+        }
+        performance_chars = {
+            "timeout_multiplier": 1.1,
+            "retry_multiplier": 0.8,
+            "concurrency_multiplier": 1.3,
+            "execution_model": "persistent",
+            "latency_sensitivity": "standard",
+        }
+
+        config = _calculate_base_config_from_environment(
+            resource_constraints, performance_chars
+        )
+
+        assert isinstance(config, dict)
+        assert "pool_connections" in config
+        assert "pool_maxsize" in config
+        assert config["pool_block"] is True  # persistent execution model
+
+    def test_apply_tracer_dynamic_adjustments_batch_size(
+        self, mock_tracer_instance: Mock
+    ) -> None:
+        """Test tracer adjustments based on batch size."""
+
+        mock_tracer_instance.batch_size = 200  # Large batch size
+
+        base_config = {"pool_connections": 10, "pool_maxsize": 20, "timeout": 30.0}
+        adjusted_config = _apply_tracer_dynamic_adjustments(
+            base_config, mock_tracer_instance
+        )
+
+        # Should scale up for large batch size
+        assert adjusted_config["pool_connections"] >= base_config["pool_connections"]
+        assert adjusted_config["pool_maxsize"] >= base_config["pool_maxsize"]
+
+    def test_apply_scenario_dynamic_adjustments_high_volume(self) -> None:
+        """Test scenario adjustments for high volume scenario."""
+
+        performance_chars = {
+            "overall_scaling_factor": 2.0,
+            "concurrency_multiplier": 1.0,
+        }
+
+        base_config = {
+            "pool_connections": 10,
+            "pool_maxsize": 20,
+            "max_retries": 3,
+            "timeout": 30.0,
+        }
+        adjusted_config = _apply_scenario_dynamic_adjustments(
+            base_config, "high_volume", performance_chars
+        )
+
+        # High volume should scale up resources
+        assert adjusted_config["pool_connections"] >= base_config["pool_connections"]
+        assert adjusted_config["max_retries"] >= base_config["max_retries"]
+
+
+class TestEnvironmentAnalysis:
+    """Test cases for environment analysis functions."""
+
+    @patch(
+        "honeyhive.tracer.processing.otlp_session.get_comprehensive_environment_analysis"
+    )
+    def test_get_comprehensive_environment_analysis_success(
+        self, mock_get_analysis: Mock
+    ) -> None:
+        """Test successful comprehensive environment analysis."""
+
+        expected_analysis = {
+            "environment_type": "production",
+            "resource_constraints": {},
+        }
+        mock_get_analysis.return_value = expected_analysis
+
+        result = _get_comprehensive_environment_analysis(None)
+
+        assert result == expected_analysis
+        mock_get_analysis.assert_called_once_with(None)
+
+    @patch("honeyhive.tracer.processing.otlp_session.get_performance_characteristics")
+    def test_get_basic_environment_analysis_success(
+        self, mock_get_performance: Mock
+    ) -> None:
+        """Test successful basic environment analysis."""
+
+        expected_performance = {"performance": "data"}
+        mock_get_performance.return_value = expected_performance
+
+        result = _get_basic_environment_analysis(None)
+
+        assert result == expected_performance
+        mock_get_performance.assert_called_once_with(None)
+
+
+class TestConfigurationFactories:
+    """Test cases for configuration factory functions."""
+
+    @patch("honeyhive.tracer.processing.otlp_session.create_dynamic_otlp_config")
+    def test_get_default_otlp_config(self, mock_create_dynamic: Mock) -> None:
+        """Test get_default_otlp_config factory function."""
+        expected_config = OTLPSessionConfig()
+        mock_create_dynamic.return_value = expected_config
+
+        result = get_default_otlp_config(None)
+
+        assert result == expected_config
+        mock_create_dynamic.assert_called_once_with(None, "default")
+
+    @patch("honeyhive.tracer.processing.otlp_session.create_dynamic_otlp_config")
+    def test_get_high_volume_otlp_config(self, mock_create_dynamic: Mock) -> None:
+        """Test get_high_volume_otlp_config factory function."""
+        expected_config = OTLPSessionConfig(pool_maxsize=50)
+        mock_create_dynamic.return_value = expected_config
+
+        result = get_high_volume_otlp_config(None)
+
+        assert result == expected_config
+        mock_create_dynamic.assert_called_once_with(None, "high_volume")
+
+    @patch("honeyhive.tracer.processing.otlp_session.create_dynamic_otlp_config")
+    def test_get_low_latency_otlp_config(self, mock_create_dynamic: Mock) -> None:
+        """Test get_low_latency_otlp_config factory function."""
+        expected_config = OTLPSessionConfig(timeout=10.0)
+        mock_create_dynamic.return_value = expected_config
+
+        result = get_low_latency_otlp_config(None)
+
+        assert result == expected_config
+        mock_create_dynamic.assert_called_once_with(None, "low_latency")
+
+
+class TestGracefulDegradation:
+    """Test cases for graceful degradation scenarios."""
+
+    @patch("honeyhive.tracer.processing.otlp_session.requests.Session")
+    def test_session_creation_graceful_failure(self, mock_session_class: Mock) -> None:
+        """Test graceful failure handling in session creation."""
+        # First call fails, second call (fallback) succeeds
+        fallback_session = Mock()
+        mock_session_class.side_effect = [
+            Exception("Creation failed"),
+            fallback_session,
+        ]
+
+        result = create_optimized_otlp_session()
+
+        assert result == fallback_session
+        assert mock_session_class.call_count == 2
+
+    @patch(
+        "honeyhive.tracer.processing.otlp_session._get_comprehensive_environment_analysis"
+    )
+    def test_config_creation_graceful_failure(self, mock_env_analysis: Mock) -> None:
+        """Test graceful failure handling in config creation."""
+        mock_env_analysis.side_effect = Exception("Environment analysis failed")
+
+        # Should not raise exception, should return valid config
+        config = create_dynamic_otlp_config(None)
+
+        assert isinstance(config, OTLPSessionConfig)
+
+    def test_no_exceptions_propagate_to_host(self) -> None:
+        """Test that no exceptions propagate to host application."""
+        with patch(
+            "honeyhive.tracer.processing.otlp_session.requests.Session"
+        ) as mock_session:
+            fallback_session = Mock()
+            mock_session.side_effect = [Exception("Critical error"), fallback_session]
+
+            # Should not raise any exception
+            result = create_optimized_otlp_session()
+            assert result is not None
+
+
+class TestCoverageEnhancement:
+    """Additional test cases to ensure comprehensive coverage."""
+
+    def test_otlp_session_config_field_validation_edge_cases(self) -> None:
+        """Test OTLPSessionConfig field validation edge cases."""
+        # Test maximum valid values
+        config = OTLPSessionConfig(
+            pool_connections=100,
+            pool_maxsize=200,
+            max_retries=20,
+            timeout=600.0,
+            backoff_factor=10.0,
+        )
+        assert config.pool_connections == 100
+        assert config.pool_maxsize == 200
+        assert config.max_retries == 20
+
+    @patch(
+        "honeyhive.tracer.processing.otlp_session._get_comprehensive_environment_analysis"
+    )
+    def test_dynamic_config_with_empty_environment_analysis(
+        self, mock_env_analysis: Mock
+    ) -> None:
+        """Test dynamic configuration with empty environment analysis."""
+        mock_env_analysis.return_value = {
+            "resource_constraints": {},
+            "performance_characteristics": {},
+        }
+
+        config = create_dynamic_otlp_config(None, "default")
+
+        assert isinstance(config, OTLPSessionConfig)
+        # Should use default values when environment analysis is empty
+        assert config.pool_connections >= 2
+        assert config.pool_maxsize >= 5
+
+    def test_tracer_adjustments_with_config_batch_size_none(self) -> None:
+        """Test tracer adjustments when both batch_size and config.batch_size are None."""
+
+        mock_tracer = Mock()
+        mock_tracer.batch_size = None
+        mock_tracer.config = Mock()
+        mock_tracer.config.batch_size = None
+        mock_tracer.disable_batch = False
+        mock_tracer.verbose = False
+
+        base_config = {"pool_connections": 10, "pool_maxsize": 20, "timeout": 30.0}
+        adjusted_config = _apply_tracer_dynamic_adjustments(base_config, mock_tracer)
+
+        # Should not modify config when no batch size is available
+        assert adjusted_config["pool_connections"] == base_config["pool_connections"]
+        assert adjusted_config["pool_maxsize"] == base_config["pool_maxsize"]
+
+    def test_environment_analysis_network_tier_variations(self) -> None:
+        """Test environment analysis with different network tier variations."""
+
+        test_cases = [
+            {"network_tier": "premium"},
+            {"network_tier": "basic"},
+            {"network_tier": "enterprise"},
+        ]
+
+        for resource_constraints in test_cases:
+            performance_chars = {"execution_model": "persistent"}
+            config = _calculate_base_config_from_environment(
+                resource_constraints, performance_chars
+            )
+
+            # Should handle all network tiers gracefully
+            assert isinstance(config, dict)
+            assert "retry_status_codes" in config
+            # Standard tiers should use standard retry codes
+            assert config["retry_status_codes"] == [429, 500, 502, 503, 504]
+
+    @patch(
+        "honeyhive.tracer.processing.otlp_session.get_comprehensive_environment_analysis"
+    )
+    def test_comprehensive_environment_analysis_exception_handling(
+        self, mock_comprehensive: Mock
+    ) -> None:
+        """Test comprehensive environment analysis exception handling."""
+
+        mock_comprehensive.side_effect = ImportError("Environment module not available")
+
+        # Should fall back to basic analysis without raising exception
+        result = _get_comprehensive_environment_analysis(None)
+
+        assert isinstance(result, dict)
+
+    def test_apply_scenario_adjustments_low_latency(self) -> None:
+        """Test scenario adjustments for low latency scenario."""
+
+        performance_chars = {
+            "overall_scaling_factor": 1.0,
+            "concurrency_multiplier": 1.0,
+            "latency_sensitivity": "critical",
+        }
+
+        base_config = {
+            "pool_connections": 10,
+            "pool_maxsize": 20,
+            "max_retries": 3,
+            "timeout": 30.0,
+            "backoff_factor": 0.5,
+        }
+
+        adjusted_config = _apply_scenario_dynamic_adjustments(
+            base_config, "low_latency", performance_chars
+        )
+
+        # Low latency should reduce timeouts and retries
+        assert adjusted_config["timeout"] <= base_config["timeout"]
+        assert adjusted_config["max_retries"] <= base_config["max_retries"]
+        assert adjusted_config["backoff_factor"] <= base_config["backoff_factor"]
+
+    def test_tracer_adjustments_disable_batch_mode(self) -> None:
+        """Test tracer adjustments when batching is disabled."""
+
+        mock_tracer = Mock()
+        mock_tracer.batch_size = 100
+        mock_tracer.disable_batch = True  # Immediate mode
+        mock_tracer.verbose = False
+        mock_tracer.config = Mock()
+        mock_tracer.config.batch_size = 100
+
+        base_config = {"pool_connections": 10, "pool_maxsize": 20, "timeout": 30.0}
+        adjusted_config = _apply_tracer_dynamic_adjustments(base_config, mock_tracer)
+
+        # Immediate mode should increase connections and reduce timeout
+        assert adjusted_config["pool_connections"] >= base_config["pool_connections"]
+        assert adjusted_config["pool_maxsize"] >= base_config["pool_maxsize"]
+        assert adjusted_config["timeout"] <= base_config["timeout"]
+
+    def test_tracer_adjustments_verbose_mode(self) -> None:
+        """Test tracer adjustments when verbose mode is enabled."""
+
+        mock_tracer = Mock()
+        mock_tracer.batch_size = 50
+        mock_tracer.disable_batch = False
+        mock_tracer.verbose = True  # Verbose mode
+        mock_tracer.config = Mock()
+        mock_tracer.config.batch_size = 50
+
+        base_config = {
+            "pool_connections": 10,
+            "pool_maxsize": 20,
+            "timeout": 30.0,
+            "max_retries": 3,
+            "backoff_factor": 0.5,
+        }
+        adjusted_config = _apply_tracer_dynamic_adjustments(base_config, mock_tracer)
+
+        # Verbose mode should increase retries and timeout, reduce backoff
+        assert adjusted_config["max_retries"] >= base_config["max_retries"]
+        assert adjusted_config["timeout"] >= base_config["timeout"]
+        assert adjusted_config["backoff_factor"] <= base_config["backoff_factor"]

--- a/tests_v2/unit/test_tracer_processing_span_processor.py
+++ b/tests_v2/unit/test_tracer_processing_span_processor.py
@@ -1,0 +1,1286 @@
+"""Unit tests for HoneyHive span processor.
+
+Generated using enhanced comprehensive analysis documentation with coverage requirements
+to achieve both 90%+ test success rate AND 90%+ code coverage.
+
+Analysis Applied:
+- Phase 1: Core file analysis completed
+- Phase 2: Method verification & analysis with exact logging messages
+- Phase 3: External dependency analysis for all imports
+- Phase 4: Integration & usage validation from production code
+- Phase 5: Coverage completeness with all conditional branches and exception paths
+"""
+
+# pylint: disable=protected-access,too-many-lines,unused-argument,unnecessary-lambda,line-too-long,use-implicit-booleaness-not-comparison
+# Justification: line-too-long: Complex processor assertions; use-implicit-booleaness-not-comparison: Explicit empty dict check for clarity
+
+from typing import Any, Dict, Optional
+from unittest.mock import Mock, call, patch
+
+from opentelemetry.context import Context
+from opentelemetry.sdk.trace import ReadableSpan, Span
+from opentelemetry.trace import Status, StatusCode
+
+from honeyhive.tracer.core.tracer import HoneyHiveTracer
+from honeyhive.tracer.processing.span_processor import HoneyHiveSpanProcessor
+
+
+class TestHoneyHiveSpanProcessorInitialization:
+    """Test span processor initialization and configuration."""
+
+    def test_init_default_parameters(self) -> None:
+        """Test initialization with default parameters."""
+        processor = HoneyHiveSpanProcessor()
+
+        assert processor.client is None
+        assert processor.disable_batch is False
+        assert processor.otlp_exporter is None
+        assert processor.tracer_instance is None
+        assert processor.mode == "otlp"
+
+    def test_init_with_client_mode(self) -> None:
+        """Test initialization with client (Events API mode)."""
+        mock_client = Mock()
+        processor = HoneyHiveSpanProcessor(client=mock_client)
+
+        assert processor.client is mock_client
+        assert processor.mode == "client"
+
+    def test_init_with_otlp_exporter(self) -> None:
+        """Test initialization with OTLP exporter."""
+        mock_exporter = Mock()
+        processor = HoneyHiveSpanProcessor(otlp_exporter=mock_exporter)
+
+        assert processor.otlp_exporter is mock_exporter
+        assert processor.mode == "otlp"
+
+    def test_init_with_tracer_instance(self) -> None:
+        """Test initialization with tracer instance."""
+        mock_tracer = Mock(spec=HoneyHiveTracer)
+        processor = HoneyHiveSpanProcessor(tracer_instance=mock_tracer)
+
+        assert processor.tracer_instance is mock_tracer
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_init_logging_client_mode(self, mock_safe_log: Mock) -> None:
+        """Test initialization logging for client mode - EXACT messages."""
+        mock_client = Mock()
+        mock_tracer = Mock(spec=HoneyHiveTracer)
+
+        HoneyHiveSpanProcessor(client=mock_client, tracer_instance=mock_tracer)
+
+        # Production code makes TWO logging calls - test both with exact messages
+        expected_calls = [
+            call(
+                mock_tracer,
+                "debug",
+                "🚀 HoneyHiveSpanProcessor initialized in CLIENT mode (direct API)",
+            ),
+            call(
+                mock_tracer,
+                "debug",
+                "🔧 Span processor mode: client, client: True, disable_batch: False",
+            ),
+        ]
+        mock_safe_log.assert_has_calls(expected_calls)
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_init_logging_otlp_immediate_mode(self, mock_safe_log: Mock) -> None:
+        """Test initialization logging for OTLP immediate mode - EXACT messages."""
+        mock_tracer = Mock(spec=HoneyHiveTracer)
+
+        HoneyHiveSpanProcessor(disable_batch=True, tracer_instance=mock_tracer)
+
+        # Production code makes TWO logging calls with format strings
+        expected_calls = [
+            call(
+                mock_tracer,
+                "debug",
+                "🚀 HoneyHiveSpanProcessor initialized in OTLP mode (immediate)",
+            ),
+            call(
+                mock_tracer,
+                "debug",
+                "🔧 Span processor mode: otlp, client: False, disable_batch: True",
+            ),
+        ]
+        mock_safe_log.assert_has_calls(expected_calls)
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_init_logging_otlp_batched_mode(self, mock_safe_log: Mock) -> None:
+        """Test initialization logging for OTLP batched mode - EXACT messages."""
+        mock_tracer = Mock(spec=HoneyHiveTracer)
+
+        HoneyHiveSpanProcessor(disable_batch=False, tracer_instance=mock_tracer)
+
+        # Production code makes TWO logging calls with format strings
+        expected_calls = [
+            call(
+                mock_tracer,
+                "debug",
+                "🚀 HoneyHiveSpanProcessor initialized in OTLP mode (batched)",
+            ),
+            call(
+                mock_tracer,
+                "debug",
+                "🔧 Span processor mode: otlp, client: False, disable_batch: False",
+            ),
+        ]
+        mock_safe_log.assert_has_calls(expected_calls)
+
+
+class TestHoneyHiveSpanProcessorSafeLog:
+    """Test safe logging functionality."""
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_safe_log_with_args(self, mock_safe_log: Mock) -> None:
+        """Test safe logging with format arguments."""
+        mock_tracer = Mock(spec=HoneyHiveTracer)
+        processor = HoneyHiveSpanProcessor(tracer_instance=mock_tracer)
+
+        processor._safe_log("debug", "Test message %s %d", "arg1", 42)
+
+        mock_safe_log.assert_called_with(mock_tracer, "debug", "Test message arg1 42")
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_safe_log_with_kwargs(self, mock_safe_log: Mock) -> None:
+        """Test safe logging with keyword arguments."""
+        mock_tracer = Mock(spec=HoneyHiveTracer)
+        processor = HoneyHiveSpanProcessor(tracer_instance=mock_tracer)
+
+        processor._safe_log("info", "Test message", honeyhive_data={"key": "value"})
+
+        mock_safe_log.assert_called_with(
+            mock_tracer, "info", "Test message", honeyhive_data={"key": "value"}
+        )
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_safe_log_no_args(self, mock_safe_log: Mock) -> None:
+        """Test safe logging without arguments."""
+        mock_tracer = Mock(spec=HoneyHiveTracer)
+        processor = HoneyHiveSpanProcessor(tracer_instance=mock_tracer)
+
+        processor._safe_log("warning", "Simple message")
+
+        mock_safe_log.assert_called_with(mock_tracer, "warning", "Simple message")
+
+
+class TestHoneyHiveSpanProcessorContext:
+    """Test context handling functionality."""
+
+    def test_get_context_with_context(self) -> None:
+        """Test context retrieval when context is provided."""
+        processor = HoneyHiveSpanProcessor()
+        mock_context = Mock(spec=Context)
+
+        result = processor._get_context(mock_context)
+
+        assert result is mock_context
+
+    @patch("honeyhive.tracer.processing.span_processor.context.get_current")
+    def test_get_context_without_context(self, mock_get_current: Mock) -> None:
+        """Test context retrieval when no context is provided."""
+        processor = HoneyHiveSpanProcessor()
+        mock_current_context = Mock(spec=Context)
+        mock_get_current.return_value = mock_current_context
+
+        result = processor._get_context(None)
+
+        assert result is mock_current_context
+        mock_get_current.assert_called_once()
+
+
+class TestHoneyHiveSpanProcessorBaggageHandling:
+    """Test baggage attribute handling with all conditional branches."""
+
+    @patch("honeyhive.tracer.processing.span_processor.baggage.get_baggage")
+    def test_get_basic_baggage_attributes_success(self, mock_get_baggage: Mock) -> None:
+        """Test successful baggage attribute extraction."""
+        processor = HoneyHiveSpanProcessor()
+        mock_context = Mock(spec=Context)
+
+        def mock_baggage_side_effect(key: str, ctx: Context) -> Optional[str]:
+            baggage_data = {
+                "session_id": "session-123",
+                "project": "test-project",
+                "source": "test-source",
+                "parent_id": "parent-456",
+            }
+            return baggage_data.get(key)
+
+        mock_get_baggage.side_effect = mock_baggage_side_effect
+
+        result = processor._get_basic_baggage_attributes(mock_context)
+
+        expected = {
+            "honeyhive.session_id": "session-123",
+            "traceloop.association.properties.session_id": "session-123",
+            "honeyhive.project": "test-project",
+            "traceloop.association.properties.project": "test-project",
+            "honeyhive.source": "test-source",
+            "traceloop.association.properties.source": "test-source",
+            "honeyhive.parent_id": "parent-456",
+        }
+        assert result == expected
+
+    @patch("honeyhive.tracer.processing.span_processor.baggage.get_baggage")
+    def test_get_basic_baggage_with_tracer_session_priority(
+        self, mock_get_baggage: Mock
+    ) -> None:
+        """Test baggage session_id priority over tracer session_id."""
+        mock_tracer = Mock(spec=HoneyHiveTracer)
+        mock_tracer.session_id = "tracer-session-456"
+        mock_tracer.project_name = "test-project"
+        mock_tracer.source_environment = "test-source"
+        processor = HoneyHiveSpanProcessor(tracer_instance=mock_tracer)
+        mock_context = Mock(spec=Context)
+
+        def mock_baggage_side_effect(key: str, ctx: Context) -> Optional[str]:
+            baggage_data = {
+                "session_id": "baggage-session-123",
+                # project/source also from baggage in distributed tracing
+                "project": "distributed-project",
+                "source": "distributed-source",
+            }
+            return baggage_data.get(key)
+
+        mock_get_baggage.side_effect = mock_baggage_side_effect
+
+        result = processor._get_basic_baggage_attributes(mock_context)
+
+        # UPDATED: Baggage now takes priority for distributed tracing
+        expected = {
+            "honeyhive.session_id": "baggage-session-123",
+            "traceloop.association.properties.session_id": "baggage-session-123",
+            "honeyhive.project": "distributed-project",
+            "traceloop.association.properties.project": "distributed-project",
+            "honeyhive.source": "distributed-source",
+            "traceloop.association.properties.source": "distributed-source",
+        }
+        assert result == expected
+
+    @patch("honeyhive.tracer.processing.span_processor.baggage.get_baggage")
+    def test_get_basic_baggage_empty(self, mock_get_baggage: Mock) -> None:
+        """Test baggage extraction with empty baggage."""
+        processor = HoneyHiveSpanProcessor()
+        mock_context = Mock(spec=Context)
+
+        mock_get_baggage.return_value = None
+
+        result = processor._get_basic_baggage_attributes(mock_context)
+
+        assert not result
+
+    @patch("honeyhive.tracer.processing.span_processor.baggage.get_baggage")
+    def test_get_evaluation_attributes_from_baggage_all_present(
+        self, mock_get_baggage: Mock
+    ) -> None:
+        """Test evaluation attribute extraction when all attributes present."""
+        processor = HoneyHiveSpanProcessor()
+        mock_context = Mock(spec=Context)
+
+        def mock_baggage_side_effect(key: str, ctx: Context) -> Optional[str]:
+            baggage_data = {
+                "run_id": "run-123",
+                "dataset_id": "dataset-456",
+                "datapoint_id": "datapoint-789",
+            }
+            return baggage_data.get(key)
+
+        mock_get_baggage.side_effect = mock_baggage_side_effect
+
+        result = processor._get_evaluation_attributes_from_baggage(mock_context)
+
+        expected = {
+            "honeyhive_metadata.run_id": "run-123",
+            "honeyhive_metadata.dataset_id": "dataset-456",
+            "honeyhive_metadata.datapoint_id": "datapoint-789",
+        }
+        assert result == expected
+
+    @patch("honeyhive.tracer.processing.span_processor.baggage.get_baggage")
+    def test_get_evaluation_attributes_from_baggage_partial(
+        self, mock_get_baggage: Mock
+    ) -> None:
+        """Test evaluation attribute extraction with some attributes missing."""
+        processor = HoneyHiveSpanProcessor()
+        mock_context = Mock(spec=Context)
+
+        def mock_baggage_side_effect(key: str, ctx: Context) -> Optional[str]:
+            baggage_data = {
+                "run_id": "run-123",
+                # dataset_id and datapoint_id missing
+            }
+            return baggage_data.get(key)
+
+        mock_get_baggage.side_effect = mock_baggage_side_effect
+
+        result = processor._get_evaluation_attributes_from_baggage(mock_context)
+
+        expected = {
+            "honeyhive_metadata.run_id": "run-123",
+        }
+        assert result == expected
+
+    @patch("honeyhive.tracer.processing.span_processor.baggage.get_baggage")
+    def test_get_evaluation_attributes_from_baggage_empty(
+        self, mock_get_baggage: Mock
+    ) -> None:
+        """Test evaluation attribute extraction with no evaluation metadata."""
+        processor = HoneyHiveSpanProcessor()
+        mock_context = Mock(spec=Context)
+
+        mock_get_baggage.return_value = None
+
+        result = processor._get_evaluation_attributes_from_baggage(mock_context)
+
+        assert result == {}
+
+    @patch("honeyhive.tracer.processing.span_processor.baggage.get_baggage")
+    def test_get_basic_baggage_no_tracer_instance(self, mock_get_baggage: Mock) -> None:
+        """Test baggage extraction without tracer instance."""
+        processor = HoneyHiveSpanProcessor()  # No tracer_instance
+        mock_context = Mock(spec=Context)
+
+        def mock_baggage_side_effect(key: str, ctx: Context) -> Optional[str]:
+            return "session-789" if key == "session_id" else None
+
+        mock_get_baggage.side_effect = mock_baggage_side_effect
+
+        result = processor._get_basic_baggage_attributes(mock_context)
+
+        expected = {
+            "honeyhive.session_id": "session-789",
+            "traceloop.association.properties.session_id": "session-789",
+        }
+        assert result == expected
+
+    @patch("honeyhive.tracer.processing.span_processor.baggage.get_baggage")
+    def test_get_basic_baggage_tracer_without_session_id(
+        self, mock_get_baggage: Mock
+    ) -> None:
+        """Test baggage extraction with tracer that has no session_id attribute."""
+        mock_tracer = Mock(spec=HoneyHiveTracer)
+        # Delete attributes to simulate tracer without these fields
+        del mock_tracer.session_id
+        del mock_tracer.project_name
+        del mock_tracer.source_environment
+        processor = HoneyHiveSpanProcessor(tracer_instance=mock_tracer)
+        mock_context = Mock(spec=Context)
+
+        def mock_baggage_side_effect(key: str, ctx: Context) -> Optional[str]:
+            return "baggage-session" if key == "session_id" else None
+
+        mock_get_baggage.side_effect = mock_baggage_side_effect
+
+        result = processor._get_basic_baggage_attributes(mock_context)
+
+        expected = {
+            "honeyhive.session_id": "baggage-session",
+            "traceloop.association.properties.session_id": "baggage-session",
+        }
+        assert result == expected
+
+
+class TestHoneyHiveSpanProcessorExperimentAttributes:
+    """Test experiment attribute extraction with all conditional branches."""
+
+    def test_get_experiment_attributes_complete(self) -> None:
+        """Test experiment attributes with complete config."""
+        mock_tracer = Mock(spec=HoneyHiveTracer)
+        mock_config = Mock()
+        mock_config.get.side_effect = lambda key: {
+            "experiment_id": "exp-123",
+            "experiment_name": "test-experiment",
+            "experiment_variant": "variant-a",
+            "experiment_group": "group-1",
+        }.get(key)
+
+        mock_experiment_config = Mock()
+        mock_experiment_config.experiment_metadata = {"key": "value", "num": 42}
+        mock_config.experiment = mock_experiment_config
+
+        mock_tracer.config = mock_config
+        processor = HoneyHiveSpanProcessor(tracer_instance=mock_tracer)
+
+        result = processor._get_experiment_attributes()
+
+        expected = {
+            "honeyhive.experiment_id": "exp-123",
+            "honeyhive.experiment_name": "test-experiment",
+            "honeyhive.experiment_variant": "variant-a",
+            "honeyhive.experiment_group": "group-1",
+            "honeyhive.experiment_metadata.key": "value",
+            "honeyhive.experiment_metadata.num": "42",
+        }
+        assert result == expected
+
+    def test_get_experiment_attributes_partial(self) -> None:
+        """Test experiment attributes with partial config."""
+        mock_tracer = Mock(spec=HoneyHiveTracer)
+        mock_config = Mock()
+        mock_config.get.side_effect = lambda key: {
+            "experiment_id": "exp-456",
+            "experiment_name": "partial-experiment",
+        }.get(key)
+
+        mock_experiment_config = Mock()
+        mock_experiment_config.experiment_metadata = None
+        mock_config.experiment = mock_experiment_config
+
+        mock_tracer.config = mock_config
+        processor = HoneyHiveSpanProcessor(tracer_instance=mock_tracer)
+
+        result = processor._get_experiment_attributes()
+
+        expected = {
+            "honeyhive.experiment_id": "exp-456",
+            "honeyhive.experiment_name": "partial-experiment",
+        }
+        assert result == expected
+
+    def test_get_experiment_attributes_no_tracer(self) -> None:
+        """Test experiment attributes without tracer instance."""
+        processor = HoneyHiveSpanProcessor()
+
+        result = processor._get_experiment_attributes()
+
+        assert not result
+
+    def test_get_experiment_attributes_no_metadata(self) -> None:
+        """Test experiment attributes with no metadata."""
+        mock_tracer = Mock(spec=HoneyHiveTracer)
+        mock_config = Mock()
+        mock_config.get.side_effect = lambda key: {"experiment_id": "exp-789"}.get(key)
+
+        mock_experiment_config = Mock()
+        mock_experiment_config.experiment_metadata = {}  # Empty metadata
+        mock_config.experiment = mock_experiment_config
+
+        mock_tracer.config = mock_config
+        processor = HoneyHiveSpanProcessor(tracer_instance=mock_tracer)
+
+        result = processor._get_experiment_attributes()
+
+        expected = {"honeyhive.experiment_id": "exp-789"}
+        assert result == expected
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_get_experiment_attributes_exception_handling(
+        self, mock_safe_log: Mock
+    ) -> None:
+        """Test experiment attributes with exception in config access."""
+        mock_tracer = Mock(spec=HoneyHiveTracer)
+        mock_config = Mock()
+        mock_config.get.side_effect = Exception("Config error")
+        mock_tracer.config = mock_config
+
+        processor = HoneyHiveSpanProcessor(tracer_instance=mock_tracer)
+
+        result = processor._get_experiment_attributes()
+
+        assert not result
+        mock_safe_log.assert_called()
+
+
+class TestHoneyHiveSpanProcessorAssociationProperties:
+    """Test association properties handling with all conditional branches."""
+
+    def test_process_association_properties_with_context_get(self) -> None:
+        """Test association properties with context that has get method."""
+        processor = HoneyHiveSpanProcessor()
+        mock_context = Mock(spec=Context)
+        mock_context.get.return_value = {"key1": "value1", "key2": None}
+
+        result = processor._process_association_properties(mock_context)
+
+        # This method returns empty dict - it doesn't process association properties
+        assert not result
+
+    def test_process_association_properties_no_get_method(self) -> None:
+        """Test association properties with context that has no get method."""
+        processor = HoneyHiveSpanProcessor()
+        mock_context = Mock(spec=Context)
+        del mock_context.get  # Remove get method
+
+        result = processor._process_association_properties(mock_context)
+
+        assert not result
+
+    def test_process_association_properties_empty_properties(self) -> None:
+        """Test association properties with empty properties."""
+        processor = HoneyHiveSpanProcessor()
+        mock_context = Mock(spec=Context)
+        mock_context.get.return_value = {}
+
+        result = processor._process_association_properties(mock_context)
+
+        assert not result
+
+    def test_process_association_properties_non_dict(self) -> None:
+        """Test association properties with non-dict return value."""
+        processor = HoneyHiveSpanProcessor()
+        mock_context = Mock(spec=Context)
+        mock_context.get.return_value = "not a dict"
+
+        result = processor._process_association_properties(mock_context)
+
+        assert not result
+
+    @patch("honeyhive.tracer.processing.span_processor.baggage.get_baggage")
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_process_association_properties_exception_handling(
+        self, mock_safe_log: Mock, mock_get_baggage: Mock
+    ) -> None:
+        """Test association properties with exception handling."""
+        processor = HoneyHiveSpanProcessor()
+        mock_context = Mock(spec=Context)
+        mock_context.get.side_effect = Exception("Context error")
+
+        result = processor._process_association_properties(mock_context)
+
+        assert not result
+        mock_safe_log.assert_called()
+
+
+class TestHoneyHiveSpanProcessorTraceloopCompatibility:
+    """Test Traceloop compatibility attributes."""
+
+    def test_get_traceloop_compatibility_attributes_with_session(self) -> None:
+        """Test Traceloop compatibility attributes with session ID."""
+        processor = HoneyHiveSpanProcessor()
+        mock_context = Mock(spec=Context)
+
+        with patch.object(processor, "_get_basic_baggage_attributes") as mock_baggage:
+            mock_baggage.return_value = {
+                "honeyhive.session_id": "session-123",
+                "honeyhive.project": "test-project",
+            }
+
+            result = processor._get_traceloop_compatibility_attributes(mock_context)
+
+        # This method returns empty dict - it doesn't process traceloop attributes
+        assert not result
+
+    def test_get_traceloop_compatibility_attributes_empty(self) -> None:
+        """Test Traceloop compatibility attributes with empty baggage."""
+        processor = HoneyHiveSpanProcessor()
+        mock_context = Mock(spec=Context)
+
+        with patch.object(processor, "_get_basic_baggage_attributes") as mock_baggage:
+            mock_baggage.return_value = {}
+
+            result = processor._get_traceloop_compatibility_attributes(mock_context)
+
+            assert not result
+
+
+class TestHoneyHiveSpanProcessorEventTypeDetection:
+    """Test event type detection logic with all conditional branches."""
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_detect_event_type_from_raw_attribute(self, mock_safe_log: Mock) -> None:
+        """Test event type detection from honeyhive_event_type_raw attribute."""
+        processor = HoneyHiveSpanProcessor()
+        mock_span = Mock(spec=Span)
+        mock_span.name = "test_span"
+        mock_span.attributes = {"honeyhive_event_type_raw": "model"}
+        mock_span.get_span_context.return_value = Mock(span_id="test-span-id")
+
+        result = processor._detect_event_type(mock_span)
+
+        assert result == "model"
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_detect_event_type_from_direct_attribute(self, mock_safe_log: Mock) -> None:
+        """Test event type detection from honeyhive_event_type attribute."""
+        processor = HoneyHiveSpanProcessor()
+        mock_span = Mock(spec=Span)
+        mock_span.name = "test_span"
+        mock_span.attributes = {"honeyhive_event_type": "chain"}
+        mock_span.get_span_context.return_value = Mock(span_id="test-span-id")
+
+        # Based on production code: returns None if already processed (not "tool")
+        result = processor._detect_event_type(mock_span)
+
+        assert result is None
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_detect_event_type_ignores_tool_default(self, mock_safe_log: Mock) -> None:
+        """Test that existing 'tool' value is ignored and pattern matching is used."""
+        processor = HoneyHiveSpanProcessor()
+        mock_span = Mock(spec=Span)
+        mock_span.name = "test_span"
+        mock_span.attributes = {"honeyhive_event_type": "tool"}
+        mock_span.get_span_context.return_value = Mock(span_id="test-span-id")
+
+        with patch(
+            "honeyhive.tracer.processing.span_processor.detect_event_type_from_patterns"
+        ) as mock_detect:
+            mock_detect.return_value = "model"
+
+            result = processor._detect_event_type(mock_span)
+
+            assert result == "model"
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_detect_event_type_default_fallback(self, mock_safe_log: Mock) -> None:
+        """Test event type detection default fallback to 'tool'."""
+        processor = HoneyHiveSpanProcessor()
+        mock_span = Mock(spec=Span)
+        mock_span.name = "unknown_operation"
+        mock_span.attributes = {}
+        mock_span.get_span_context.return_value = Mock(span_id="test-span-id")
+
+        with patch(
+            "honeyhive.tracer.processing.span_processor.detect_event_type_from_patterns"
+        ) as mock_detect:
+            mock_detect.return_value = None
+
+            result = processor._detect_event_type(mock_span)
+
+            assert result == "tool"
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_detect_event_type_no_attributes(self, mock_safe_log: Mock) -> None:
+        """Test event type detection with no attributes."""
+        processor = HoneyHiveSpanProcessor()
+        mock_span = Mock(spec=Span)
+        mock_span.name = "test_span"
+        mock_span.attributes = None
+        mock_span.get_span_context.return_value = Mock(span_id="test-span-id")
+
+        result = processor._detect_event_type(mock_span)
+
+        assert result == "tool"
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_detect_event_type_exception_fallback(self, mock_safe_log: Mock) -> None:
+        """Test event type detection exception handling."""
+        processor = HoneyHiveSpanProcessor()
+        mock_span = Mock(spec=Span)
+        mock_span.name = "test_span"
+        mock_span.get_span_context.side_effect = Exception("Span context error")
+
+        result = processor._detect_event_type(mock_span)
+
+        assert result == "tool"
+        mock_safe_log.assert_called()
+
+
+class TestHoneyHiveSpanProcessorOnStart:
+    """Test on_start method functionality with all conditional branches."""
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_on_start_basic_functionality(self, mock_safe_log: Mock) -> None:
+        """Test basic on_start functionality."""
+        processor = HoneyHiveSpanProcessor()
+        mock_span = Mock(spec=Span)
+        mock_span.name = "test_span"
+        mock_span.get_span_context.return_value = Mock(span_id=12345)
+        mock_context = Mock(spec=Context)
+
+        processor.on_start(mock_span, mock_context)
+
+        mock_safe_log.assert_called()
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_on_start_with_tracer_session_id(self, mock_safe_log: Mock) -> None:
+        """Test on_start with tracer instance having session_id."""
+        mock_tracer = Mock(spec=HoneyHiveTracer)
+        mock_tracer.session_id = "tracer-session"
+        processor = HoneyHiveSpanProcessor(tracer_instance=mock_tracer)
+
+        mock_span = Mock(spec=Span)
+        mock_span.name = "test_span"
+        mock_span.get_span_context.return_value = Mock(span_id=12345)
+        mock_context = Mock(spec=Context)
+
+        processor.on_start(mock_span, mock_context)
+
+        mock_safe_log.assert_called()
+
+    @patch("honeyhive.tracer.processing.span_processor.baggage.get_baggage")
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_on_start_with_baggage_session_id(
+        self, mock_safe_log: Mock, mock_get_baggage: Mock
+    ) -> None:
+        """Test on_start with session_id from baggage."""
+        processor = HoneyHiveSpanProcessor()
+        mock_span = Mock(spec=Span)
+        mock_span.name = "test_span"
+        mock_span.get_span_context.return_value = Mock(span_id=12345)
+        mock_context = Mock(spec=Context)
+
+        mock_get_baggage.side_effect = lambda key, ctx: (
+            "baggage-session" if key == "session_id" else None
+        )
+
+        processor.on_start(mock_span, mock_context)
+
+        mock_safe_log.assert_called()
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_on_start_no_session_id(self, mock_safe_log: Mock) -> None:
+        """Test on_start with no session_id found."""
+        processor = HoneyHiveSpanProcessor()
+        mock_span = Mock(spec=Span)
+        mock_span.name = "test_span"
+        mock_span.get_span_context.return_value = Mock(span_id=12345)
+        mock_context = Mock(spec=Context)
+
+        with patch(
+            "honeyhive.tracer.processing.span_processor.baggage.get_baggage"
+        ) as mock_get_baggage:
+            mock_get_baggage.return_value = None
+
+            processor.on_start(mock_span, mock_context)
+
+            mock_safe_log.assert_called()
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_on_start_context_none(self, mock_safe_log: Mock) -> None:
+        """Test on_start with None context."""
+        processor = HoneyHiveSpanProcessor()
+        mock_span = Mock(spec=Span)
+        mock_span.name = "test_span"
+        mock_span.get_span_context.return_value = Mock(span_id=12345)
+
+        with patch.object(processor, "_get_context") as mock_get_context:
+            mock_get_context.return_value = None
+
+            processor.on_start(mock_span, None)
+
+            mock_safe_log.assert_called()
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_on_start_exception_handling(self, mock_safe_log: Mock) -> None:
+        """Test on_start exception handling."""
+        processor = HoneyHiveSpanProcessor()
+        mock_span = Mock(spec=Span)
+        mock_span.name = "test_span"
+        mock_span.get_span_context.side_effect = Exception("Span error")
+        mock_context = Mock(spec=Context)
+
+        # Exception should be caught and logged
+        try:
+            processor.on_start(mock_span, mock_context)
+        except Exception:
+            pass  # Exception should be caught by production code
+
+        mock_safe_log.assert_called()
+
+
+class TestHoneyHiveSpanProcessorOnEnd:
+    """Test on_end method functionality with all conditional branches."""
+
+    @patch("honeyhive.tracer.processing.span_processor.baggage.get_baggage")
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_on_end_client_mode_success(
+        self, mock_safe_log: Mock, mock_get_baggage: Mock
+    ) -> None:
+        """Test on_end in client mode with successful processing."""
+        mock_client = Mock()
+        mock_client.events.create.return_value = {"id": "event-123"}
+        mock_tracer = Mock(spec=HoneyHiveTracer)
+
+        processor = HoneyHiveSpanProcessor(
+            client=mock_client, tracer_instance=mock_tracer
+        )
+
+        mock_span = Mock(spec=ReadableSpan)
+        mock_span.name = "test_operation"
+        mock_span.start_time = 1000000000
+        mock_span.end_time = 2000000000
+        mock_span.attributes = {"test": "value", "honeyhive.session_id": "session-123"}
+        mock_span.status = Status(StatusCode.OK)
+        mock_span.get_span_context.return_value = Mock(span_id=12345, trace_id=67890)
+
+        mock_get_baggage.side_effect = lambda key, ctx: (
+            "session-123" if key == "session_id" else None
+        )
+
+        processor.on_end(mock_span)
+
+        mock_client.events.create.assert_called_once()
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_on_end_otlp_mode_success(self, mock_safe_log: Mock) -> None:
+        """Test on_end in OTLP mode with successful processing."""
+        mock_exporter = Mock()
+        mock_exporter.export.return_value = Mock(name="SUCCESS")
+
+        processor = HoneyHiveSpanProcessor(otlp_exporter=mock_exporter)
+
+        mock_span = Mock(spec=ReadableSpan)
+        mock_span.name = "test_operation"
+        mock_span.attributes = {"honeyhive.session_id": "session-123"}
+
+        processor.on_end(mock_span)
+
+        mock_exporter.export.assert_called_once_with([mock_span])
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_on_end_no_session_id(self, mock_safe_log: Mock) -> None:
+        """Test on_end with no session_id - should skip export."""
+        processor = HoneyHiveSpanProcessor()
+
+        mock_span = Mock(spec=ReadableSpan)
+        mock_span.name = "test_operation"
+        mock_span.attributes = {}  # No session_id
+
+        processor.on_end(mock_span)
+
+        mock_safe_log.assert_called()
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_on_end_invalid_span_context(self, mock_safe_log: Mock) -> None:
+        """Test on_end with invalid span context."""
+        processor = HoneyHiveSpanProcessor()
+
+        mock_span = Mock(spec=ReadableSpan)
+        mock_span.name = "test_operation"
+        mock_span.attributes = {"honeyhive.session_id": "session-123"}
+        mock_span.get_span_context.return_value = None
+
+        processor.on_end(mock_span)
+
+        mock_safe_log.assert_called()
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_on_end_no_valid_export_method(self, mock_safe_log: Mock) -> None:
+        """Test on_end with no valid export method."""
+        processor = HoneyHiveSpanProcessor()  # No client or exporter
+
+        mock_span = Mock(spec=ReadableSpan)
+        mock_span.name = "test_operation"
+        mock_span.attributes = {"honeyhive.session_id": "session-123"}
+        mock_span.get_span_context.return_value = Mock(span_id=12345)
+
+        processor.on_end(mock_span)
+
+        mock_safe_log.assert_called()
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_on_end_exception_handling(self, mock_safe_log: Mock) -> None:
+        """Test on_end exception handling."""
+        mock_client = Mock()
+        mock_client.events.create.side_effect = Exception("API Error")
+
+        processor = HoneyHiveSpanProcessor(client=mock_client)
+
+        mock_span = Mock(spec=ReadableSpan)
+        mock_span.name = "test_operation"
+        mock_span.attributes = {"honeyhive.session_id": "session-123"}
+        mock_span.get_span_context.return_value = Mock(span_id=12345)
+
+        processor.on_end(mock_span)
+
+        mock_safe_log.assert_called()
+
+
+class TestHoneyHiveSpanProcessorSending:
+    """Test span sending functionality with all conditional branches."""
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_send_via_client_success(self, mock_safe_log: Mock) -> None:
+        """Test successful span sending via client."""
+        mock_client = Mock()
+        mock_client.events.create.return_value = {"id": "event-123"}
+
+        processor = HoneyHiveSpanProcessor(client=mock_client)
+
+        mock_span = Mock(spec=ReadableSpan)
+        mock_span.name = "test_operation"
+        mock_span.start_time = 1000000000
+        mock_span.end_time = 2000000000
+        mock_span.attributes = {}
+        mock_span.status = Status(StatusCode.OK)
+        mock_span.get_span_context.return_value = Mock(span_id=12345, trace_id=67890)
+
+        processor._send_via_client(mock_span, {}, "session-123")
+
+        mock_client.events.create.assert_called_once()
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_send_via_client_no_events_method(self, mock_safe_log: Mock) -> None:
+        """Test client without events.create method."""
+        mock_client = Mock()
+        del mock_client.events
+
+        processor = HoneyHiveSpanProcessor(client=mock_client)
+
+        mock_span = Mock(spec=ReadableSpan)
+        processor._send_via_client(mock_span, {}, "session-123")
+
+        mock_safe_log.assert_called()
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_send_via_client_exception_handling(self, mock_safe_log: Mock) -> None:
+        """Test client sending with exception handling."""
+        mock_client = Mock()
+        mock_client.events.create.side_effect = Exception("Client error")
+
+        processor = HoneyHiveSpanProcessor(client=mock_client)
+
+        mock_span = Mock(spec=ReadableSpan)
+        processor._send_via_client(mock_span, {}, "session-123")
+
+        mock_safe_log.assert_called()
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_send_via_otlp_batched_mode(self, mock_safe_log: Mock) -> None:
+        """Test OTLP sending in batched mode."""
+        mock_exporter = Mock()
+        mock_exporter.export.return_value = Mock(name="SUCCESS")
+
+        processor = HoneyHiveSpanProcessor(
+            otlp_exporter=mock_exporter, disable_batch=False
+        )
+
+        mock_span = Mock(spec=ReadableSpan)
+        processor._send_via_otlp(mock_span, {}, "session-123")
+
+        mock_exporter.export.assert_called_once_with([mock_span])
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_send_via_otlp_immediate_mode(self, mock_safe_log: Mock) -> None:
+        """Test OTLP sending in immediate mode."""
+        mock_exporter = Mock()
+        mock_exporter.export.return_value = Mock(name="SUCCESS")
+
+        processor = HoneyHiveSpanProcessor(
+            otlp_exporter=mock_exporter, disable_batch=True
+        )
+
+        mock_span = Mock(spec=ReadableSpan)
+        processor._send_via_otlp(mock_span, {}, "session-123")
+
+        mock_exporter.export.assert_called_once_with([mock_span])
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_send_via_otlp_no_exporter(self, mock_safe_log: Mock) -> None:
+        """Test OTLP sending with no exporter."""
+        processor = HoneyHiveSpanProcessor()  # No exporter
+
+        mock_span = Mock(spec=ReadableSpan)
+        processor._send_via_otlp(mock_span, {}, "session-123")
+
+        mock_safe_log.assert_called()
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_send_via_otlp_with_result_name(self, mock_safe_log: Mock) -> None:
+        """Test OTLP sending with result that has name attribute."""
+        mock_exporter = Mock()
+        mock_result = Mock()
+        mock_result.name = "SUCCESS"
+        mock_exporter.export.return_value = mock_result
+
+        processor = HoneyHiveSpanProcessor(otlp_exporter=mock_exporter)
+
+        mock_span = Mock(spec=ReadableSpan)
+        processor._send_via_otlp(mock_span, {}, "session-123")
+
+        mock_exporter.export.assert_called_once_with([mock_span])
+        mock_safe_log.assert_called()
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_send_via_otlp_exception_handling(self, mock_safe_log: Mock) -> None:
+        """Test OTLP sending with exception handling."""
+        mock_exporter = Mock()
+        mock_exporter.export.side_effect = Exception("OTLP error")
+
+        processor = HoneyHiveSpanProcessor(otlp_exporter=mock_exporter)
+
+        mock_span = Mock(spec=ReadableSpan)
+        processor._send_via_otlp(mock_span, {}, "session-123")
+
+        mock_safe_log.assert_called()
+
+
+class TestHoneyHiveSpanProcessorAttributeProcessing:
+    """Test attribute processing functionality with all conditional branches."""
+
+    @patch("honeyhive.tracer.processing.span_processor.extract_raw_attributes")
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_process_honeyhive_attributes_basic(
+        self, mock_safe_log: Mock, mock_extract: Mock
+    ) -> None:
+        """Test honeyhive attribute processing method signature."""
+        mock_extract.return_value = {"processed": "attributes"}
+
+        processor = HoneyHiveSpanProcessor()
+
+        mock_span = Mock(spec=Span)
+        mock_span.name = "test_span"
+        mock_span.attributes = {"raw": "data"}
+
+        processor._process_honeyhive_attributes(mock_span)
+
+        # Method returns None, just verify it was called
+        mock_extract.assert_called()
+
+    @patch("honeyhive.tracer.processing.span_processor.extract_raw_attributes")
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_process_honeyhive_attributes_no_attributes(
+        self, mock_safe_log: Mock, mock_extract: Mock
+    ) -> None:
+        """Test attribute processing with no span attributes."""
+        mock_extract.return_value = {}
+
+        processor = HoneyHiveSpanProcessor()
+
+        mock_span = Mock(spec=Span)
+        mock_span.name = "test_span"
+        mock_span.attributes = None
+
+        processor._process_honeyhive_attributes(mock_span)
+
+        # Method returns None, just verify it was called
+
+    @patch("honeyhive.tracer.processing.span_processor.extract_raw_attributes")
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_process_honeyhive_attributes_exception_handling(
+        self, mock_safe_log: Mock, mock_extract: Mock
+    ) -> None:
+        """Test attribute processing with exception handling."""
+        mock_extract.side_effect = Exception("Processing error")
+
+        processor = HoneyHiveSpanProcessor()
+
+        mock_span = Mock(spec=Span)
+        mock_span.name = "test_span"
+        mock_span.attributes = {"raw": "data"}
+
+        processor._process_honeyhive_attributes(mock_span)
+
+        # Method returns None, just verify it was called
+        mock_safe_log.assert_called()
+
+
+class TestHoneyHiveSpanProcessorLifecycle:
+    """Test span processor lifecycle methods with all conditional branches."""
+
+    def test_shutdown_with_exporter(self) -> None:
+        """Test shutdown with OTLP exporter - returns None per production code."""
+        mock_exporter = Mock()
+        mock_exporter.shutdown.return_value = None
+
+        processor = HoneyHiveSpanProcessor(otlp_exporter=mock_exporter)
+
+        processor.shutdown()
+
+        # Method returns None, just verify shutdown was called
+        mock_exporter.shutdown.assert_called_once()
+
+    def test_shutdown_without_exporter(self) -> None:
+        """Test shutdown without OTLP exporter - returns None per production code."""
+        processor = HoneyHiveSpanProcessor()
+
+        processor.shutdown()
+
+        # Method returns None, just verify shutdown was called
+
+    def test_shutdown_exporter_no_shutdown_method(self) -> None:
+        """Test shutdown with exporter that has no shutdown method."""
+        mock_exporter = Mock()
+        del mock_exporter.shutdown
+
+        processor = HoneyHiveSpanProcessor(otlp_exporter=mock_exporter)
+
+        processor.shutdown()
+
+        # Method returns None, just verify shutdown was called
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_shutdown_exception_handling(self, mock_safe_log: Mock) -> None:
+        """Test shutdown with exception handling."""
+        mock_exporter = Mock()
+        mock_exporter.shutdown.side_effect = Exception("Shutdown error")
+
+        processor = HoneyHiveSpanProcessor(otlp_exporter=mock_exporter)
+
+        processor.shutdown()
+
+        # Method returns None, just verify shutdown was called
+        mock_safe_log.assert_called()
+
+    def test_force_flush_success(self) -> None:
+        """Test force flush with successful exporter."""
+        mock_exporter = Mock()
+        mock_exporter.force_flush.return_value = True
+
+        processor = HoneyHiveSpanProcessor(otlp_exporter=mock_exporter)
+
+        result = processor.force_flush()
+
+        assert result is True
+        mock_exporter.force_flush.assert_called_once()
+
+    def test_force_flush_without_exporter(self) -> None:
+        """Test force flush without exporter."""
+        processor = HoneyHiveSpanProcessor()
+
+        result = processor.force_flush()
+
+        assert result is True
+
+    def test_force_flush_exporter_no_method(self) -> None:
+        """Test force flush with exporter that has no force_flush method."""
+        mock_exporter = Mock()
+        del mock_exporter.force_flush
+
+        processor = HoneyHiveSpanProcessor(otlp_exporter=mock_exporter)
+
+        result = processor.force_flush()
+
+        assert result is True
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_force_flush_exception_handling(self, mock_safe_log: Mock) -> None:
+        """Test force flush with exception handling."""
+        mock_exporter = Mock()
+        mock_exporter.force_flush.side_effect = Exception("Flush error")
+
+        processor = HoneyHiveSpanProcessor(otlp_exporter=mock_exporter)
+
+        result = processor.force_flush()
+
+        assert result is False
+        mock_safe_log.assert_called()
+
+
+class TestHoneyHiveSpanProcessorConversion:
+    """Test span to event conversion functionality with all conditional branches."""
+
+    def test_convert_span_to_event_success(self) -> None:
+        """Test successful span to event conversion."""
+        processor = HoneyHiveSpanProcessor()
+
+        mock_span = Mock(spec=ReadableSpan)
+        mock_span.name = "test_operation"
+        mock_span.start_time = 1000000000
+        mock_span.end_time = 2000000000
+        mock_span.status = Status(StatusCode.OK)
+        mock_span.attributes = {}
+
+        mock_context = Mock()
+        mock_context.span_id = 12345
+        mock_context.trace_id = 67890
+        mock_span.get_span_context.return_value = mock_context
+
+        attributes = {"test": "value"}
+        session_id = "session-123"
+
+        with patch.object(processor, "_detect_event_type", return_value="tool"):
+            result = processor._convert_span_to_event(mock_span, attributes, session_id)
+
+        assert result["event_name"] == "test_operation"
+        assert result["session_id"] == "session-123"
+        assert result["event_type"] == "tool"
+        assert "start_time" in result
+        assert "end_time" in result
+
+    def test_convert_span_to_event_with_error_status(self) -> None:
+        """Test span to event conversion with error status."""
+        processor = HoneyHiveSpanProcessor()
+
+        mock_span = Mock(spec=ReadableSpan)
+        mock_span.name = "failed_operation"
+        mock_span.start_time = 1000000000
+        mock_span.end_time = 2000000000
+        mock_span.status = Status(StatusCode.ERROR, "Test error")
+        mock_span.attributes = {}
+
+        mock_context = Mock()
+        mock_context.span_id = 12345
+        mock_context.trace_id = 67890
+        mock_span.get_span_context.return_value = mock_context
+
+        attributes: Dict[str, Any] = {}
+        session_id = "session-123"
+
+        with patch.object(processor, "_detect_event_type", return_value="tool"):
+            result = processor._convert_span_to_event(mock_span, attributes, session_id)
+
+        assert result["event_name"] == "failed_operation"
+        assert "error" in result
+        assert result["error"]["type"] == "span_error"
+        assert result["error"]["message"] == "Test error"
+
+    def test_convert_span_to_event_no_span_attributes(self) -> None:
+        """Test conversion with no span attributes."""
+        processor = HoneyHiveSpanProcessor()
+
+        mock_span = Mock(spec=ReadableSpan)
+        mock_span.name = "test_operation"
+        mock_span.start_time = 1000000000
+        mock_span.end_time = 2000000000
+        mock_span.status = Status(StatusCode.OK)
+        mock_span.attributes = None
+
+        mock_context = Mock()
+        mock_context.span_id = 12345
+        mock_context.trace_id = 67890
+        mock_span.get_span_context.return_value = mock_context
+
+        attributes: Dict[str, Any] = {}
+        session_id = "session-123"
+
+        with patch.object(processor, "_detect_event_type", return_value="tool"):
+            result = processor._convert_span_to_event(mock_span, attributes, session_id)
+
+        assert result["event_name"] == "test_operation"
+        assert result["session_id"] == "session-123"
+
+    def test_convert_span_to_event_no_status(self) -> None:
+        """Test conversion with no span status."""
+        processor = HoneyHiveSpanProcessor()
+
+        mock_span = Mock(spec=ReadableSpan)
+        mock_span.name = "test_operation"
+        mock_span.start_time = 1000000000
+        mock_span.end_time = 2000000000
+        mock_span.status = None
+        mock_span.attributes = {}
+
+        mock_context = Mock()
+        mock_context.span_id = 12345
+        mock_context.trace_id = 67890
+        mock_span.get_span_context.return_value = mock_context
+
+        attributes: Dict[str, Any] = {}
+        session_id = "session-123"
+
+        with patch.object(processor, "_detect_event_type", return_value="tool"):
+            result = processor._convert_span_to_event(mock_span, attributes, session_id)
+
+        assert result["event_name"] == "test_operation"
+        assert "error" not in result
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_convert_span_to_event_exception_handling(
+        self, mock_safe_log: Mock
+    ) -> None:
+        """Test conversion with exception handling."""
+        processor = HoneyHiveSpanProcessor()
+
+        mock_span = Mock(spec=ReadableSpan)
+        mock_span.name = "test_operation"
+        mock_span.get_span_context.side_effect = Exception("Context error")
+
+        attributes: Dict[str, Any] = {}
+        session_id = "session-123"
+
+        # Exception should be caught and return empty dict or basic structure
+        try:
+            result = processor._convert_span_to_event(mock_span, attributes, session_id)
+            # If no exception, should have basic structure
+            if result:
+                assert "event_name" in result
+                assert "session_id" in result
+        except Exception:
+            # Exception might not be fully caught, that's ok for this test
+            pass
+
+        mock_safe_log.assert_called()

--- a/tests_v2/unit/test_tracer_utils_event_type.py
+++ b/tests_v2/unit/test_tracer_utils_event_type.py
@@ -1,0 +1,699 @@
+"""Unit tests for HoneyHive tracer utils event type functionality.
+
+This module tests the event type detection utilities including pattern matching,
+LLM attribute detection, and raw attribute processing.
+"""
+
+# pylint: disable=line-too-long,attribute-defined-outside-init,missing-class-docstring
+# pylint: disable=too-few-public-methods,import-outside-toplevel
+# Justification: Test module requires dynamic attributes and test classes may have few methods
+
+from typing import Any, Dict, List
+from unittest.mock import Mock, patch
+
+import pytest
+
+from honeyhive.tracer.utils.event_type import (
+    _extract_base_attribute_name_dynamically,
+    _identify_raw_attributes_dynamically,
+    _is_raw_attribute_dynamically,
+    _is_sensitive_attribute_dynamically,
+    _process_raw_value_dynamically,
+    _process_single_raw_attribute_dynamically,
+    detect_event_type_from_patterns,
+    extract_raw_attributes,
+    get_llm_attributes,
+    get_model_patterns,
+)
+
+
+class TestModelPatterns:
+    """Test model pattern generation and detection."""
+
+    def test_get_model_patterns_returns_list(self) -> None:
+        """Test that get_model_patterns returns a list of strings."""
+        patterns = get_model_patterns()
+
+        assert isinstance(patterns, list)
+        assert len(patterns) > 0
+        assert all(isinstance(pattern, str) for pattern in patterns)
+
+    def test_get_model_patterns_includes_provider_patterns(self) -> None:
+        """Test that model patterns include major LLM provider patterns."""
+        patterns = get_model_patterns()
+
+        # Check for major provider patterns
+        expected_providers = [
+            "openai.chat.completions",
+            "openai.completions",
+            "anthropic.messages",
+            "bedrock.invoke_model",
+            "google.generativeai",
+        ]
+
+        for provider in expected_providers:
+            assert provider in patterns
+
+    def test_get_model_patterns_includes_operation_patterns(self) -> None:
+        """Test that model patterns include generic operation patterns."""
+        patterns = get_model_patterns()
+
+        expected_operations = [
+            "llm.",
+            "model.",
+            "chat",
+            "completion",
+            "generate",
+            "inference",
+        ]
+
+        for operation in expected_operations:
+            assert operation in patterns
+
+    def test_get_model_patterns_includes_model_names(self) -> None:
+        """Test that model patterns include popular model name patterns."""
+        patterns = get_model_patterns()
+
+        expected_models = ["gpt", "claude", "llama", "gemini", "mistral", "palm"]
+
+        for model in expected_models:
+            assert model in patterns
+
+    def test_get_model_patterns_dynamic_extensibility(self) -> None:
+        """Test that model patterns can be dynamically extended."""
+        patterns = get_model_patterns()
+
+        # Verify the function returns a comprehensive list
+        assert (
+            len(patterns) >= 15
+        )  # Should have at least provider + operation + model patterns
+
+        # Verify no duplicates
+        assert len(patterns) == len(set(patterns))
+
+
+class TestLLMAttributes:
+    """Test LLM attribute generation and detection."""
+
+    def test_get_llm_attributes_returns_list(self) -> None:
+        """Test that get_llm_attributes returns a list of strings."""
+        attributes = get_llm_attributes()
+
+        assert isinstance(attributes, list)
+        assert len(attributes) > 0
+        assert all(isinstance(attr, str) for attr in attributes)
+
+    def test_get_llm_attributes_includes_otel_conventions(self) -> None:
+        """Test that LLM attributes include OpenTelemetry semantic conventions."""
+        attributes = get_llm_attributes()
+
+        expected_otel = [
+            "llm.request.model",
+            "llm.response.model",
+            "llm.model.name",
+            "gen_ai.request.model",
+            "gen_ai.response.model",
+        ]
+
+        for attr in expected_otel:
+            assert attr in attributes
+
+    def test_get_llm_attributes_includes_provider_specific(self) -> None:
+        """Test that LLM attributes include provider-specific attributes."""
+        attributes = get_llm_attributes()
+
+        expected_providers = [
+            "openai.model",
+            "anthropic.model",
+            "bedrock.model_id",
+            "google.model",
+        ]
+
+        for attr in expected_providers:
+            assert attr in attributes
+
+    def test_get_llm_attributes_includes_generic_attributes(self) -> None:
+        """Test that LLM attributes include generic model attributes."""
+        attributes = get_llm_attributes()
+
+        expected_generic = ["model_name", "model_id", "model_type", "ai_model"]
+
+        for attr in expected_generic:
+            assert attr in attributes
+
+    def test_get_llm_attributes_no_duplicates(self) -> None:
+        """Test that LLM attributes list has no duplicates."""
+        attributes = get_llm_attributes()
+
+        assert len(attributes) == len(set(attributes))
+
+
+class TestEventTypeDetection:
+    """Test event type detection from patterns."""
+
+    def setup_method(self) -> None:
+        """Set up test fixtures before each test method."""
+        self.mock_patches = []
+
+    def teardown_method(self) -> None:
+        """Clean up after each test method."""
+        # Stop all patches
+        for patch_obj in self.mock_patches:
+            patch_obj.stop()
+
+    def test_detect_event_type_from_patterns_model_span_name(self) -> None:
+        """Test event type detection from model-related span names."""
+        test_cases = [
+            ("openai.chat.completions.create", "model"),
+            ("anthropic.messages.create", "model"),
+            ("llm_call", "model"),
+            ("gpt_request", "model"),
+            ("chat_completion", "model"),
+            ("model_inference", "model"),
+        ]
+
+        for span_name, expected_type in test_cases:
+            result = detect_event_type_from_patterns(span_name, {})
+            assert result == expected_type, f"Failed for span_name: {span_name}"
+
+    def test_detect_event_type_from_patterns_model_attributes(self) -> None:
+        """Test event type detection from model-related attributes."""
+        test_cases = [
+            ({"llm.request.model": "gpt-4"}, "model"),
+            ({"gen_ai.request.model": "claude-3"}, "model"),
+            ({"openai.model": "gpt-3.5-turbo"}, "model"),
+            ({"model_name": "llama-2"}, "model"),
+            ({"bedrock.model_id": "anthropic.claude-v2"}, "model"),
+        ]
+
+        for attributes, expected_type in test_cases:
+            result = detect_event_type_from_patterns("generic_span", attributes)
+            assert result == expected_type, f"Failed for attributes: {attributes}"
+
+    def test_detect_event_type_from_patterns_tool_fallback(self) -> None:
+        """Test event type detection falls back to tool for non-model operations."""
+        test_cases = [
+            ("data_processing", {}),
+            ("api_call", {}),
+            ("database_query", {}),
+            ("file_operation", {"file_path": "/tmp/test.txt"}),
+            ("generic_function", {"param1": "value1"}),
+        ]
+
+        for span_name, attributes in test_cases:
+            result = detect_event_type_from_patterns(span_name, attributes)
+            assert (
+                result == "tool"
+            ), f"Failed for span_name: {span_name}, attributes: {attributes}"
+
+    def test_detect_event_type_from_patterns_case_insensitive(self) -> None:
+        """Test event type detection is case insensitive."""
+        test_cases = [
+            ("GPT_CALL", "model"),
+            ("OpenAI.Chat.Completions", "model"),
+            ("LLM_REQUEST", "model"),
+            ("Model_Inference", "model"),
+        ]
+
+        for span_name, expected_type in test_cases:
+            result = detect_event_type_from_patterns(span_name, {})
+            assert result == expected_type, f"Failed for span_name: {span_name}"
+
+    def test_detect_event_type_from_patterns_combined_detection(self) -> None:
+        """Test event type detection with both span name and attributes."""
+        # Model detection should work with either span name or attributes
+        result1 = detect_event_type_from_patterns(
+            "generic_span", {"llm.request.model": "gpt-4"}
+        )
+        result2 = detect_event_type_from_patterns("llm_call", {"generic_attr": "value"})
+        result3 = detect_event_type_from_patterns(
+            "llm_call", {"llm.request.model": "gpt-4"}
+        )
+
+        assert result1 == "model"
+        assert result2 == "model"
+        assert result3 == "model"
+
+    @pytest.mark.parametrize(
+        "span_name,attributes,expected",
+        [
+            ("openai.chat.completions", {}, "model"),
+            ("anthropic.messages", {}, "model"),
+            ("bedrock.invoke_model", {}, "model"),
+            ("google.generativeai", {}, "model"),
+            ("data_processing", {}, "tool"),
+            ("api_request", {}, "tool"),
+            ("", {"llm.request.model": "gpt-4"}, "model"),
+            ("", {"gen_ai.response.model": "claude"}, "model"),
+            ("", {"openai.model": "gpt-3.5"}, "model"),
+            ("", {"normal_attr": "value"}, "tool"),
+        ],
+    )
+    def test_detect_event_type_parametrized(
+        self, span_name: str, attributes: Dict[str, Any], expected: str
+    ) -> None:
+        """Test event type detection with parametrized inputs."""
+        result = detect_event_type_from_patterns(span_name, attributes)
+        assert result == expected
+
+
+class TestRawAttributeExtraction:
+    """Test raw attribute extraction functionality."""
+
+    def test_extract_raw_attributes_simple_dict(self) -> None:
+        """Test raw attribute extraction from simple dictionary."""
+        attributes = {"key1": "value1", "key2": 42, "key3": True, "key4": 3.14}
+
+        result = extract_raw_attributes(attributes)
+
+        assert isinstance(result, dict)
+        assert result["key1"] == "value1"
+        assert result["key2"] == 42
+        assert result["key3"] is True
+        assert result["key4"] == 3.14
+
+    def test_extract_raw_attributes_nested_dict(self) -> None:
+        """Test raw attribute extraction from nested dictionary."""
+        attributes = {
+            "top_level": "value",
+            "nested": {
+                "inner_key": "inner_value",
+                "deep_nested": {"deep_key": "deep_value"},
+            },
+        }
+
+        result = extract_raw_attributes(attributes)
+
+        # Should flatten nested structures
+        assert "top_level" in result
+        assert result["top_level"] == "value"
+
+        # Nested attributes should be accessible
+        nested_str = str(result)
+        assert "inner_value" in nested_str
+        assert "deep_value" in nested_str
+
+    def test_extract_raw_attributes_with_lists(self) -> None:
+        """Test raw attribute extraction with list values."""
+        attributes = {
+            "simple_list": ["item1", "item2", "item3"],
+            "mixed_list": [1, "string", True, {"nested": "value"}],
+            "empty_list": [],
+        }
+
+        result = extract_raw_attributes(attributes)
+
+        assert "simple_list" in result
+        assert "mixed_list" in result
+        assert "empty_list" in result
+
+    def test_extract_raw_attributes_filters_sensitive_data(self) -> None:
+        """Test raw attribute extraction filters sensitive data."""
+        attributes = {
+            "api_key": "secret-api-key",
+            "password": "secret-password",
+            "token": "secret-token",
+            "secret": "secret-value",
+            "normal_attr": "normal-value",
+            "user_id": "user123",
+        }
+
+        result = extract_raw_attributes(attributes)
+
+        # Sensitive attributes should be filtered out
+        result_str = str(result)
+        assert "secret-api-key" not in result_str
+        assert "secret-password" not in result_str
+        assert "secret-token" not in result_str
+        assert "secret-value" not in result_str
+
+        # Normal attributes should be preserved
+        assert "normal-value" in result_str
+        assert "user123" in result_str
+
+    def test_extract_raw_attributes_handles_none_values(self) -> None:
+        """Test raw attribute extraction handles None values."""
+        attributes = {
+            "none_value": None,
+            "normal_value": "test",
+            "zero_value": 0,
+            "false_value": False,
+            "empty_string": "",
+        }
+
+        result = extract_raw_attributes(attributes)
+
+        # Should handle all value types gracefully
+        assert "none_value" in result
+        assert "normal_value" in result
+        assert "zero_value" in result
+        assert "false_value" in result
+        assert "empty_string" in result
+
+    def test_extract_raw_attributes_handles_complex_objects(self) -> None:
+        """Test raw attribute extraction handles complex objects."""
+
+        class CustomObject:
+            def __init__(self, value):
+                self.value = value
+
+            def __str__(self):
+                return f"CustomObject({self.value})"
+
+        attributes = {
+            "custom_object": CustomObject("test"),
+            "function": lambda x: x + 1,
+            "normal_value": "test",
+        }
+
+        # Should not raise exceptions with complex objects
+        result = extract_raw_attributes(attributes)
+
+        assert isinstance(result, dict)
+        assert "normal_value" in result
+
+    def test_extract_raw_attributes_empty_input(self) -> None:
+        """Test raw attribute extraction with empty input."""
+        result = extract_raw_attributes({})
+
+        assert isinstance(result, dict)
+        assert len(result) == 0
+
+    def test_extract_raw_attributes_preserves_structure(self) -> None:
+        """Test raw attribute extraction preserves important structure."""
+        attributes = {
+            "llm.request.model": "gpt-4",
+            "llm.request.messages": [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi there!"},
+            ],
+            "llm.response.content": "Response text",
+            "llm.usage.prompt_tokens": 10,
+            "llm.usage.completion_tokens": 20,
+        }
+
+        result = extract_raw_attributes(attributes)
+
+        # Important LLM attributes should be preserved
+        assert "llm.request.model" in result
+        assert result["llm.request.model"] == "gpt-4"
+        assert "llm.usage.prompt_tokens" in result
+        assert result["llm.usage.prompt_tokens"] == 10
+
+    @pytest.mark.parametrize(
+        "input_attrs,expected_keys",
+        [
+            ({"key1": "value1"}, ["key1"]),
+            ({"key1": "value1", "key2": "value2"}, ["key1", "key2"]),
+            ({}, []),
+            ({"nested": {"inner": "value"}}, ["nested"]),
+            ({"list_attr": [1, 2, 3]}, ["list_attr"]),
+        ],
+    )
+    def test_extract_raw_attributes_parametrized(
+        self, input_attrs: Dict[str, Any], expected_keys: List[str]
+    ) -> None:
+        """Test raw attribute extraction with parametrized inputs."""
+        result = extract_raw_attributes(input_attrs)
+
+        assert isinstance(result, dict)
+        for key in expected_keys:
+            assert key in result
+
+
+class TestRawAttributeProcessingEdgeCases:
+    """Test edge cases and internal functions for raw attribute processing."""
+
+    def test_extract_raw_attributes_with_raw_suffix_attributes(self) -> None:
+        """Test extraction with _raw suffix attributes that need special processing."""
+        attributes = {
+            "honeyhive_event_type_raw": "model",
+            "custom_param_raw": "test_value",
+            "normal_attr": "normal_value",
+            "not_raw_attr": "another_value",
+        }
+
+        result = extract_raw_attributes(attributes)
+
+        # Raw attributes should be processed and have suffix removed
+        assert "honeyhive_event_type" in result
+        assert result["honeyhive_event_type"] == "model"
+        assert "custom_param" in result
+        assert result["custom_param"] == "test_value"
+
+        # Normal attributes should be preserved as-is
+        assert "normal_attr" in result
+        assert result["normal_attr"] == "normal_value"
+        assert "not_raw_attr" in result
+        assert result["not_raw_attr"] == "another_value"
+
+    def test_extract_raw_attributes_with_tracer_instance_logging(self) -> None:
+        """Test extraction with tracer instance for logging."""
+        mock_tracer = Mock()
+        attributes = {"test_key": "test_value", "honeyhive_param_raw": "raw_value"}
+
+        result = extract_raw_attributes(attributes, tracer_instance=mock_tracer)
+
+        assert isinstance(result, dict)
+        assert "test_key" in result
+        assert "honeyhive_param" in result
+
+    def test_is_raw_attribute_dynamically(self) -> None:
+        """Test raw attribute detection logic."""
+        # Should detect raw attributes
+        assert _is_raw_attribute_dynamically("honeyhive_event_type_raw") is True
+        assert _is_raw_attribute_dynamically("custom_param_raw") is True
+        assert _is_raw_attribute_dynamically("test_value_raw") is True
+
+        # Should not detect non-raw attributes
+        assert _is_raw_attribute_dynamically("normal_attr") is False
+        assert _is_raw_attribute_dynamically("honeyhive_event_type") is False
+        assert (
+            _is_raw_attribute_dynamically("raw") is False
+        )  # Just "raw" without underscore
+        assert (
+            _is_raw_attribute_dynamically("_raw") is True
+        )  # "_raw" matches the pattern
+
+    def test_is_sensitive_attribute_dynamically(self) -> None:
+        """Test sensitive attribute detection logic."""
+        # Should detect sensitive attributes
+        sensitive_attrs = [
+            "api_key",
+            "password",
+            "token",
+            "secret",
+            "auth",
+            "credential",
+            "private_key",
+            "access_key",
+            "session_key",
+            "bearer",
+        ]
+        for attr in sensitive_attrs:
+            assert _is_sensitive_attribute_dynamically(attr) is True
+            assert (
+                _is_sensitive_attribute_dynamically(attr.upper()) is True
+            )  # Case insensitive
+
+        # Should not flag LLM usage metrics with "token" (only when "usage" is also present)
+        usage_attrs = ["llm.usage.tokens", "usage_tokens", "usage.token_count"]
+        for attr in usage_attrs:
+            assert _is_sensitive_attribute_dynamically(attr) is False
+
+        # These should still be flagged as sensitive (no "usage" context)
+        sensitive_token_attrs = ["token_count", "prompt_tokens", "completion_tokens"]
+        for attr in sensitive_token_attrs:
+            assert _is_sensitive_attribute_dynamically(attr) is True
+
+        # Should not detect normal attributes
+        normal_attrs = ["user_id", "model_name", "response_text", "timestamp"]
+        for attr in normal_attrs:
+            assert _is_sensitive_attribute_dynamically(attr) is False
+
+    def test_identify_raw_attributes_dynamically_deprecated(self) -> None:
+        """Test the deprecated batch processing function for raw attributes."""
+        attributes = {
+            "honeyhive_event_type_raw": "model",
+            "custom_param_raw": "test_value",
+            "normal_attr": "normal_value",
+            "another_raw": "value",  # This should NOT match (no underscore before raw)
+        }
+
+        result = _identify_raw_attributes_dynamically(attributes)
+
+        # Should only return raw attributes
+        assert "honeyhive_event_type_raw" in result
+        assert "custom_param_raw" in result
+        assert "normal_attr" not in result
+        assert (
+            "another_raw" in result
+        )  # This actually matches the pattern "_raw" at the end
+
+    def test_process_single_raw_attribute_dynamically_success(self) -> None:
+        """Test successful processing of a single raw attribute."""
+        result = _process_single_raw_attribute_dynamically(
+            "honeyhive_event_type_raw", "model"
+        )
+
+        assert result is not None
+        assert isinstance(result, dict)
+        assert "honeyhive_event_type" in result
+        assert result["honeyhive_event_type"] == "model"
+
+    def test_process_single_raw_attribute_dynamically_with_tracer(self) -> None:
+        """Test raw attribute processing with tracer instance for logging."""
+        mock_tracer = Mock()
+
+        result = _process_single_raw_attribute_dynamically(
+            "custom_param_raw", "test_value", tracer_instance=mock_tracer
+        )
+
+        assert result is not None
+        assert isinstance(result, dict)
+        assert "custom_param" in result
+        assert result["custom_param"] == "test_value"
+
+    def test_process_single_raw_attribute_dynamically_invalid_name(self) -> None:
+        """Test raw attribute processing with invalid attribute name."""
+        mock_tracer = Mock()
+
+        # Attribute name that doesn't end with _raw
+        result = _process_single_raw_attribute_dynamically(
+            "invalid_attr", "value", tracer_instance=mock_tracer
+        )
+
+        assert result is None
+
+    def test_process_single_raw_attribute_dynamically_exception_handling(self) -> None:
+        """Test exception handling in raw attribute processing."""
+        mock_tracer = Mock()
+
+        # Test with an attribute name that will cause issues in processing
+        with patch(
+            "honeyhive.tracer.utils.event_type._extract_base_attribute_name_dynamically",
+            side_effect=Exception("Processing error"),
+        ):
+            result = _process_single_raw_attribute_dynamically(
+                "test_raw", "value", tracer_instance=mock_tracer
+            )
+
+            assert result is None
+
+    def test_extract_base_attribute_name_dynamically(self) -> None:
+        """Test base attribute name extraction from raw attribute names."""
+        # Should extract base names correctly
+        assert (
+            _extract_base_attribute_name_dynamically("honeyhive_event_type_raw")
+            == "honeyhive_event_type"
+        )
+        assert (
+            _extract_base_attribute_name_dynamically("custom_param_raw")
+            == "custom_param"
+        )
+        assert (
+            _extract_base_attribute_name_dynamically("test_RAW") == "test"
+        )  # Case insensitive
+
+        # Should return None for invalid names
+        assert _extract_base_attribute_name_dynamically("no_raw_suffix") is None
+        assert _extract_base_attribute_name_dynamically("raw") is None
+        assert (
+            _extract_base_attribute_name_dynamically("_raw") == ""
+        )  # Returns empty string, not None
+
+    def test_process_raw_value_dynamically_basic_types(self) -> None:
+        """Test raw value processing with basic types."""
+        # Should preserve basic types
+        assert _process_raw_value_dynamically("string") == "string"
+        assert _process_raw_value_dynamically(42) == 42
+        assert _process_raw_value_dynamically(3.14) == 3.14
+        assert _process_raw_value_dynamically(True) is True
+        assert _process_raw_value_dynamically(False) is False
+        assert _process_raw_value_dynamically([1, 2, 3]) == [1, 2, 3]
+        assert _process_raw_value_dynamically({"key": "value"}) == {"key": "value"}
+
+        # Should preserve None
+        assert _process_raw_value_dynamically(None) is None
+
+    def test_process_raw_value_dynamically_enum_conversion(self) -> None:
+        """Test raw value processing with enum-like objects."""
+        from enum import Enum
+
+        class TestEnum(Enum):
+            VALUE1 = "value1"
+            VALUE2 = "value2"
+
+        # Should convert enum to string
+        result = _process_raw_value_dynamically(TestEnum.VALUE1)
+        assert result == "value1"
+
+    def test_process_raw_value_dynamically_complex_objects(self) -> None:
+        """Test raw value processing with complex objects."""
+
+        class CustomObject:
+            def __init__(self, value):
+                self.value = value
+
+            def __str__(self):
+                return f"CustomObject({self.value})"
+
+        obj = CustomObject("test")
+        result = _process_raw_value_dynamically(obj)
+
+        # Should convert to string
+        assert result == "CustomObject(test)"
+
+
+class TestEventTypeDetectionEdgeCases:
+    """Test edge cases in event type detection."""
+
+    def test_detect_event_type_compound_patterns(self) -> None:
+        """Test detection of compound AI/ML patterns in span names."""
+        compound_patterns = [
+            "ai_model_inference",
+            "ml_prediction_service",
+            "nlp_text_processing",
+        ]
+
+        for span_name in compound_patterns:
+            result = detect_event_type_from_patterns(span_name, {})
+            assert result == "model", f"Failed for compound pattern: {span_name}"
+
+    def test_detect_event_type_empty_inputs(self) -> None:
+        """Test event type detection with empty inputs."""
+        # Empty span name and attributes should return default
+        result = detect_event_type_from_patterns("", {})
+        assert result == "tool"
+
+        # None span name should be handled gracefully
+        result = detect_event_type_from_patterns(None, {})
+        assert result == "tool"
+
+    def test_detect_event_type_with_tracer_logging(self) -> None:
+        """Test event type detection with tracer instance for logging."""
+        mock_tracer = Mock()
+
+        # Should detect model type and log
+        result = detect_event_type_from_patterns(
+            "openai.chat.completions", {}, tracer_instance=mock_tracer
+        )
+        assert result == "model"
+
+        # Should detect from attributes and log
+        result = detect_event_type_from_patterns(
+            "generic_span", {"llm.request.model": "gpt-4"}, tracer_instance=mock_tracer
+        )
+        assert result == "model"
+
+    def test_detect_event_type_attribute_detection_edge_cases(self) -> None:
+        """Test attribute-based detection edge cases."""
+        # Empty attributes dict
+        result = detect_event_type_from_patterns("generic_span", None)
+        assert result == "tool"
+
+        # Attributes with None values should still trigger detection
+        result = detect_event_type_from_patterns(
+            "generic_span", {"llm.request.model": None}
+        )
+        assert result == "model"

--- a/tests_v2/unit/test_tracer_utils_general.py
+++ b/tests_v2/unit/test_tracer_utils_general.py
@@ -1,0 +1,635 @@
+"""Unit tests for honeyhive.tracer.utils.general module.
+
+This module provides comprehensive unit tests for the general utility functions
+used throughout the HoneyHive tracer system, focusing on enum conversion,
+string conversion, attribute key normalization, and caller information extraction.
+
+Test Coverage Target: 90%+ line coverage with comprehensive mocking.
+"""
+
+from enum import Enum
+from typing import Any
+from unittest.mock import Mock, patch
+
+from honeyhive.tracer.utils.general import (
+    _apply_normalization_pipeline_dynamically,
+    _convert_to_string_dynamically,
+    _ensure_valid_identifier_dynamically,
+    _extract_caller_details_dynamically,
+    _extract_enum_value_dynamically,
+    _get_default_caller_info_dynamically,
+    _inspect_call_stack_dynamically,
+    _is_enum_value_dynamically,
+    _remove_special_chars_dynamically,
+    _replace_separators_dynamically,
+    _truncate_string_dynamically,
+    _validate_and_correct_key_dynamically,
+    convert_enum_to_string,
+    get_caller_info,
+    normalize_attribute_key,
+    safe_string_conversion,
+)
+
+
+# Test enums for comprehensive enum testing
+class EventTypeEnum(Enum):
+    """Test enum for enum conversion testing."""
+
+    MODEL = "model"
+    TOOL = "tool"
+    CHAIN = "chain"
+
+
+class StatusEnum(Enum):
+    """Test enum with different value types."""
+
+    SUCCESS = 200
+    ERROR = 500
+    PENDING = "pending"
+
+
+class ComplexEnum(Enum):
+    """Test enum with complex values."""
+
+    COMPLEX = {"key": "value", "nested": {"inner": "data"}}
+
+
+# pylint: disable=too-few-public-methods
+class MockEnumLike:
+    """Mock enum-like object for testing dynamic enum detection."""
+
+    def __init__(self, value: Any) -> None:
+        self.value = value
+        self.name = "MOCK_ENUM"
+
+
+# pylint: disable=too-few-public-methods
+class MockInvalidEnum:
+    """Mock object that looks like enum but has no value."""
+
+    def __init__(self) -> None:
+        self.name = "INVALID"
+
+
+class TestConvertEnumToString:
+    """Test suite for convert_enum_to_string function."""
+
+    def test_convert_enum_to_string_with_none(self) -> None:
+        """Test convert_enum_to_string with None input returns None."""
+        result = convert_enum_to_string(None)
+        assert result is None
+
+    def test_convert_enum_to_string_with_standard_enum(self) -> None:
+        """Test convert_enum_to_string with standard enum returns string value."""
+        result = convert_enum_to_string(EventTypeEnum.MODEL)
+        assert result == "model"
+
+    def test_convert_enum_to_string_with_integer_enum(self) -> None:
+        """Test convert_enum_to_string with integer enum value."""
+        result = convert_enum_to_string(StatusEnum.SUCCESS)
+        assert result == "200"
+
+    def test_convert_enum_to_string_with_complex_enum(self) -> None:
+        """Test convert_enum_to_string with complex enum value."""
+        result = convert_enum_to_string(ComplexEnum.COMPLEX)
+        expected = "{'key': 'value', 'nested': {'inner': 'data'}}"
+        assert result == expected
+
+    def test_convert_enum_to_string_with_non_enum(self) -> None:
+        """Test convert_enum_to_string with non-enum returns string conversion."""
+        result = convert_enum_to_string("regular_string")
+        assert result == "regular_string"
+
+    def test_convert_enum_to_string_with_mock_enum_like(self) -> None:
+        """Test convert_enum_to_string with enum-like object."""
+        mock_enum = MockEnumLike("test_value")
+        result = convert_enum_to_string(mock_enum)
+        assert result == "test_value"
+
+    @patch("honeyhive.tracer.utils.general._is_enum_value_dynamically")
+    @patch("honeyhive.tracer.utils.general._extract_enum_value_dynamically")
+    def test_convert_enum_to_string_enum_detection_flow(
+        self, mock_extract: Mock, mock_is_enum: Mock
+    ) -> None:
+        """Test convert_enum_to_string follows enum detection flow correctly."""
+        mock_is_enum.return_value = True
+        mock_extract.return_value = "extracted_value"
+
+        result = convert_enum_to_string("test_input")
+
+        assert result == "extracted_value"
+        mock_is_enum.assert_called_once_with("test_input")
+        mock_extract.assert_called_once_with("test_input")
+
+    def test_convert_enum_to_string_with_integer(self) -> None:
+        """Test convert_enum_to_string with integer input."""
+        result = convert_enum_to_string(42)
+        assert result == "42"
+
+    def test_convert_enum_to_string_with_boolean(self) -> None:
+        """Test convert_enum_to_string with boolean input."""
+        result = convert_enum_to_string(True)
+        assert result == "True"
+
+    def test_convert_enum_to_string_with_list(self) -> None:
+        """Test convert_enum_to_string with list input."""
+        result = convert_enum_to_string([1, 2, 3])
+        assert result == "[1, 2, 3]"
+
+
+class TestSafeStringConversion:
+    """Test suite for safe_string_conversion function."""
+
+    def test_safe_string_conversion_with_none(self) -> None:
+        """Test safe_string_conversion with None returns 'None'."""
+        result = safe_string_conversion(None)
+        assert result == "None"
+
+    def test_safe_string_conversion_with_string(self) -> None:
+        """Test safe_string_conversion with string input."""
+        result = safe_string_conversion("test_string")
+        assert result == "test_string"
+
+    def test_safe_string_conversion_with_integer(self) -> None:
+        """Test safe_string_conversion with integer input."""
+        result = safe_string_conversion(42)
+        assert result == "42"
+
+    def test_safe_string_conversion_with_max_length_limit(self) -> None:
+        """Test safe_string_conversion with max_length truncation."""
+        long_string = "x" * 100
+        result = safe_string_conversion(long_string, max_length=50)
+        assert len(result) <= 50  # May be 49 due to ellipsis placement
+        assert "..." in result
+
+    def test_safe_string_conversion_with_zero_max_length(self) -> None:
+        """Test safe_string_conversion with zero max_length."""
+        result = safe_string_conversion("test", max_length=0)
+        assert result == "test"  # No truncation when max_length is 0
+
+    def test_safe_string_conversion_with_negative_max_length(self) -> None:
+        """Test safe_string_conversion with negative max_length."""
+        result = safe_string_conversion("test", max_length=-1)
+        assert result == "test"  # No truncation when max_length is negative
+
+    @patch("honeyhive.tracer.utils.general.safe_log")
+    @patch("honeyhive.tracer.utils.general._convert_to_string_dynamically")
+    def test_safe_string_conversion_with_exception(
+        self, mock_convert: Mock, mock_safe_log: Mock
+    ) -> None:
+        """Test safe_string_conversion handles exceptions with logging."""
+        mock_convert.side_effect = ValueError("Conversion failed")
+        mock_tracer = Mock()
+
+        result = safe_string_conversion("test_value", tracer_instance=mock_tracer)
+
+        assert result == "<str>"
+        mock_safe_log.assert_called_once_with(
+            mock_tracer,
+            "warning",
+            "Failed to convert value to string",
+            honeyhive_data={
+                "value_type": "str",
+                "error": "Conversion failed",
+                "error_type": "ValueError",
+            },
+        )
+
+    def test_safe_string_conversion_with_complex_object(self) -> None:
+        """Test safe_string_conversion with complex object."""
+        test_dict = {"key": "value", "nested": {"inner": "data"}}
+        result = safe_string_conversion(test_dict)
+        assert "key" in result
+        assert "value" in result
+
+    def test_safe_string_conversion_with_custom_tracer(self) -> None:
+        """Test safe_string_conversion with custom tracer instance."""
+        mock_tracer = Mock()
+        result = safe_string_conversion("test", tracer_instance=mock_tracer)
+        assert result == "test"
+
+    @patch("honeyhive.tracer.utils.general._truncate_string_dynamically")
+    def test_safe_string_conversion_calls_truncation(self, mock_truncate: Mock) -> None:
+        """Test safe_string_conversion calls truncation for long strings."""
+        mock_truncate.return_value = "truncated"
+        long_string = "x" * 2000
+
+        result = safe_string_conversion(long_string, max_length=100)
+
+        assert result == "truncated"
+        mock_truncate.assert_called_once_with(long_string, 100)
+
+
+class TestNormalizeAttributeKey:
+    """Test suite for normalize_attribute_key function."""
+
+    def test_normalize_attribute_key_with_simple_key(self) -> None:
+        """Test normalize_attribute_key with simple key."""
+        result = normalize_attribute_key("simple_key")
+        assert result == "simple_key"
+
+    def test_normalize_attribute_key_with_dashes(self) -> None:
+        """Test normalize_attribute_key converts dashes to underscores."""
+        result = normalize_attribute_key("user-name")
+        assert result == "user_name"
+
+    def test_normalize_attribute_key_with_spaces(self) -> None:
+        """Test normalize_attribute_key converts spaces to underscores."""
+        result = normalize_attribute_key("user name")
+        assert result == "user_name"
+
+    def test_normalize_attribute_key_with_special_chars(self) -> None:
+        """Test normalize_attribute_key removes special characters."""
+        result = normalize_attribute_key("user@name!")
+        assert result == "username"
+
+    def test_normalize_attribute_key_with_empty_string(self) -> None:
+        """Test normalize_attribute_key with empty string returns 'unknown'."""
+        result = normalize_attribute_key("")
+        assert result == "unknown"
+
+    def test_normalize_attribute_key_with_unicode(self) -> None:
+        """Test normalize_attribute_key handles unicode characters."""
+        result = normalize_attribute_key("usér_nämé")
+        assert result == "usér_nämé"  # Unicode is preserved in current implementation
+
+    @patch("honeyhive.tracer.utils.general.safe_log")
+    @patch("honeyhive.tracer.utils.general._apply_normalization_pipeline_dynamically")
+    def test_normalize_attribute_key_with_exception(
+        self, mock_pipeline: Mock, mock_safe_log: Mock
+    ) -> None:
+        """Test normalize_attribute_key handles exceptions with logging."""
+        mock_pipeline.side_effect = ValueError("Pipeline failed")
+        mock_tracer = Mock()
+
+        result = normalize_attribute_key("test_key", tracer_instance=mock_tracer)
+
+        assert result == "unknown"
+        mock_safe_log.assert_called_once_with(
+            mock_tracer,
+            "warning",
+            "Failed to normalize attribute key",
+            honeyhive_data={
+                "original_key": "test_key",
+                "error": "Pipeline failed",
+            },
+        )
+
+    def test_normalize_attribute_key_with_mixed_case(self) -> None:
+        """Test normalize_attribute_key handles mixed case."""
+        result = normalize_attribute_key("UserName")
+        assert result == "username"
+
+    def test_normalize_attribute_key_with_numbers(self) -> None:
+        """Test normalize_attribute_key preserves numbers."""
+        result = normalize_attribute_key("user123")
+        assert result == "user123"
+
+    def test_normalize_attribute_key_with_custom_tracer(self) -> None:
+        """Test normalize_attribute_key with custom tracer instance."""
+        mock_tracer = Mock()
+        result = normalize_attribute_key("test_key", tracer_instance=mock_tracer)
+        assert result == "test_key"
+
+
+class TestGetCallerInfo:
+    """Test suite for get_caller_info function."""
+
+    @patch("honeyhive.tracer.utils.general._inspect_call_stack_dynamically")
+    @patch("honeyhive.tracer.utils.general._extract_caller_details_dynamically")
+    def test_get_caller_info_success(
+        self, mock_extract: Mock, mock_inspect: Mock
+    ) -> None:
+        """Test get_caller_info successful execution."""
+        mock_frame = Mock()
+        mock_inspect.return_value = mock_frame
+        expected_details = {
+            "filename": "test.py",
+            "function": "test_function",
+            "line_number": "42",
+        }
+        mock_extract.return_value = expected_details
+
+        result = get_caller_info()
+
+        assert result == expected_details
+        mock_inspect.assert_called_once_with(2)  # Adjusted for actual call stack depth
+        mock_extract.assert_called_once_with(mock_frame)
+
+    @patch("honeyhive.tracer.utils.general._inspect_call_stack_dynamically")
+    @patch("honeyhive.tracer.utils.general._get_default_caller_info_dynamically")
+    def test_get_caller_info_with_none_frame(
+        self, mock_default: Mock, mock_inspect: Mock
+    ) -> None:
+        """Test get_caller_info when frame inspection returns None."""
+        mock_inspect.return_value = None
+        expected_default = {"filename": None, "function": None, "line_number": None}
+        mock_default.return_value = expected_default
+
+        result = get_caller_info()
+
+        assert result == expected_default
+        mock_default.assert_called_once()
+
+    @patch("honeyhive.tracer.utils.general.safe_log")
+    @patch("honeyhive.tracer.utils.general._inspect_call_stack_dynamically")
+    @patch("honeyhive.tracer.utils.general._get_default_caller_info_dynamically")
+    def test_get_caller_info_with_exception(
+        self, mock_default: Mock, mock_inspect: Mock, mock_safe_log: Mock
+    ) -> None:
+        """Test get_caller_info handles exceptions with logging."""
+        mock_inspect.side_effect = RuntimeError("Inspection failed")
+        mock_tracer = Mock()
+        expected_default = {"filename": None, "function": None, "line_number": None}
+        mock_default.return_value = expected_default
+
+        result = get_caller_info(skip_frames=2, tracer_instance=mock_tracer)
+
+        assert result == expected_default
+        mock_safe_log.assert_called_once_with(
+            mock_tracer,
+            "debug",
+            "Failed to get caller info",
+            honeyhive_data={
+                "error": "Inspection failed",
+                "skip_frames": 2,
+            },
+        )
+
+    def test_get_caller_info_with_custom_skip_frames(self) -> None:
+        """Test get_caller_info with custom skip_frames parameter."""
+        result = get_caller_info(skip_frames=3)
+        assert isinstance(result, dict)
+        assert "filename" in result
+        assert "function" in result
+        assert "line_number" in result
+
+    def test_get_caller_info_with_tracer_instance(self) -> None:
+        """Test get_caller_info with tracer instance."""
+        mock_tracer = Mock()
+        result = get_caller_info(tracer_instance=mock_tracer)
+        assert isinstance(result, dict)
+
+
+class TestPrivateHelperFunctions:
+    """Test suite for private helper functions."""
+
+    def test_is_enum_value_dynamically_with_enum(self) -> None:
+        """Test _is_enum_value_dynamically with actual enum."""
+        result = _is_enum_value_dynamically(EventTypeEnum.MODEL)
+        assert result is True
+
+    def test_is_enum_value_dynamically_with_non_enum(self) -> None:
+        """Test _is_enum_value_dynamically with non-enum."""
+        result = _is_enum_value_dynamically("not_an_enum")
+        assert result is False
+
+    def test_is_enum_value_dynamically_with_mock_enum(self) -> None:
+        """Test _is_enum_value_dynamically with mock enum-like object."""
+        mock_enum = MockEnumLike("test")
+        result = _is_enum_value_dynamically(mock_enum)
+        assert result is True
+
+    def test_extract_enum_value_dynamically_with_enum(self) -> None:
+        """Test _extract_enum_value_dynamically with actual enum."""
+        result = _extract_enum_value_dynamically(EventTypeEnum.TOOL)
+        assert result == "tool"
+
+    def test_extract_enum_value_dynamically_with_mock_enum(self) -> None:
+        """Test _extract_enum_value_dynamically with mock enum."""
+        mock_enum = MockEnumLike("mock_value")
+        result = _extract_enum_value_dynamically(mock_enum)
+        assert result == "mock_value"
+
+    def test_extract_enum_value_dynamically_with_invalid_enum(self) -> None:
+        """Test _extract_enum_value_dynamically with invalid enum falls back."""
+        mock_invalid = MockInvalidEnum()
+        result = _extract_enum_value_dynamically(mock_invalid)
+        # The actual implementation may extract class name without full module path
+        assert "MockInvalidEnum" in result
+
+    def test_convert_to_string_dynamically_with_string(self) -> None:
+        """Test _convert_to_string_dynamically with string input."""
+        result = _convert_to_string_dynamically("test_string")
+        assert result == "test_string"
+
+    def test_convert_to_string_dynamically_with_integer(self) -> None:
+        """Test _convert_to_string_dynamically with integer input."""
+        result = _convert_to_string_dynamically(42)
+        assert result == "42"
+
+    def test_convert_to_string_dynamically_with_complex_object(self) -> None:
+        """Test _convert_to_string_dynamically with complex object."""
+        test_dict = {"key": "value"}
+        result = _convert_to_string_dynamically(test_dict)
+        assert "key" in result
+
+    def test_truncate_string_dynamically_short_limit(self) -> None:
+        """Test _truncate_string_dynamically with short limit."""
+        result = _truncate_string_dynamically("test_string", 5)
+        assert result == "test_"
+        assert len(result) == 5
+
+    def test_truncate_string_dynamically_normal_limit(self) -> None:
+        """Test _truncate_string_dynamically with normal limit."""
+        long_string = "x" * 100
+        result = _truncate_string_dynamically(long_string, 50)
+        assert len(result) <= 50  # May be 49 due to ellipsis placement
+        assert result.startswith("x")
+        assert result.endswith("x")
+        assert "..." in result
+
+    def test_apply_normalization_pipeline_dynamically(self) -> None:
+        """Test _apply_normalization_pipeline_dynamically."""
+        result = _apply_normalization_pipeline_dynamically("test-key")
+        assert result == "test_key"
+
+    def test_replace_separators_dynamically(self) -> None:
+        """Test _replace_separators_dynamically."""
+        result = _replace_separators_dynamically("test-key.value")
+        assert result == "test_key_value"
+
+    def test_remove_special_chars_dynamically(self) -> None:
+        """Test _remove_special_chars_dynamically."""
+        result = _remove_special_chars_dynamically("test@key!")
+        assert result == "testkey"
+
+    def test_ensure_valid_identifier_dynamically(self) -> None:
+        """Test _ensure_valid_identifier_dynamically."""
+        result = _ensure_valid_identifier_dynamically("123test")
+        assert result == "attr_123test"
+
+    def test_validate_and_correct_key_dynamically(self) -> None:
+        """Test _validate_and_correct_key_dynamically."""
+        result = _validate_and_correct_key_dynamically("valid_key")
+        assert result == "valid_key"
+
+    @patch("honeyhive.tracer.utils.general.inspect.currentframe")
+    def test_inspect_call_stack_dynamically_success(
+        self, mock_currentframe: Mock
+    ) -> None:
+        """Test _inspect_call_stack_dynamically successful execution."""
+        mock_frame = Mock()
+        mock_frame.f_back = Mock()  # Mock the frame back reference
+        mock_currentframe.return_value = mock_frame
+
+        result = _inspect_call_stack_dynamically(1)
+
+        assert result == mock_frame.f_back  # Returns f_back after skipping frames
+
+    @patch("honeyhive.tracer.utils.general.inspect.currentframe")
+    def test_inspect_call_stack_dynamically_failure(
+        self, mock_currentframe: Mock
+    ) -> None:
+        """Test _inspect_call_stack_dynamically handles failure."""
+        mock_currentframe.side_effect = RuntimeError("Frame access failed")
+
+        result = _inspect_call_stack_dynamically(1)
+
+        assert result is None
+
+    @patch("honeyhive.tracer.utils.general.os.path.basename")
+    def test_extract_caller_details_dynamically_complete(
+        self, mock_basename: Mock
+    ) -> None:
+        """Test _extract_caller_details_dynamically with complete frame."""
+        mock_basename.return_value = "test.py"
+        mock_frame = Mock()
+        mock_frame.f_code.co_filename = "/path/to/test.py"
+        mock_frame.f_code.co_name = "test_function"
+        mock_frame.f_lineno = 42
+
+        result = _extract_caller_details_dynamically(mock_frame)
+
+        assert result == {
+            "filename": "test.py",
+            "function": "test_function",
+            "line_number": "42",
+        }
+
+    def test_extract_caller_details_dynamically_missing_attributes(self) -> None:
+        """Test _extract_caller_details_dynamically with missing attributes."""
+        mock_frame = Mock()
+        del mock_frame.f_code
+        del mock_frame.f_lineno
+
+        result = _extract_caller_details_dynamically(mock_frame)
+
+        assert result == {"filename": None, "function": None, "line_number": None}
+
+    def test_extract_caller_details_dynamically_with_exception(self) -> None:
+        """Test _extract_caller_details_dynamically handles exceptions."""
+        mock_frame = Mock()
+        # Make the frame raise an exception during processing
+        mock_frame.f_code.co_filename = "/path/to/test.py"
+        mock_frame.f_code.co_name = "test_function"
+        mock_frame.f_lineno = 42
+
+        # Patch os.path.basename to raise an exception
+        with patch(
+            "honeyhive.tracer.utils.general.os.path.basename",
+            side_effect=Exception("Basename failed"),
+        ):
+            result = _extract_caller_details_dynamically(mock_frame)
+
+        # Should return default values due to exception handling
+        assert result == {"filename": None, "function": None, "line_number": None}
+
+    def test_get_default_caller_info_dynamically(self) -> None:
+        """Test _get_default_caller_info_dynamically returns default values."""
+        result = _get_default_caller_info_dynamically()
+
+        assert result == {"filename": None, "function": None, "line_number": None}
+
+
+class TestEdgeCasesAndErrorHandling:
+    """Test suite for edge cases and error handling scenarios."""
+
+    def test_convert_enum_to_string_with_recursive_enum(self) -> None:
+        """Test convert_enum_to_string handles recursive enum structures."""
+        # Create a mock enum that references itself
+        mock_enum = Mock()
+        mock_enum.value = mock_enum
+
+        with patch(
+            "honeyhive.tracer.utils.general._is_enum_value_dynamically",
+            return_value=True,
+        ):
+            result = convert_enum_to_string(mock_enum)
+            assert isinstance(result, str)
+
+    def test_safe_string_conversion_with_unconvertible_object(self) -> None:
+        """Test safe_string_conversion with object that can't be converted."""
+
+        # Create an object that raises exception on string conversion
+        class UnconvertibleObject:
+            """Test class that cannot be converted to string."""
+
+            def __str__(self) -> str:
+                raise RuntimeError("Cannot convert to string")
+
+            def __repr__(self) -> str:
+                raise RuntimeError("Cannot convert to repr")
+
+        obj = UnconvertibleObject()
+        result = safe_string_conversion(obj)
+        # The actual implementation uses type name + id as fallback
+        assert "UnconvertibleObject" in result
+
+    def test_normalize_attribute_key_with_only_special_chars(self) -> None:
+        """Test normalize_attribute_key with only special characters."""
+        result = normalize_attribute_key("!@#$%^&*()")
+        assert result == "unknown"
+
+    def test_get_caller_info_with_deep_skip_frames(self) -> None:
+        """Test get_caller_info with very deep skip_frames."""
+        result = get_caller_info(skip_frames=1000)
+        assert isinstance(result, dict)
+        # Should return default values when skipping too many frames
+        assert result["filename"] is None or isinstance(result["filename"], str)
+
+    @patch("honeyhive.tracer.utils.general._convert_to_string_dynamically")
+    def test_safe_string_conversion_all_strategies_fail(
+        self, mock_convert: Mock
+    ) -> None:
+        """Test safe_string_conversion when all conversion strategies fail."""
+        mock_convert.return_value = ""  # Empty string should trigger fallback
+
+        result = safe_string_conversion("test")
+        assert result == ""
+
+    def test_truncate_string_dynamically_edge_cases(self) -> None:
+        """Test _truncate_string_dynamically with edge case lengths."""
+        # Test with exact ellipsis length
+        result = _truncate_string_dynamically("test", 3)
+        assert len(result) == 3
+
+        # Test with length exactly at ellipsis boundary
+        result = _truncate_string_dynamically("test_string", 10)
+        assert len(result) == 10
+
+    def test_private_functions_with_none_inputs(self) -> None:
+        """Test private functions handle None inputs gracefully."""
+        assert _is_enum_value_dynamically(None) is False
+        assert isinstance(_convert_to_string_dynamically(None), str)
+        assert isinstance(_apply_normalization_pipeline_dynamically(""), str)
+
+    @patch("honeyhive.tracer.utils.general.hasattr")
+    def test_enum_detection_with_hasattr_failure(self, mock_hasattr: Mock) -> None:
+        """Test enum detection when hasattr fails."""
+        mock_hasattr.side_effect = [False, False, False]  # All checks fail
+
+        # Use a non-enum object since hasattr is mocked to return False
+        result = _is_enum_value_dynamically("not_an_enum")
+        assert result is False
+
+    def test_frame_cleanup_in_extract_caller_details(self) -> None:
+        """Test frame cleanup in _extract_caller_details_dynamically."""
+        mock_frame = Mock()
+        mock_frame.f_code.co_filename = "test.py"
+        mock_frame.f_code.co_name = "test_func"
+        mock_frame.f_lineno = 10
+
+        # Should not raise exception even if frame cleanup fails
+        result = _extract_caller_details_dynamically(mock_frame)
+        assert isinstance(result, dict)

--- a/tests_v2/unit/test_tracer_utils_git.py
+++ b/tests_v2/unit/test_tracer_utils_git.py
@@ -1,0 +1,1082 @@
+"""Unit tests for HoneyHive tracer utils git functionality.
+
+This module tests the git information collection utilities including telemetry
+settings, repository detection, and git command execution using standard fixtures
+and comprehensive edge case coverage following Agent OS testing standards.
+"""
+
+# pylint: disable=too-many-lines,protected-access,redefined-outer-name,too-many-public-methods,line-too-long
+# Justification: Comprehensive git testing requires extensive test coverage
+
+import subprocess
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+
+from honeyhive.tracer.utils.git import (
+    _collect_git_information_dynamically,
+    _convert_to_boolean_dynamically,
+    _generate_commit_link_dynamically,
+    _get_git_branch_dynamically,
+    _get_git_commit_hash_dynamically,
+    _get_git_repo_url_dynamically,
+    _get_main_module_path_dynamically,
+    _get_main_module_relative_path_dynamically,
+    _get_repository_root_dynamically,
+    _get_telemetry_setting_dynamically,
+    _handle_git_command_error_dynamically,
+    _handle_git_not_found_error_dynamically,
+    _handle_unexpected_git_error_dynamically,
+    _has_uncommitted_changes_dynamically,
+    _is_git_repository_dynamically,
+    _log_git_collection_success_dynamically,
+    get_git_information,
+    is_telemetry_enabled,
+)
+
+
+class TestIsTelemetryEnabled:
+    """Test telemetry enablement checking functionality."""
+
+    @patch("honeyhive.tracer.utils.git._get_telemetry_setting_dynamically")
+    @patch("honeyhive.tracer.utils.git._convert_to_boolean_dynamically")
+    def test_is_telemetry_enabled_calls_helper_functions(
+        self, mock_convert: Any, mock_get_setting: Any, honeyhive_tracer: Any
+    ) -> None:
+        """Test that telemetry check calls helper functions properly."""
+        mock_get_setting.return_value = "true"
+        mock_convert.return_value = True
+
+        result = is_telemetry_enabled(honeyhive_tracer)
+
+        assert result is True
+        mock_get_setting.assert_called_once_with(honeyhive_tracer)
+        mock_convert.assert_called_once_with(
+            "true", default=True, tracer_instance=honeyhive_tracer
+        )
+
+    @patch("honeyhive.tracer.utils.git._get_telemetry_setting_dynamically")
+    @patch("honeyhive.tracer.utils.git._convert_to_boolean_dynamically")
+    def test_is_telemetry_enabled_with_false_setting(
+        self, mock_convert: Any, mock_get_setting: Any, honeyhive_tracer: Any
+    ) -> None:
+        """Test telemetry check with false setting."""
+        mock_get_setting.return_value = "false"
+        mock_convert.return_value = False
+
+        result = is_telemetry_enabled(honeyhive_tracer)
+
+        assert result is False
+
+    def test_is_telemetry_enabled_without_tracer_instance(self) -> None:
+        """Test telemetry check without tracer instance."""
+        with patch(
+            "honeyhive.tracer.utils.git._get_telemetry_setting_dynamically"
+        ) as mock_get_setting:
+            with patch(
+                "honeyhive.tracer.utils.git._convert_to_boolean_dynamically"
+            ) as mock_convert:
+                mock_get_setting.return_value = "true"
+                mock_convert.return_value = True
+
+                result = is_telemetry_enabled()
+
+                assert result is True
+                mock_get_setting.assert_called_once_with(None)
+
+
+class TestGetTelemetrySettingDynamically:
+    """Test telemetry setting retrieval functionality."""
+
+    @patch("os.getenv")
+    @patch("honeyhive.tracer.utils.git.safe_log")
+    def test_get_telemetry_setting_honeyhive_telemetry(
+        self, mock_log: Any, mock_getenv: Any, honeyhive_tracer: Any
+    ) -> None:
+        """Test telemetry setting retrieval with HONEYHIVE_TELEMETRY."""
+        mock_getenv.side_effect = lambda key: (
+            "TRUE" if key == "HONEYHIVE_TELEMETRY" else None
+        )
+
+        result = _get_telemetry_setting_dynamically(honeyhive_tracer)
+
+        assert result == "true"
+        mock_log.assert_called_once()
+        args, kwargs = mock_log.call_args
+        assert args[2] == "Found telemetry setting"
+        assert kwargs["honeyhive_data"]["env_var"] == "HONEYHIVE_TELEMETRY"
+        assert kwargs["honeyhive_data"]["value"] == "TRUE"
+
+    @patch("os.getenv")
+    @patch("honeyhive.tracer.utils.git.safe_log")
+    def test_get_telemetry_setting_hh_telemetry(
+        self, mock_log: Any, mock_getenv: Any, honeyhive_tracer: Any
+    ) -> None:
+        """Test telemetry setting retrieval with HH_TELEMETRY."""
+        mock_getenv.side_effect = lambda key: "false" if key == "HH_TELEMETRY" else None
+
+        result = _get_telemetry_setting_dynamically(honeyhive_tracer)
+
+        assert result == "false"
+        mock_log.assert_called_once()
+        _, kwargs = mock_log.call_args
+        assert kwargs["honeyhive_data"]["env_var"] == "HH_TELEMETRY"
+
+    @patch("os.getenv")
+    @patch("honeyhive.tracer.utils.git.safe_log")
+    def test_get_telemetry_setting_telemetry_enabled(
+        self, mock_log: Any, mock_getenv: Any, honeyhive_tracer: Any
+    ) -> None:
+        """Test telemetry setting retrieval with TELEMETRY_ENABLED."""
+        mock_getenv.side_effect = lambda key: (
+            "0" if key == "TELEMETRY_ENABLED" else None
+        )
+
+        result = _get_telemetry_setting_dynamically(honeyhive_tracer)
+
+        assert result == "0"
+        mock_log.assert_called_once()
+        _, kwargs = mock_log.call_args
+        assert kwargs["honeyhive_data"]["env_var"] == "TELEMETRY_ENABLED"
+
+    @patch("os.getenv")
+    def test_get_telemetry_setting_no_env_vars(
+        self, mock_getenv: Any, honeyhive_tracer: Any
+    ) -> None:
+        """Test telemetry setting retrieval with no environment variables set."""
+        mock_getenv.return_value = None
+
+        result = _get_telemetry_setting_dynamically(honeyhive_tracer)
+
+        assert result == "true"
+
+    @patch("os.getenv")
+    @patch("honeyhive.tracer.utils.git.safe_log")
+    def test_get_telemetry_setting_priority_order(
+        self, mock_log: Any, mock_getenv: Any, honeyhive_tracer: Any
+    ) -> None:
+        """Test that environment variables are checked in priority order."""
+
+        # Set multiple env vars, should pick the first one found
+        def mock_getenv_side_effect(key: Any) -> Any:
+            if key == "HONEYHIVE_TELEMETRY":
+                return "first"
+            if key == "HH_TELEMETRY":
+                return "second"
+            if key == "TELEMETRY_ENABLED":
+                return "third"
+            return None
+
+        mock_getenv.side_effect = mock_getenv_side_effect
+
+        result = _get_telemetry_setting_dynamically(honeyhive_tracer)
+
+        assert result == "first"
+        mock_log.assert_called_once()
+        _, kwargs = mock_log.call_args
+        assert kwargs["honeyhive_data"]["env_var"] == "HONEYHIVE_TELEMETRY"
+
+
+class TestConvertToBooleanDynamically:
+    """Test boolean conversion functionality."""
+
+    def test_convert_to_boolean_false_patterns(self, honeyhive_tracer: Any) -> None:
+        """Test boolean conversion with false patterns."""
+        false_values = ["false", "0", "f", "no", "n", "off", "disabled"]
+
+        for value in false_values:
+            result = _convert_to_boolean_dynamically(
+                value, tracer_instance=honeyhive_tracer
+            )
+            assert result is False, f"Failed for value: {value}"
+
+            # Test case insensitive
+            result = _convert_to_boolean_dynamically(
+                value.upper(), tracer_instance=honeyhive_tracer
+            )
+            assert result is False, f"Failed for uppercase value: {value.upper()}"
+
+    def test_convert_to_boolean_true_patterns(self, honeyhive_tracer: Any) -> None:
+        """Test boolean conversion with true patterns."""
+        true_values = ["true", "1", "t", "yes", "y", "on", "enabled"]
+
+        for value in true_values:
+            result = _convert_to_boolean_dynamically(
+                value, tracer_instance=honeyhive_tracer
+            )
+            assert result is True, f"Failed for value: {value}"
+
+            # Test case insensitive
+            result = _convert_to_boolean_dynamically(
+                value.upper(), tracer_instance=honeyhive_tracer
+            )
+            assert result is True, f"Failed for uppercase value: {value.upper()}"
+
+    def test_convert_to_boolean_with_whitespace(self, honeyhive_tracer: Any) -> None:
+        """Test boolean conversion with whitespace."""
+        result = _convert_to_boolean_dynamically(
+            "  true  ", tracer_instance=honeyhive_tracer
+        )
+        assert result is True
+
+        result = _convert_to_boolean_dynamically(
+            "  false  ", tracer_instance=honeyhive_tracer
+        )
+        assert result is False
+
+    @patch("honeyhive.tracer.utils.git.safe_log")
+    def test_convert_to_boolean_unknown_value_default_true(
+        self, mock_log: Any, honeyhive_tracer: Any
+    ) -> None:
+        """Test boolean conversion with unknown value and default True."""
+        result = _convert_to_boolean_dynamically(
+            "unknown", default=True, tracer_instance=honeyhive_tracer
+        )
+
+        assert result is True
+        mock_log.assert_called_once()
+        args, kwargs = mock_log.call_args
+        assert args[2] == "Unknown telemetry value, using default"
+        assert kwargs["honeyhive_data"]["value"] == "unknown"
+        assert kwargs["honeyhive_data"]["default"] is True
+
+    @patch("honeyhive.tracer.utils.git.safe_log")
+    def test_convert_to_boolean_unknown_value_default_false(
+        self, mock_log: Any, honeyhive_tracer: Any
+    ) -> None:
+        """Test boolean conversion with unknown value and default False."""
+        result = _convert_to_boolean_dynamically(
+            "unknown", default=False, tracer_instance=honeyhive_tracer
+        )
+
+        assert result is False
+        mock_log.assert_called_once()
+        _, kwargs = mock_log.call_args
+        assert kwargs["honeyhive_data"]["default"] is False
+
+
+class TestGetGitInformation:
+    """Test main git information collection functionality."""
+
+    @patch("honeyhive.tracer.utils.git.is_telemetry_enabled")
+    @patch("honeyhive.tracer.utils.git.safe_log")
+    def test_get_git_information_telemetry_disabled(
+        self, mock_log: Any, mock_telemetry: Any, honeyhive_tracer: Any
+    ) -> None:
+        """Test git information collection when telemetry is disabled."""
+        mock_telemetry.return_value = False
+
+        result = get_git_information(verbose=True, tracer_instance=honeyhive_tracer)
+
+        assert result == {"error": "Telemetry disabled"}
+        mock_log.assert_called_once_with(
+            honeyhive_tracer,
+            "debug",
+            "Telemetry disabled. Skipping git information collection.",
+        )
+
+    @patch("honeyhive.tracer.utils.git.is_telemetry_enabled")
+    def test_get_git_information_telemetry_disabled_not_verbose(
+        self, mock_telemetry: Any, honeyhive_tracer: Any
+    ) -> None:
+        """Test git information collection when telemetry is disabled and not
+        verbose."""
+        mock_telemetry.return_value = False
+
+        result = get_git_information(verbose=False, tracer_instance=honeyhive_tracer)
+
+        assert result == {"error": "Telemetry disabled"}
+
+    @patch("honeyhive.tracer.utils.git.is_telemetry_enabled")
+    @patch("honeyhive.tracer.utils.git._is_git_repository_dynamically")
+    @patch("honeyhive.tracer.utils.git.safe_log")
+    def test_get_git_information_not_git_repo(
+        self,
+        mock_log: Any,
+        mock_is_git: Any,
+        mock_telemetry: Any,
+        honeyhive_tracer: Any,
+    ) -> None:
+        """Test git information collection when not in git repository."""
+        mock_telemetry.return_value = True
+        mock_is_git.return_value = False
+
+        result = get_git_information(verbose=True, tracer_instance=honeyhive_tracer)
+
+        assert result == {"error": "Not a git repository"}
+        mock_log.assert_called_once_with(
+            honeyhive_tracer,
+            "debug",
+            "Not a git repository. Skipping git information collection.",
+        )
+
+    @patch("honeyhive.tracer.utils.git.is_telemetry_enabled")
+    @patch("honeyhive.tracer.utils.git._is_git_repository_dynamically")
+    @patch("honeyhive.tracer.utils.git._collect_git_information_dynamically")
+    @patch("honeyhive.tracer.utils.git._log_git_collection_success_dynamically")
+    def test_get_git_information_success(  # pylint: disable=R0917 # too-many-positional-arguments
+        self,
+        mock_log_success: Any,
+        mock_collect: Any,
+        mock_is_git: Any,
+        mock_telemetry: Any,
+        honeyhive_tracer: Any,
+    ) -> None:
+        """Test successful git information collection."""
+        mock_telemetry.return_value = True
+        mock_is_git.return_value = True
+        expected_git_info = {
+            "commit_hash": "abc123",
+            "branch": "main",
+            "repo_url": "https://github.com/user/repo.git",
+        }
+        mock_collect.return_value = expected_git_info
+
+        result = get_git_information(verbose=True, tracer_instance=honeyhive_tracer)
+
+        assert result == expected_git_info
+        mock_collect.assert_called_once_with(True)
+        mock_log_success.assert_called_once_with(expected_git_info)
+
+    @patch("honeyhive.tracer.utils.git.is_telemetry_enabled")
+    @patch("honeyhive.tracer.utils.git._is_git_repository_dynamically")
+    @patch("honeyhive.tracer.utils.git._collect_git_information_dynamically")
+    def test_get_git_information_success_not_verbose(
+        self,
+        mock_collect: Any,
+        mock_is_git: Any,
+        mock_telemetry: Any,
+        honeyhive_tracer: Any,
+    ) -> None:
+        """Test successful git information collection without verbose logging."""
+        mock_telemetry.return_value = True
+        mock_is_git.return_value = True
+        expected_git_info = {"commit_hash": "abc123"}
+        mock_collect.return_value = expected_git_info
+
+        result = get_git_information(verbose=False, tracer_instance=honeyhive_tracer)
+
+        assert result == expected_git_info
+        mock_collect.assert_called_once_with(False)
+
+    @patch("honeyhive.tracer.utils.git.is_telemetry_enabled")
+    @patch("honeyhive.tracer.utils.git._is_git_repository_dynamically")
+    @patch("honeyhive.tracer.utils.git._collect_git_information_dynamically")
+    @patch("honeyhive.tracer.utils.git._handle_git_command_error_dynamically")
+    def test_get_git_information_subprocess_error(  # pylint: disable=R0917 # too-many-positional-arguments
+        self,
+        mock_handle_error: Any,
+        mock_collect: Any,
+        mock_is_git: Any,
+        mock_telemetry: Any,
+        honeyhive_tracer: Any,
+    ) -> None:
+        """Test git information collection with subprocess error."""
+        mock_telemetry.return_value = True
+        mock_is_git.return_value = True
+        error = subprocess.CalledProcessError(1, "git")
+        mock_collect.side_effect = error
+        expected_error_result = {"error": "Git command failed"}
+        mock_handle_error.return_value = expected_error_result
+
+        result = get_git_information(verbose=True, tracer_instance=honeyhive_tracer)
+
+        assert result == expected_error_result
+        mock_handle_error.assert_called_once_with(error, True)
+
+    @patch("honeyhive.tracer.utils.git.is_telemetry_enabled")
+    @patch("honeyhive.tracer.utils.git._is_git_repository_dynamically")
+    @patch("honeyhive.tracer.utils.git._collect_git_information_dynamically")
+    @patch("honeyhive.tracer.utils.git._handle_git_not_found_error_dynamically")
+    def test_get_git_information_file_not_found(  # pylint: disable=R0917 # too-many-positional-arguments
+        self,
+        mock_handle_error: Any,
+        mock_collect: Any,
+        mock_is_git: Any,
+        mock_telemetry: Any,
+        honeyhive_tracer: Any,
+    ) -> None:
+        """Test git information collection with FileNotFoundError."""
+        mock_telemetry.return_value = True
+        mock_is_git.return_value = True
+        mock_collect.side_effect = FileNotFoundError("git not found")
+        expected_error_result = {"error": "Git not found"}
+        mock_handle_error.return_value = expected_error_result
+
+        result = get_git_information(verbose=True, tracer_instance=honeyhive_tracer)
+
+        assert result == expected_error_result
+        mock_handle_error.assert_called_once_with(True)
+
+    @patch("honeyhive.tracer.utils.git.is_telemetry_enabled")
+    @patch("honeyhive.tracer.utils.git._is_git_repository_dynamically")
+    @patch("honeyhive.tracer.utils.git._collect_git_information_dynamically")
+    @patch("honeyhive.tracer.utils.git._handle_unexpected_git_error_dynamically")
+    def test_get_git_information_unexpected_error(  # pylint: disable=R0917 # too-many-positional-arguments
+        self,
+        mock_handle_error: Any,
+        mock_collect: Any,
+        mock_is_git: Any,
+        mock_telemetry: Any,
+        honeyhive_tracer: Any,
+    ) -> None:
+        """Test git information collection with unexpected error."""
+        mock_telemetry.return_value = True
+        mock_is_git.return_value = True
+        error = ValueError("Unexpected error")
+        mock_collect.side_effect = error
+        expected_error_result = {"error": "Unexpected error"}
+        mock_handle_error.return_value = expected_error_result
+
+        result = get_git_information(verbose=True, tracer_instance=honeyhive_tracer)
+
+        assert result == expected_error_result
+        mock_handle_error.assert_called_once_with(error, True)
+
+
+class TestIsGitRepositoryDynamically:
+    """Test git repository detection functionality."""
+
+    @patch("os.getcwd")
+    @patch("subprocess.run")
+    def test_is_git_repository_true(self, mock_run: Any, mock_getcwd: Any) -> None:
+        """Test git repository detection when in git repository."""
+        mock_getcwd.return_value = "/path/to/repo"
+        mock_result = Mock()
+        mock_result.returncode = 0
+        mock_run.return_value = mock_result
+
+        result = _is_git_repository_dynamically()
+
+        assert result is True
+        mock_run.assert_called_once_with(
+            ["git", "rev-parse", "--is-inside-work-tree"],
+            cwd="/path/to/repo",
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    @patch("os.getcwd")
+    @patch("subprocess.run")
+    def test_is_git_repository_false(self, mock_run: Any, mock_getcwd: Any) -> None:
+        """Test git repository detection when not in git repository."""
+        mock_getcwd.return_value = "/path/to/non-repo"
+        mock_result = Mock()
+        mock_result.returncode = 1
+        mock_run.return_value = mock_result
+
+        result = _is_git_repository_dynamically()
+
+        assert result is False
+
+    @patch("os.getcwd")
+    @patch("subprocess.run")
+    def test_is_git_repository_exception(self, mock_run: Any, mock_getcwd: Any) -> None:
+        """Test git repository detection with exception."""
+        mock_getcwd.return_value = "/path/to/repo"
+        mock_run.side_effect = Exception("Command failed")
+
+        result = _is_git_repository_dynamically()
+
+        assert result is False
+
+
+class TestCollectGitInformationDynamically:
+    """Test git information collection functionality."""
+
+    @patch("os.getcwd")
+    @patch("honeyhive.tracer.utils.git._get_git_commit_hash_dynamically")
+    @patch("honeyhive.tracer.utils.git._get_git_branch_dynamically")
+    @patch("honeyhive.tracer.utils.git._get_git_repo_url_dynamically")
+    @patch("honeyhive.tracer.utils.git._has_uncommitted_changes_dynamically")
+    @patch("honeyhive.tracer.utils.git._get_main_module_relative_path_dynamically")
+    def test_collect_git_information_all_success(  # pylint: disable=R0917 # too-many-positional-arguments
+        self,
+        mock_path: Any,
+        mock_changes: Any,
+        mock_url: Any,
+        mock_branch: Any,
+        mock_commit: Any,
+        mock_getcwd: Any,
+    ) -> None:
+        """Test git information collection when all steps succeed."""
+        mock_getcwd.return_value = "/repo"
+        mock_commit.return_value = "abc123"
+        mock_branch.return_value = "main"
+        mock_url.return_value = "https://github.com/user/repo.git"
+        mock_changes.return_value = True
+        mock_path.return_value = "src/main.py"
+
+        result = _collect_git_information_dynamically(verbose=True)
+
+        expected = {
+            "commit_hash": "abc123",
+            "branch": "main",
+            "repo_url": "https://github.com/user/repo.git",
+            "uncommitted_changes": True,
+            "relative_path": "src/main.py",
+            "commit_link": "https://github.com/user/repo.git/commit/abc123",
+        }
+        assert result == expected
+
+    @patch("os.getcwd")
+    @patch("honeyhive.tracer.utils.git._get_git_commit_hash_dynamically")
+    @patch("honeyhive.tracer.utils.git._get_git_branch_dynamically")
+    @patch("honeyhive.tracer.utils.git._get_git_repo_url_dynamically")
+    @patch("honeyhive.tracer.utils.git._has_uncommitted_changes_dynamically")
+    @patch("honeyhive.tracer.utils.git._get_main_module_relative_path_dynamically")
+    def test_collect_git_information_partial_success(  # pylint: disable=R0917 # too-many-positional-arguments
+        self,
+        mock_path: Any,
+        mock_changes: Any,
+        mock_url: Any,
+        mock_branch: Any,
+        mock_commit: Any,
+        mock_getcwd: Any,
+    ) -> None:
+        """Test git information collection when some steps fail."""
+        mock_getcwd.return_value = "/repo"
+        mock_commit.return_value = "abc123"
+        mock_branch.return_value = None  # Failed to get branch
+        mock_url.return_value = "https://github.com/user/repo.git"
+        mock_changes.return_value = False
+        mock_path.return_value = None  # Failed to get path
+
+        result = _collect_git_information_dynamically(verbose=False)
+
+        expected = {
+            "commit_hash": "abc123",
+            "branch": None,
+            "repo_url": "https://github.com/user/repo.git",
+            "uncommitted_changes": False,
+            "relative_path": None,
+            "commit_link": "https://github.com/user/repo.git/commit/abc123",
+        }
+        assert result == expected
+
+    @patch("os.getcwd")
+    @patch("honeyhive.tracer.utils.git._get_git_commit_hash_dynamically")
+    def test_collect_git_information_exception_handling(
+        self, mock_commit: Any, mock_getcwd: Any
+    ) -> None:
+        """Test git information collection with exception in collector."""
+        mock_getcwd.return_value = "/repo"
+        mock_commit.side_effect = Exception("Git command failed")
+
+        # Should not raise exception, just skip the failed collector
+        result = _collect_git_information_dynamically(verbose=True)
+
+        # Should return empty dict or dict without commit_hash
+        assert isinstance(result, dict)
+        # The function sets keys to None when there's an exception
+        assert result["commit_hash"] is None
+
+
+class TestGetGitCommitHashDynamically:
+    """Test git commit hash retrieval functionality."""
+
+    @patch("subprocess.run")
+    def test_get_git_commit_hash_success(self, mock_run: Any) -> None:
+        """Test successful git commit hash retrieval."""
+        mock_result = Mock()
+        mock_result.stdout = "abc123def456\n"
+        mock_result.returncode = 0
+        mock_run.return_value = mock_result
+
+        result = _get_git_commit_hash_dynamically("/repo")
+
+        assert result == "abc123def456"
+        mock_run.assert_called_once_with(
+            ["git", "rev-parse", "HEAD"],
+            cwd="/repo",
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    @patch("subprocess.run")
+    def test_get_git_commit_hash_failure(self, mock_run: Any) -> None:
+        """Test git commit hash retrieval failure."""
+        mock_run.side_effect = subprocess.CalledProcessError(1, "git")
+
+        # The function doesn't catch exceptions, so it will raise
+        with pytest.raises(subprocess.CalledProcessError):
+            _get_git_commit_hash_dynamically("/repo")
+
+    @patch("subprocess.run")
+    def test_get_git_commit_hash_exception(self, mock_run: Any) -> None:
+        """Test git commit hash retrieval with exception."""
+        mock_run.side_effect = Exception("Command failed")
+
+        # The function doesn't catch exceptions, so it will raise
+        with pytest.raises(Exception):
+            _get_git_commit_hash_dynamically("/repo")
+
+
+class TestGetGitBranchDynamically:
+    """Test git branch retrieval functionality."""
+
+    @patch("subprocess.run")
+    def test_get_git_branch_success(self, mock_run: Any) -> None:
+        """Test successful git branch retrieval."""
+        mock_result = Mock()
+        mock_result.stdout = "main\n"
+        mock_result.returncode = 0
+        mock_run.return_value = mock_result
+
+        result = _get_git_branch_dynamically("/repo")
+
+        assert result == "main"
+        mock_run.assert_called_once_with(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd="/repo",
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    @patch("subprocess.run")
+    def test_get_git_branch_failure(self, mock_run: Any) -> None:
+        """Test git branch retrieval failure."""
+        mock_run.side_effect = subprocess.CalledProcessError(1, "git")
+
+        # The function doesn't catch exceptions, so it will raise
+        with pytest.raises(subprocess.CalledProcessError):
+            _get_git_branch_dynamically("/repo")
+
+    @patch("subprocess.run")
+    def test_get_git_branch_exception(self, mock_run: Any) -> None:
+        """Test git branch retrieval with exception."""
+        mock_run.side_effect = Exception("Command failed")
+
+        # The function doesn't catch exceptions, so it will raise
+        with pytest.raises(Exception):
+            _get_git_branch_dynamically("/repo")
+
+
+class TestGetGitRepoUrlDynamically:
+    """Test git repository URL retrieval functionality."""
+
+    @patch("subprocess.run")
+    def test_get_git_repo_url_success(self, mock_run: Any) -> None:
+        """Test successful git repository URL retrieval."""
+        mock_result = Mock()
+        mock_result.stdout = "https://github.com/user/repo.git\n"
+        mock_result.returncode = 0
+        mock_run.return_value = mock_result
+
+        result = _get_git_repo_url_dynamically("/repo")
+
+        # The function strips .git suffix
+        assert result == "https://github.com/user/repo"
+        mock_run.assert_called_once_with(
+            ["git", "config", "--get", "remote.origin.url"],
+            cwd="/repo",
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    @patch("subprocess.run")
+    def test_get_git_repo_url_failure(self, mock_run: Any) -> None:
+        """Test git repository URL retrieval failure."""
+        mock_run.side_effect = subprocess.CalledProcessError(1, "git")
+
+        # The function doesn't handle exceptions - it lets them propagate
+        with pytest.raises(subprocess.CalledProcessError):
+            _get_git_repo_url_dynamically("/repo")
+
+    @patch("subprocess.run")
+    def test_get_git_repo_url_exception(self, mock_run: Any) -> None:
+        """Test git repository URL retrieval with exception."""
+        mock_run.side_effect = Exception("Command failed")
+
+        # The function doesn't handle exceptions - it lets them propagate
+        with pytest.raises(Exception):
+            _get_git_repo_url_dynamically("/repo")
+
+
+class TestGenerateCommitLinkDynamically:
+    """Test commit link generation functionality."""
+
+    def test_generate_commit_link_github(self) -> None:
+        """Test commit link generation for GitHub repository."""
+        repo_url = "https://github.com/user/repo.git"
+        commit_hash = "abc123def456"
+
+        result = _generate_commit_link_dynamically(repo_url, commit_hash)
+
+        expected = "https://github.com/user/repo.git/commit/abc123def456"
+        assert result == expected
+
+    def test_generate_commit_link_github_no_git_suffix(self) -> None:
+        """Test commit link generation for GitHub repository without .git suffix."""
+        repo_url = "https://github.com/user/repo"
+        commit_hash = "abc123def456"
+
+        result = _generate_commit_link_dynamically(repo_url, commit_hash)
+
+        expected = "https://github.com/user/repo/commit/abc123def456"
+        assert result == expected
+
+    def test_generate_commit_link_gitlab(self) -> None:
+        """Test commit link generation for GitLab repository."""
+        repo_url = "https://gitlab.com/user/repo.git"
+        commit_hash = "abc123def456"
+
+        result = _generate_commit_link_dynamically(repo_url, commit_hash)
+
+        expected = "https://gitlab.com/user/repo.git/-/commit/abc123def456"
+        assert result == expected
+
+    def test_generate_commit_link_bitbucket(self) -> None:
+        """Test commit link generation for Bitbucket repository."""
+        repo_url = "https://bitbucket.org/user/repo.git"
+        commit_hash = "abc123def456"
+
+        result = _generate_commit_link_dynamically(repo_url, commit_hash)
+
+        expected = "https://bitbucket.org/user/repo.git/commits/abc123def456"
+        assert result == expected
+
+    def test_generate_commit_link_unknown_provider(self) -> None:
+        """Test commit link generation for unknown git provider."""
+        repo_url = "https://custom-git.com/user/repo.git"
+        commit_hash = "abc123def456"
+
+        result = _generate_commit_link_dynamically(repo_url, commit_hash)
+
+        # Should return the original repo URL for unknown providers
+        expected = "https://custom-git.com/user/repo.git"
+        assert result == expected
+
+
+class TestHasUncommittedChangesDynamically:
+    """Test uncommitted changes detection functionality."""
+
+    @patch("subprocess.run")
+    def test_has_uncommitted_changes_true(self, mock_run: Any) -> None:
+        """Test uncommitted changes detection when changes exist."""
+        mock_result = Mock()
+        mock_result.stdout = " M modified_file.py\n?? new_file.py\n"
+        mock_result.returncode = 0
+        mock_run.return_value = mock_result
+
+        result = _has_uncommitted_changes_dynamically("/repo")
+
+        assert result is True
+        mock_run.assert_called_once_with(
+            ["git", "status", "--porcelain"],
+            cwd="/repo",
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    @patch("subprocess.run")
+    def test_has_uncommitted_changes_false(self, mock_run: Any) -> None:
+        """Test uncommitted changes detection when no changes exist."""
+        mock_result = Mock()
+        mock_result.stdout = ""
+        mock_result.returncode = 0
+        mock_run.return_value = mock_result
+
+        result = _has_uncommitted_changes_dynamically("/repo")
+
+        assert result is False
+
+    @patch("subprocess.run")
+    def test_has_uncommitted_changes_failure(self, mock_run: Any) -> None:
+        """Test uncommitted changes detection failure."""
+        mock_run.side_effect = subprocess.CalledProcessError(1, "git")
+
+        # The function doesn't handle exceptions - it lets them propagate
+        with pytest.raises(subprocess.CalledProcessError):
+            _has_uncommitted_changes_dynamically("/repo")
+
+    @patch("subprocess.run")
+    def test_has_uncommitted_changes_exception(self, mock_run: Any) -> None:
+        """Test uncommitted changes detection with exception."""
+        mock_run.side_effect = Exception("Command failed")
+
+        # The function doesn't handle exceptions - it lets them propagate
+        with pytest.raises(Exception):
+            _has_uncommitted_changes_dynamically("/repo")
+
+
+class TestGetMainModuleRelativePathDynamically:
+    """Test main module relative path retrieval functionality."""
+
+    @patch("honeyhive.tracer.utils.git._get_repository_root_dynamically")
+    @patch("honeyhive.tracer.utils.git._get_main_module_path_dynamically")
+    def test_get_main_module_relative_path_success(
+        self, mock_main_path: Any, mock_repo_root: Any
+    ) -> None:
+        """Test successful main module relative path retrieval."""
+        mock_repo_root.return_value = "/repo"
+        mock_main_path.return_value = "/repo/src/main.py"
+
+        result = _get_main_module_relative_path_dynamically("/repo")
+
+        assert result == "src/main.py"
+
+    @patch("honeyhive.tracer.utils.git._get_repository_root_dynamically")
+    @patch("honeyhive.tracer.utils.git._get_main_module_path_dynamically")
+    def test_get_main_module_relative_path_no_repo_root(
+        self, mock_main_path: Any, mock_repo_root: Any
+    ) -> None:
+        """Test main module relative path retrieval when repo root not found."""
+        mock_repo_root.return_value = None
+        mock_main_path.return_value = "/repo/src/main.py"
+
+        result = _get_main_module_relative_path_dynamically("/repo")
+
+        assert result is None
+
+    @patch("honeyhive.tracer.utils.git._get_repository_root_dynamically")
+    @patch("honeyhive.tracer.utils.git._get_main_module_path_dynamically")
+    def test_get_main_module_relative_path_no_main_path(
+        self, mock_main_path: Any, mock_repo_root: Any
+    ) -> None:
+        """Test main module relative path retrieval when main path not found."""
+        mock_repo_root.return_value = "/repo"
+        mock_main_path.return_value = None
+
+        result = _get_main_module_relative_path_dynamically("/repo")
+
+        assert result is None
+
+    @patch("honeyhive.tracer.utils.git._get_repository_root_dynamically")
+    @patch("honeyhive.tracer.utils.git._get_main_module_path_dynamically")
+    def test_get_main_module_relative_path_not_in_repo(
+        self, mock_main_path: Any, mock_repo_root: Any
+    ) -> None:
+        """Test main module relative path retrieval when main path not in repo."""
+        mock_repo_root.return_value = "/repo"
+        mock_main_path.return_value = "/other/path/main.py"
+
+        result = _get_main_module_relative_path_dynamically("/repo")
+
+        # The function returns the relative path even if it's outside the repo
+        assert result == "../other/path/main.py"
+
+    @patch("honeyhive.tracer.utils.git._get_repository_root_dynamically")
+    @patch("honeyhive.tracer.utils.git._get_main_module_path_dynamically")
+    def test_get_main_module_relative_path_exception(
+        self, mock_main_path: Any, mock_repo_root: Any
+    ) -> None:
+        """Test main module relative path retrieval with exception."""
+        mock_repo_root.return_value = "/repo"
+        mock_main_path.side_effect = Exception("Path error")
+
+        result = _get_main_module_relative_path_dynamically("/repo")
+
+        assert result is None
+
+
+class TestGetRepositoryRootDynamically:
+    """Test repository root retrieval functionality."""
+
+    @patch("subprocess.run")
+    def test_get_repository_root_success(self, mock_run: Any) -> None:
+        """Test successful repository root retrieval."""
+        mock_result = Mock()
+        mock_result.stdout = "/path/to/repo\n"
+        mock_result.returncode = 0
+        mock_run.return_value = mock_result
+
+        result = _get_repository_root_dynamically("/repo")
+
+        assert result == "/path/to/repo"
+        mock_run.assert_called_once_with(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd="/repo",
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    @patch("subprocess.run")
+    def test_get_repository_root_failure(self, mock_run: Any) -> None:
+        """Test repository root retrieval failure."""
+        mock_run.side_effect = subprocess.CalledProcessError(1, "git")
+
+        result = _get_repository_root_dynamically("/repo")
+
+        assert result is None
+
+    @patch("subprocess.run")
+    def test_get_repository_root_exception(self, mock_run: Any) -> None:
+        """Test repository root retrieval with exception."""
+        mock_run.side_effect = Exception("Command failed")
+
+        result = _get_repository_root_dynamically("/repo")
+
+        assert result is None
+
+
+class TestGetMainModulePathDynamically:
+    """Test main module path retrieval functionality."""
+
+    def test_get_main_module_path_with_main_module(self) -> None:
+        """Test main module path retrieval when __main__ module exists."""
+        mock_main_module = Mock()
+        mock_main_module.__file__ = "/path/to/main.py"
+
+        with patch.dict("sys.modules", {"__main__": mock_main_module}):
+            result = _get_main_module_path_dynamically()
+
+        assert result == "/path/to/main.py"
+
+    def test_get_main_module_path_no_main_module(self) -> None:
+        """Test main module path retrieval when __main__ module doesn't exist."""
+        with patch.dict("sys.modules", {}, clear=True):
+            result = _get_main_module_path_dynamically()
+
+        assert result is None
+
+    def test_get_main_module_path_no_file_attribute(self) -> None:
+        """Test main module path retrieval when __main__ module has no __file__."""
+        mock_main_module = Mock()
+        del mock_main_module.__file__  # Remove __file__ attribute
+
+        with patch.dict("sys.modules", {"__main__": mock_main_module}):
+            result = _get_main_module_path_dynamically()
+
+        assert result is None
+
+    def test_get_main_module_path_none_file_attribute(self) -> None:
+        """Test main module path retrieval when __main__ module __file__ is None."""
+        mock_main_module = Mock()
+        mock_main_module.__file__ = None
+
+        with patch.dict("sys.modules", {"__main__": mock_main_module}):
+            result = _get_main_module_path_dynamically()
+
+        assert result is None
+
+
+class TestLogGitCollectionSuccessDynamically:
+    """Test git collection success logging functionality."""
+
+    @patch("honeyhive.tracer.utils.git.safe_log")
+    def test_log_git_collection_success_with_data(self, mock_log: Any) -> None:
+        """Test git collection success logging with data."""
+        git_info = {
+            "commit_hash": "abc123",
+            "branch": "main",
+            "repo_url": "https://github.com/user/repo.git",
+            "uncommitted_changes": True,
+        }
+
+        _log_git_collection_success_dynamically(git_info)
+
+        mock_log.assert_called_once_with(
+            None,
+            "debug",
+            "Git information collected successfully",
+            honeyhive_data={
+                "commit_hash": "abc123",  # Short hash (first 8 chars)
+                "branch": "main",
+                "has_changes": True,  # Renamed from uncommitted_changes
+            },
+        )
+
+    @patch("honeyhive.tracer.utils.git.safe_log")
+    def test_log_git_collection_success_empty_data(self, mock_log: Any) -> None:
+        """Test git collection success logging with empty data."""
+        git_info: dict[str, Any] = {}
+
+        _log_git_collection_success_dynamically(git_info)
+
+        mock_log.assert_called_once_with(
+            None,
+            "debug",
+            "Git information collected successfully",
+            honeyhive_data={},  # Empty dict when no git info available
+        )
+
+
+class TestHandleGitCommandErrorDynamically:
+    """Test git command error handling functionality."""
+
+    def test_handle_git_command_error_verbose(self) -> None:
+        """Test git command error handling with verbose logging."""
+        error = subprocess.CalledProcessError(1, ["git", "rev-parse", "HEAD"])
+        error.stderr = "fatal: not a git repository"
+
+        result = _handle_git_command_error_dynamically(error, verbose=True)
+
+        expected = {"error": "Failed to retrieve Git info. Is this a valid repo?"}
+        assert result == expected
+
+    def test_handle_git_command_error_not_verbose(self) -> None:
+        """Test git command error handling without verbose logging."""
+        error = subprocess.CalledProcessError(1, ["git", "rev-parse", "HEAD"])
+        error.stderr = "fatal: not a git repository"
+
+        result = _handle_git_command_error_dynamically(error, verbose=False)
+
+        expected = {"error": "Failed to retrieve Git info. Is this a valid repo?"}
+        assert result == expected
+
+    def test_handle_git_command_error_no_stderr(self) -> None:
+        """Test git command error handling when stderr is None."""
+        error = subprocess.CalledProcessError(1, ["git", "rev-parse", "HEAD"])
+        error.stderr = None
+
+        result = _handle_git_command_error_dynamically(error, verbose=True)
+
+        expected = {"error": "Failed to retrieve Git info. Is this a valid repo?"}
+        assert result == expected
+
+
+class TestHandleGitNotFoundErrorDynamically:
+    """Test git not found error handling functionality."""
+
+    def test_handle_git_not_found_error_verbose(self) -> None:
+        """Test git not found error handling with verbose logging."""
+        result = _handle_git_not_found_error_dynamically(verbose=True)
+
+        expected = {"error": "Git is not installed or not in PATH."}
+        assert result == expected
+
+    def test_handle_git_not_found_error_not_verbose(self) -> None:
+        """Test git not found error handling without verbose logging."""
+        result = _handle_git_not_found_error_dynamically(verbose=False)
+
+        expected = {"error": "Git is not installed or not in PATH."}
+        assert result == expected
+
+
+class TestHandleUnexpectedGitErrorDynamically:
+    """Test unexpected git error handling functionality."""
+
+    def test_handle_unexpected_git_error_verbose(self) -> None:
+        """Test unexpected git error handling with verbose logging."""
+        error = ValueError("Unexpected error message")
+
+        result = _handle_unexpected_git_error_dynamically(error, verbose=True)
+
+        expected = {"error": "Error getting git info: Unexpected error message"}
+        assert result == expected
+
+    def test_handle_unexpected_git_error_not_verbose(self) -> None:
+        """Test unexpected git error handling without verbose logging."""
+        error = ValueError("Unexpected error message")
+
+        result = _handle_unexpected_git_error_dynamically(error, verbose=False)
+
+        expected = {"error": "Error getting git info: Unexpected error message"}
+        assert result == expected
+
+    def test_handle_unexpected_git_error_no_message(self) -> None:
+        """Test unexpected git error handling when exception has no message."""
+        error = ValueError()
+
+        result = _handle_unexpected_git_error_dynamically(error, verbose=True)
+
+        expected = {"error": "Error getting git info: "}
+        assert result == expected

--- a/tests_v2/unit/test_tracer_utils_propagation.py
+++ b/tests_v2/unit/test_tracer_utils_propagation.py
@@ -1,0 +1,613 @@
+"""Unit tests for HoneyHive tracer utils propagation functionality.
+
+This module tests the context propagation utilities including carrier sanitization,
+header extraction, and dynamic key matching using standard fixtures and comprehensive
+edge case coverage following Agent OS testing standards.
+"""
+
+from typing import Any, Dict
+from unittest.mock import Mock, patch
+
+import pytest
+
+from honeyhive.tracer.utils.propagation import (
+    _case_insensitive_lookup_dynamically,
+    _create_default_getter_dynamically,
+    _extract_header_value_dynamically,
+    _fuzzy_key_lookup_dynamically,
+    _generate_key_variations_dynamically,
+    _get_carrier_value_dynamically,
+    _get_custom_propagation_headers_dynamically,
+    _get_propagation_headers_dynamically,
+    _log_sanitization_results_dynamically,
+    _sanitize_carrier_headers_dynamically,
+    sanitize_carrier,
+)
+
+
+class TestSanitizeCarrier:
+    """Test main carrier sanitization functionality."""
+
+    def test_sanitize_carrier_with_valid_headers(self, honeyhive_tracer: Any) -> None:
+        """Test carrier sanitization with valid OpenTelemetry headers."""
+        carrier = {
+            "baggage": "session_id=test123,user_id=456",
+            "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+            "tracestate": "rojo=00f067aa0ba902b7,congo=t61rcWkgMzE",
+            "custom-header": "should-be-ignored",
+        }
+
+        result = sanitize_carrier(carrier, tracer_instance=honeyhive_tracer)
+
+        assert isinstance(result, dict)
+        assert "baggage" in result
+        assert "traceparent" in result
+        assert "tracestate" in result
+        assert "custom-header" not in result
+        assert result["baggage"] == "session_id=test123,user_id=456"
+
+    def test_sanitize_carrier_with_empty_carrier(self, honeyhive_tracer: Any) -> None:
+        """Test carrier sanitization with empty carrier."""
+        carrier: Dict[str, Any] = {}
+
+        result = sanitize_carrier(carrier, tracer_instance=honeyhive_tracer)
+
+        assert isinstance(result, dict)
+        assert len(result) == 0
+
+    def test_sanitize_carrier_with_none_carrier(self, honeyhive_tracer: Any) -> None:
+        """Test carrier sanitization with None carrier."""
+        with patch("honeyhive.tracer.utils.propagation.safe_log") as mock_log:
+            result = sanitize_carrier(
+                None, tracer_instance=honeyhive_tracer  # type: ignore[arg-type]
+            )
+
+        assert not result
+        mock_log.assert_called()
+
+    def test_sanitize_carrier_with_case_insensitive_headers(
+        self, honeyhive_tracer: Any
+    ) -> None:
+        """Test carrier sanitization with case-insensitive header matching."""
+        carrier = {
+            "BAGGAGE": "session_id=test123",
+            "TraceParent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+            "TRACESTATE": "rojo=00f067aa0ba902b7",
+        }
+
+        result = sanitize_carrier(carrier, tracer_instance=honeyhive_tracer)
+
+        assert len(result) == 3
+        assert "baggage" in result or "BAGGAGE" in result
+        assert "traceparent" in result or "TraceParent" in result
+        assert "tracestate" in result or "TRACESTATE" in result
+
+    def test_sanitize_carrier_with_custom_getter(self, honeyhive_tracer: Any) -> None:
+        """Test carrier sanitization with custom getter."""
+        carrier = {"baggage": "test=value"}
+
+        # Create a mock getter
+        mock_getter = Mock()
+        mock_getter.get.return_value = "test=value"
+
+        result = sanitize_carrier(
+            carrier, getter=mock_getter, tracer_instance=honeyhive_tracer
+        )
+
+        assert isinstance(result, dict)
+        mock_getter.get.assert_called()
+
+    @patch("honeyhive.tracer.utils.propagation.safe_log")
+    def test_sanitize_carrier_exception_handling(
+        self, mock_log: Any, honeyhive_tracer: Any
+    ) -> None:
+        """Test carrier sanitization exception handling."""
+        # Create a carrier that will cause an exception in processing
+        carrier = {"baggage": "test=value"}
+
+        with patch(
+            "honeyhive.tracer.utils.propagation._sanitize_carrier_headers_dynamically",
+            side_effect=Exception("Test error"),
+        ):
+            result = sanitize_carrier(carrier, tracer_instance=honeyhive_tracer)
+
+        assert not result
+        mock_log.assert_called_with(
+            honeyhive_tracer,
+            "warning",
+            "Failed to sanitize carrier",
+            honeyhive_data={
+                "error": "Test error",
+                "carrier_keys": ["baggage"],
+            },
+        )
+
+
+class TestCreateDefaultGetterDynamically:
+    """Test default getter creation functionality."""
+
+    def test_create_default_getter_returns_getter_instance(self) -> None:
+        """Test that default getter creation returns a valid getter."""
+        getter = _create_default_getter_dynamically()
+
+        assert hasattr(getter, "get")
+        assert hasattr(getter, "keys")
+        assert callable(getter.get)
+        assert callable(getter.keys)
+
+    def test_default_getter_get_method(self) -> None:
+        """Test default getter get method functionality."""
+        getter = _create_default_getter_dynamically()
+        carrier = {"test-key": "test-value", "UPPER": "upper-value"}
+
+        # Test exact match
+        result = getter.get(carrier, "test-key")
+        assert result == "test-value"
+
+        # Test case-insensitive match
+        result = getter.get(carrier, "upper")
+        assert result == "upper-value"
+
+    def test_default_getter_keys_method(self) -> None:
+        """Test default getter keys method functionality."""
+        getter = _create_default_getter_dynamically()
+        carrier = {"key1": "value1", "key2": "value2"}
+
+        result = getter.keys(carrier)
+
+        assert isinstance(result, list)
+        assert set(result) == {"key1", "key2"}
+
+    def test_default_getter_keys_with_empty_carrier(self) -> None:
+        """Test default getter keys method with empty carrier."""
+        getter = _create_default_getter_dynamically()
+
+        result = getter.keys({})
+        assert not result
+
+        result = getter.keys(None)
+        assert not result
+
+
+class TestGetCarrierValueDynamically:
+    """Test dynamic carrier value retrieval functionality."""
+
+    def test_get_carrier_value_exact_match(self) -> None:
+        """Test carrier value retrieval with exact key match."""
+        carrier = {"baggage": "session_id=123", "traceparent": "trace-value"}
+
+        result = _get_carrier_value_dynamically(carrier, "baggage")
+
+        assert result == "session_id=123"
+
+    def test_get_carrier_value_case_insensitive(self) -> None:
+        """Test carrier value retrieval with case-insensitive matching."""
+        carrier = {"BAGGAGE": "session_id=123", "TraceParent": "trace-value"}
+
+        result = _get_carrier_value_dynamically(carrier, "baggage")
+        assert result == "session_id=123"
+
+        result = _get_carrier_value_dynamically(carrier, "traceparent")
+        assert result == "trace-value"
+
+    def test_get_carrier_value_fuzzy_matching(self) -> None:
+        """Test carrier value retrieval with fuzzy key matching."""
+        carrier = {"trace_parent": "trace-value", "trace-state": "state-value"}
+
+        # Should find trace_parent when looking for traceparent (underscore to hyphen)
+        result = _get_carrier_value_dynamically(carrier, "trace-parent")
+        assert result == "trace-value"
+
+        # Should find trace-state when looking for tracestate (hyphen to underscore)
+        result = _get_carrier_value_dynamically(carrier, "trace_state")
+        assert result == "state-value"
+
+    def test_get_carrier_value_with_empty_inputs(self) -> None:
+        """Test carrier value retrieval with empty inputs."""
+        result = _get_carrier_value_dynamically({}, "key")
+        assert result is None
+
+        result = _get_carrier_value_dynamically(None, "key")  # type: ignore
+        assert result is None
+
+        result = _get_carrier_value_dynamically({"key": "value"}, "")
+        assert result is None
+
+        result = _get_carrier_value_dynamically({"key": "value"}, None)  # type: ignore
+        assert result is None
+
+    def test_get_carrier_value_key_not_found(self) -> None:
+        """Test carrier value retrieval when key is not found."""
+        carrier = {"existing-key": "value"}
+
+        result = _get_carrier_value_dynamically(carrier, "non-existent-key")
+
+        assert result is None
+
+    def test_get_carrier_value_exception_handling(self) -> None:
+        """Test carrier value retrieval with exception in strategies."""
+        carrier = {"key": "value"}
+
+        # Mock one strategy to raise an exception
+        with patch(
+            "honeyhive.tracer.utils.propagation._case_insensitive_lookup_dynamically",
+            side_effect=Exception("Test error"),
+        ):
+            # Should still work with other strategies
+            result = _get_carrier_value_dynamically(carrier, "key")
+            assert result == "value"
+
+
+class TestCaseInsensitiveLookupDynamically:
+    """Test case-insensitive lookup functionality."""
+
+    def test_case_insensitive_lookup_exact_match(self) -> None:
+        """Test case-insensitive lookup with exact match."""
+        carrier = {"baggage": "value", "traceparent": "trace"}
+
+        result = _case_insensitive_lookup_dynamically(carrier, "baggage")
+
+        assert result == "value"
+
+    def test_case_insensitive_lookup_different_cases(self) -> None:
+        """Test case-insensitive lookup with different cases."""
+        carrier = {"BAGGAGE": "upper-value", "TraceParent": "mixed-case"}
+
+        result = _case_insensitive_lookup_dynamically(carrier, "baggage")
+        assert result == "upper-value"
+
+        result = _case_insensitive_lookup_dynamically(carrier, "TRACEPARENT")
+        assert result == "mixed-case"
+
+        result = _case_insensitive_lookup_dynamically(carrier, "traceparent")
+        assert result == "mixed-case"
+
+    def test_case_insensitive_lookup_not_found(self) -> None:
+        """Test case-insensitive lookup when key is not found."""
+        carrier = {"existing": "value"}
+
+        result = _case_insensitive_lookup_dynamically(carrier, "non-existent")
+
+        assert result is None
+
+    def test_case_insensitive_lookup_empty_carrier(self) -> None:
+        """Test case-insensitive lookup with empty carrier."""
+        result = _case_insensitive_lookup_dynamically({}, "key")
+
+        assert result is None
+
+
+class TestFuzzyKeyLookupDynamically:
+    """Test fuzzy key lookup functionality."""
+
+    def test_fuzzy_key_lookup_hyphen_underscore(self) -> None:
+        """Test fuzzy lookup with hyphen/underscore variations."""
+        carrier = {"trace-parent": "hyphen-value", "trace_state": "underscore-value"}
+
+        result = _fuzzy_key_lookup_dynamically(carrier, "trace_parent")
+        assert result == "hyphen-value"
+
+        result = _fuzzy_key_lookup_dynamically(carrier, "trace-state")
+        assert result == "underscore-value"
+
+    def test_fuzzy_key_lookup_case_variations(self) -> None:
+        """Test fuzzy lookup with case variations."""
+        carrier = {"BAGGAGE": "upper", "Traceparent": "title", "tracestate": "lower"}
+
+        result = _fuzzy_key_lookup_dynamically(carrier, "baggage")
+        assert result == "upper"
+
+        result = _fuzzy_key_lookup_dynamically(carrier, "traceparent")
+        assert result == "title"
+
+    def test_fuzzy_key_lookup_not_found(self) -> None:
+        """Test fuzzy lookup when no variations match."""
+        carrier = {"existing": "value"}
+
+        result = _fuzzy_key_lookup_dynamically(carrier, "completely-different")
+
+        assert result is None
+
+    def test_fuzzy_key_lookup_empty_carrier(self) -> None:
+        """Test fuzzy lookup with empty carrier."""
+        result = _fuzzy_key_lookup_dynamically({}, "key")
+
+        assert result is None
+
+
+class TestGenerateKeyVariationsDynamically:
+    """Test key variation generation functionality."""
+
+    def test_generate_key_variations_basic(self) -> None:
+        """Test key variation generation with basic input."""
+        variations = _generate_key_variations_dynamically("traceparent")
+
+        # Check that all expected variations are present
+        # (order may vary due to deduplication)
+        assert "traceparent" in variations  # Original/lowercase
+        assert "TRACEPARENT" in variations  # Uppercase
+        assert "Traceparent" in variations  # Title case
+        # For "traceparent" (no underscore), underscore to hyphen creates "trace-parent"
+        # But hyphen to underscore doesn't change it, so no "trace-parent" expected
+
+        # The actual variations for "traceparent" should be:
+        # ["traceparent", "TRACEPARENT", "Traceparent"] (duplicates removed)
+        assert len(variations) == 3
+
+    def test_generate_key_variations_with_hyphens(self) -> None:
+        """Test key variation generation with hyphenated input."""
+        variations = _generate_key_variations_dynamically("trace-parent")
+
+        assert "trace-parent" in variations
+        assert "TRACE-PARENT" in variations
+        assert "Trace-Parent" in variations
+        assert "trace_parent" in variations
+
+    def test_generate_key_variations_with_underscores(self) -> None:
+        """Test key variation generation with underscored input."""
+        variations = _generate_key_variations_dynamically("trace_state")
+
+        assert "trace_state" in variations
+        assert "TRACE_STATE" in variations
+        assert "Trace_State" in variations
+        assert "trace-state" in variations
+
+    def test_generate_key_variations_empty_string(self) -> None:
+        """Test key variation generation with empty string."""
+        variations = _generate_key_variations_dynamically("")
+
+        assert not variations
+
+    def test_generate_key_variations_deduplication(self) -> None:
+        """Test that key variations are deduplicated."""
+        variations = _generate_key_variations_dynamically("test")
+
+        # "test" and "test".lower() are the same, should only appear once
+        assert variations.count("test") == 1
+
+
+class TestSanitizeCarrierHeadersDynamically:
+    """Test carrier header sanitization functionality."""
+
+    def test_sanitize_carrier_headers_with_standard_headers(self) -> None:
+        """Test header sanitization with standard OpenTelemetry headers."""
+        carrier = {
+            "baggage": "session_id=123",
+            "traceparent": "00-trace-span-01",
+            "tracestate": "vendor=state",
+            "custom": "ignored",
+        }
+
+        mock_getter = Mock()
+        mock_getter.get.side_effect = lambda c, k: c.get(k.lower())
+
+        with patch("honeyhive.tracer.utils.propagation.safe_log"):
+            result = _sanitize_carrier_headers_dynamically(carrier, mock_getter)
+
+        assert "baggage" in result
+        assert "traceparent" in result
+        assert "tracestate" in result
+        assert "custom" not in result
+
+    def test_sanitize_carrier_headers_empty_carrier(self) -> None:
+        """Test header sanitization with empty carrier."""
+        mock_getter = Mock()
+        mock_getter.get.return_value = None
+
+        result = _sanitize_carrier_headers_dynamically({}, mock_getter)
+
+        assert not result
+
+    @patch("honeyhive.tracer.utils.propagation.safe_log")
+    def test_sanitize_carrier_headers_logs_found_headers(self, mock_log: Any) -> None:
+        """Test that header sanitization logs found headers."""
+        carrier = {"baggage": "test=value"}
+        mock_getter = Mock()
+        mock_getter.get.side_effect = lambda c, k: c.get(k)
+
+        _sanitize_carrier_headers_dynamically(carrier, mock_getter)
+
+        # Should log debug message for found header
+        mock_log.assert_called()
+        args, _ = mock_log.call_args
+        assert args[1] == "debug"
+        assert args[2] == "Found propagation header"
+
+
+class TestGetPropagationHeadersDynamically:
+    """Test propagation header list generation."""
+
+    def test_get_propagation_headers_includes_standard_headers(self) -> None:
+        """Test that standard OpenTelemetry headers are included."""
+        headers = _get_propagation_headers_dynamically()
+
+        assert "baggage" in headers
+        assert "traceparent" in headers
+        assert "tracestate" in headers
+
+    def test_get_propagation_headers_includes_custom_headers(self) -> None:
+        """Test that custom headers are included when available."""
+        with patch(
+            "honeyhive.tracer.utils.propagation."
+            "_get_custom_propagation_headers_dynamically",
+            return_value=["custom-header"],
+        ):
+            headers = _get_propagation_headers_dynamically()
+
+        assert "baggage" in headers
+        assert "traceparent" in headers
+        assert "tracestate" in headers
+        assert "custom-header" in headers
+
+
+class TestGetCustomPropagationHeadersDynamically:  # pylint: disable=too-few-public-methods
+    """Test custom propagation header retrieval."""
+
+    def test_get_custom_propagation_headers_returns_empty_list(self) -> None:
+        """Test that custom headers returns empty list by default."""
+        headers = _get_custom_propagation_headers_dynamically()
+
+        assert not headers
+        assert isinstance(headers, list)
+
+
+class TestExtractHeaderValueDynamically:
+    """Test header value extraction functionality."""
+
+    def test_extract_header_value_exact_case(self) -> None:
+        """Test header extraction with exact case match."""
+        carrier = {"baggage": "test=value"}
+        mock_getter = Mock()
+        mock_getter.get.side_effect = lambda c, k: c.get(k)
+
+        with patch("honeyhive.tracer.utils.propagation.safe_log"):
+            result = _extract_header_value_dynamically(carrier, "baggage", mock_getter)
+
+        assert result == "test=value"
+
+    def test_extract_header_value_case_variations(self) -> None:
+        """Test header extraction with case variations."""
+        carrier = {"BAGGAGE": "test=value"}
+        mock_getter = Mock()
+        mock_getter.get.side_effect = lambda c, k: c.get(k)
+
+        with patch("honeyhive.tracer.utils.propagation.safe_log"):
+            result = _extract_header_value_dynamically(carrier, "baggage", mock_getter)
+
+        assert result == "test=value"
+
+    def test_extract_header_value_not_found(self) -> None:
+        """Test header extraction when header is not found."""
+        carrier = {"other": "value"}
+        mock_getter = Mock()
+        mock_getter.get.return_value = None
+
+        result = _extract_header_value_dynamically(carrier, "baggage", mock_getter)
+
+        assert result is None
+
+    @patch("honeyhive.tracer.utils.propagation.safe_log")
+    def test_extract_header_value_logs_found_variation(self, mock_log: Any) -> None:
+        """Test that header extraction logs found case variations."""
+        carrier = {"BAGGAGE": "test=value"}
+        mock_getter = Mock()
+        mock_getter.get.side_effect = lambda c, k: c.get(k)
+
+        _extract_header_value_dynamically(carrier, "baggage", mock_getter)
+
+        # Should log debug message for found variation
+        mock_log.assert_called()
+        args, _ = mock_log.call_args
+        assert args[1] == "debug"
+        assert args[2] == "Found header with case variation"
+
+    def test_extract_header_value_exception_handling(self) -> None:
+        """Test header extraction with getter exceptions."""
+        carrier = {"baggage": "test=value"}
+        mock_getter = Mock()
+        mock_getter.get.side_effect = [
+            Exception("First error"),
+            Exception("Second error"),
+            Exception("Third error"),
+            "test=value",
+        ]
+
+        with patch("honeyhive.tracer.utils.propagation.safe_log"):
+            result = _extract_header_value_dynamically(carrier, "baggage", mock_getter)
+
+        assert result == "test=value"
+
+
+class TestLogSanitizationResultsDynamically:
+    """Test sanitization results logging functionality."""
+
+    @patch("honeyhive.tracer.utils.propagation.safe_log")
+    def test_log_sanitization_results_with_data(
+        self, mock_log: Any, honeyhive_tracer: Any
+    ) -> None:
+        """Test sanitization results logging with actual data."""
+        original_carrier = {"BAGGAGE": "test=value", "custom": "ignored"}
+        sanitized_carrier = {"baggage": "test=value"}
+
+        _log_sanitization_results_dynamically(
+            original_carrier, sanitized_carrier, honeyhive_tracer
+        )
+
+        mock_log.assert_called_with(
+            honeyhive_tracer,
+            "debug",
+            "Carrier sanitization completed",
+            honeyhive_data={
+                "original_keys": ["BAGGAGE", "custom"],
+                "sanitized_keys": ["baggage"],
+                "found_baggage": True,
+                "found_traceparent": False,
+                "found_tracestate": False,
+            },
+        )
+
+    @patch("honeyhive.tracer.utils.propagation.safe_log")
+    def test_log_sanitization_results_empty_carriers(
+        self, mock_log: Any, honeyhive_tracer: Any
+    ) -> None:
+        """Test sanitization results logging with empty carriers."""
+        _log_sanitization_results_dynamically({}, {}, honeyhive_tracer)
+
+        mock_log.assert_called_with(
+            honeyhive_tracer,
+            "debug",
+            "Carrier sanitization completed",
+            honeyhive_data={
+                "original_keys": [],
+                "sanitized_keys": [],
+                "found_baggage": False,
+                "found_traceparent": False,
+                "found_tracestate": False,
+            },
+        )
+
+    @patch("honeyhive.tracer.utils.propagation.safe_log")
+    def test_log_sanitization_results_none_carriers(
+        self, mock_log: Any, honeyhive_tracer: Any  # pylint: disable=unused-argument
+    ) -> None:
+        """Test sanitization results logging with None carriers."""
+        # The function handles None carriers by checking "if original_carrier else []"
+        # but the "in" operator on None will raise TypeError,
+        # so this should raise
+        with pytest.raises(TypeError):
+            _log_sanitization_results_dynamically(
+                None, None, honeyhive_tracer  # type: ignore[arg-type]
+            )
+
+    @patch("honeyhive.tracer.utils.propagation.safe_log")
+    def test_log_sanitization_results_all_headers_found(
+        self, mock_log: Any, honeyhive_tracer: Any
+    ) -> None:
+        """Test sanitization results logging when all standard headers are found."""
+        original_carrier = {
+            "BAGGAGE": "test",
+            "TRACEPARENT": "trace",
+            "TRACESTATE": "state",
+        }
+        sanitized_carrier = {
+            "baggage": "test",
+            "traceparent": "trace",
+            "tracestate": "state",
+        }
+
+        _log_sanitization_results_dynamically(
+            original_carrier, sanitized_carrier, honeyhive_tracer
+        )
+
+        mock_log.assert_called_with(
+            honeyhive_tracer,
+            "debug",
+            "Carrier sanitization completed",
+            honeyhive_data={
+                "original_keys": ["BAGGAGE", "TRACEPARENT", "TRACESTATE"],
+                "sanitized_keys": ["baggage", "traceparent", "tracestate"],
+                "found_baggage": True,
+                "found_traceparent": True,
+                "found_tracestate": True,
+            },
+        )

--- a/tests_v2/unit/test_tracer_utils_session.py
+++ b/tests_v2/unit/test_tracer_utils_session.py
@@ -1,0 +1,855 @@
+"""Unit tests for HoneyHive tracer utils session functionality.
+
+This module tests the session ID generation, validation, and filename extraction
+utilities using standard fixtures and comprehensive edge case coverage.
+"""
+
+import uuid
+from unittest.mock import Mock, patch
+
+import pytest
+
+from honeyhive.tracer.utils.session import (
+    _clean_filename_characters_dynamically,
+    _clean_filename_dynamically,
+    _extract_base_filename_dynamically,
+    _generate_uuid_dynamically,
+    _is_valid_session_name_dynamically,
+    _remove_extension_dynamically,
+    _validate_uuid_format_dynamically,
+    _validate_uuid_structure_dynamically,
+    extract_filename_from_path,
+    generate_session_id,
+    validate_session_id,
+)
+
+
+class TestValidateSessionId:
+    """Test session ID validation functionality."""
+
+    def test_validate_session_id_with_valid_uuid(self, honeyhive_tracer) -> None:
+        """Test validation with valid UUID format using standard fixture."""
+        valid_uuid = "550e8400-e29b-41d4-a716-446655440000"
+
+        result = validate_session_id(valid_uuid, honeyhive_tracer)
+
+        assert result is True
+
+    def test_validate_session_id_with_invalid_uuid(self, honeyhive_tracer) -> None:
+        """Test validation with invalid UUID format using standard fixture."""
+        invalid_uuid = "not-a-uuid"
+
+        result = validate_session_id(invalid_uuid, honeyhive_tracer)
+
+        assert result is False
+
+    def test_validate_session_id_with_empty_string(self) -> None:
+        """Test validation with empty string."""
+        result = validate_session_id("")
+
+        assert result is False
+
+    def test_validate_session_id_with_none_type(self) -> None:
+        """Test validation with None value."""
+        result = validate_session_id(None)  # type: ignore
+
+        assert result is False
+
+    def test_validate_session_id_without_tracer_instance(self) -> None:
+        """Test validation without tracer instance."""
+        valid_uuid = str(uuid.uuid4())
+
+        result = validate_session_id(valid_uuid)
+
+        assert result is True
+
+    @patch("honeyhive.tracer.utils.session.safe_log")
+    def test_validate_session_id_logs_validation_failure(
+        self, mock_log: Mock, honeyhive_tracer
+    ) -> None:
+        """Test that validation failures are logged properly."""
+        # Create a mock function with __name__ attribute
+        mock_method = Mock()
+        mock_method.__name__ = "test_validation_method"
+        mock_method.side_effect = ValueError("Test error")
+
+        # Mock the validation methods to raise an exception
+        with patch(
+            "honeyhive.tracer.utils.session._validate_uuid_format_dynamically",
+            mock_method,
+        ):
+            with patch(
+                "honeyhive.tracer.utils.session._validate_uuid_structure_dynamically",
+                mock_method,
+            ):
+                result = validate_session_id("test-uuid", honeyhive_tracer)
+
+        assert result is False
+        mock_log.assert_called()
+
+    def test_validate_session_id_with_malformed_uuids(self) -> None:
+        """Test validation with various malformed UUIDs."""
+        malformed_uuids = [
+            "550e8400-e29b-41d4-a716",  # Too short
+            "550e8400-e29b-41d4-a716-446655440000-extra",  # Too long
+            "550e8400xe29bx41d4xa716x446655440000",  # Wrong separators
+            "ggge8400-e29b-41d4-a716-446655440000",  # Invalid hex
+            "550e8400-e29b-41d4-a716-44665544000",  # Wrong part length
+        ]
+
+        for malformed_uuid in malformed_uuids:
+            result = validate_session_id(malformed_uuid)
+            assert result is False, f"Should reject malformed UUID: {malformed_uuid}"
+
+    def test_validate_session_id_uses_multiple_validation_methods(self) -> None:
+        """Test that validation uses multiple methods as fallbacks."""
+        valid_uuid = str(uuid.uuid4())
+
+        # Mock first method to fail, second should succeed
+        with patch(
+            "honeyhive.tracer.utils.session._validate_uuid_format_dynamically",
+            return_value=False,
+        ):
+            with patch(
+                "honeyhive.tracer.utils.session._validate_uuid_structure_dynamically",
+                return_value=True,
+            ):
+                result = validate_session_id(valid_uuid)
+
+        assert result is True
+
+
+class TestValidateUuidFormatDynamically:
+    """Test UUID format validation helper."""
+
+    def test_validate_uuid_format_with_valid_uuid(self) -> None:
+        """Test format validation with valid UUID."""
+        valid_uuid = str(uuid.uuid4())
+
+        result = _validate_uuid_format_dynamically(valid_uuid)
+
+        assert result is True
+
+    def test_validate_uuid_format_with_invalid_string(self) -> None:
+        """Test format validation with invalid string."""
+        result = _validate_uuid_format_dynamically("invalid")
+
+        assert result is False
+
+    def test_validate_uuid_format_with_none_type(self) -> None:
+        """Test format validation with None."""
+        result = _validate_uuid_format_dynamically(None)  # type: ignore
+
+        assert result is False
+
+    def test_validate_uuid_format_with_number(self) -> None:
+        """Test format validation with number."""
+        # The function catches (ValueError, TypeError) but uuid.UUID()
+        # raises AttributeError for int input, so this should raise
+        with pytest.raises(AttributeError):
+            _validate_uuid_format_dynamically(123)  # type: ignore
+
+    def test_validate_uuid_format_handles_exceptions(self) -> None:
+        """Test that format validation handles UUID exceptions."""
+        # Test with string that causes ValueError in uuid.UUID()
+        result = _validate_uuid_format_dynamically("not-a-uuid-at-all")
+
+        assert result is False
+
+
+class TestValidateUuidStructureDynamically:
+    """Test UUID structure validation helper."""
+
+    def test_validate_uuid_structure_with_valid_uuid(self) -> None:
+        """Test structure validation with valid UUID."""
+        valid_uuid = "550e8400-e29b-41d4-a716-446655440000"
+
+        result = _validate_uuid_structure_dynamically(valid_uuid)
+
+        assert result is True
+
+    def test_validate_uuid_structure_with_wrong_length(self) -> None:
+        """Test structure validation with wrong length."""
+        result = _validate_uuid_structure_dynamically("too-short")
+
+        assert result is False
+
+    def test_validate_uuid_structure_with_wrong_hyphens(self) -> None:
+        """Test structure validation with wrong hyphen positions."""
+        wrong_hyphens = "550e8400xe29bx41d4xa716x446655440000"
+
+        result = _validate_uuid_structure_dynamically(wrong_hyphens)
+
+        assert result is False
+
+    def test_validate_uuid_structure_with_wrong_part_lengths(self) -> None:
+        """Test structure validation with wrong part lengths."""
+        wrong_parts = "550e8400-e29b-41d4-a716-4466554400"  # Last part too short
+
+        result = _validate_uuid_structure_dynamically(wrong_parts)
+
+        assert result is False
+
+    def test_validate_uuid_structure_with_non_hex_characters(self) -> None:
+        """Test structure validation with non-hex characters."""
+        non_hex = "550g8400-e29b-41d4-a716-446655440000"
+
+        result = _validate_uuid_structure_dynamically(non_hex)
+
+        assert result is False
+
+    def test_validate_uuid_structure_with_too_many_parts(self) -> None:
+        """Test structure validation with too many parts."""
+        too_many_parts = "550e8400-e29b-41d4-a716-4466-55440000"
+
+        result = _validate_uuid_structure_dynamically(too_many_parts)
+
+        assert result is False
+
+    def test_validate_uuid_structure_edge_cases(self) -> None:
+        """Test structure validation with edge cases."""
+        edge_cases = [
+            ("", False),  # Empty string
+            ("550e8400-e29b-41d4-a716-446655440000", True),  # Perfect UUID
+            ("550E8400-E29B-41D4-A716-446655440000", True),  # Uppercase hex
+            ("550e8400-e29b-41d4-a716-44665544000g", False),  # Invalid hex at end
+        ]
+
+        for test_uuid, expected in edge_cases:
+            result = _validate_uuid_structure_dynamically(test_uuid)
+            assert result == expected, f"Failed for UUID: {test_uuid}"
+
+
+class TestGenerateSessionId:
+    """Test session ID generation functionality."""
+
+    def test_generate_session_id_returns_valid_uuid(self, honeyhive_tracer) -> None:
+        """Test that generated session ID is a valid UUID using standard fixture."""
+        session_id = generate_session_id(honeyhive_tracer)
+
+        assert session_id is not None
+        assert validate_session_id(session_id)
+        assert len(session_id) == 36
+
+    def test_generate_session_id_returns_lowercase(self) -> None:
+        """Test that generated session ID is lowercase."""
+        session_id = generate_session_id()
+
+        assert session_id == session_id.lower()
+
+    def test_generate_session_id_without_tracer_instance(self) -> None:
+        """Test session ID generation without tracer instance."""
+        session_id = generate_session_id()
+
+        assert session_id is not None
+        assert validate_session_id(session_id)
+
+    @patch("honeyhive.tracer.utils.session.safe_log")
+    def test_generate_session_id_logs_success(
+        self, mock_log: Mock, honeyhive_tracer
+    ) -> None:
+        """Test that successful generation is logged."""
+        generate_session_id(honeyhive_tracer)
+
+        # Should log debug message for successful generation
+        mock_log.assert_called()
+
+    @patch("honeyhive.tracer.utils.session._generate_uuid_dynamically")
+    @patch("honeyhive.tracer.utils.session.safe_log")
+    def test_generate_session_id_handles_generation_failure(
+        self, mock_log: Mock, mock_generate: Mock, honeyhive_tracer
+    ) -> None:
+        """Test handling of UUID generation failures."""
+        mock_generate.side_effect = [
+            RuntimeError("Generation failed"),
+            RuntimeError("Generation failed"),
+            RuntimeError("Generation failed"),
+        ]
+
+        # Should fall back to uuid.uuid4()
+        session_id = generate_session_id(honeyhive_tracer)
+
+        assert session_id is not None
+        assert validate_session_id(session_id)
+        mock_log.assert_called()
+
+    def test_generate_session_id_multiple_calls_unique(self) -> None:
+        """Test that multiple calls generate unique session IDs."""
+        session_ids = [generate_session_id() for _ in range(10)]
+
+        # All should be unique
+        assert len(set(session_ids)) == 10
+
+        # All should be valid
+        for session_id in session_ids:
+            assert validate_session_id(session_id)
+
+    @patch("honeyhive.tracer.utils.session._generate_uuid_dynamically")
+    def test_generate_session_id_retry_logic(
+        self, mock_generate: Mock, honeyhive_tracer
+    ) -> None:
+        """Test retry logic when generation fails initially."""
+        # First two attempts fail, third succeeds
+        mock_generate.side_effect = [
+            RuntimeError("First failure"),
+            RuntimeError("Second failure"),
+            "550e8400-e29b-41d4-a716-446655440000",
+        ]
+
+        session_id = generate_session_id(honeyhive_tracer)
+
+        assert session_id == "550e8400-e29b-41d4-a716-446655440000"
+        assert mock_generate.call_count == 3
+
+
+class TestGenerateUuidDynamically:
+    """Test UUID generation helper."""
+
+    def test_generate_uuid_dynamically_returns_valid_uuid(self) -> None:
+        """Test that UUID generation returns valid UUID."""
+        uuid_str = _generate_uuid_dynamically()
+
+        assert uuid_str is not None
+        assert len(uuid_str) == 36
+        assert validate_session_id(uuid_str)
+
+    def test_generate_uuid_dynamically_returns_lowercase(self) -> None:
+        """Test that generated UUID is lowercase."""
+        uuid_str = _generate_uuid_dynamically()
+
+        assert uuid_str == uuid_str.lower()
+
+    @patch("uuid.uuid4")
+    @patch("uuid.uuid1")
+    def test_generate_uuid_dynamically_fallback_strategy(
+        self, mock_uuid1: Mock, mock_uuid4: Mock
+    ) -> None:
+        """Test fallback strategy when uuid4 fails."""
+        mock_uuid4.side_effect = RuntimeError("UUID4 failed")
+        mock_uuid1.return_value = Mock()
+        mock_uuid1.return_value.__str__ = Mock(
+            return_value="550e8400-e29b-41d4-a716-446655440000"
+        )
+
+        uuid_str = _generate_uuid_dynamically()
+
+        assert uuid_str == "550e8400-e29b-41d4-a716-446655440000"
+        mock_uuid1.assert_called_once()
+
+    @patch("uuid.uuid4")
+    @patch("uuid.uuid1")
+    def test_generate_uuid_dynamically_all_strategies_fail(
+        self, mock_uuid1: Mock, mock_uuid4: Mock
+    ) -> None:
+        """Test behavior when all generation strategies fail."""
+        mock_uuid4.side_effect = RuntimeError("UUID4 failed")
+        mock_uuid1.side_effect = RuntimeError("UUID1 failed")
+
+        with pytest.raises(RuntimeError, match="All UUID generation strategies failed"):
+            _generate_uuid_dynamically()
+
+    @patch("uuid.uuid4")
+    def test_generate_uuid_dynamically_invalid_length_fallback(
+        self, mock_uuid4: Mock
+    ) -> None:
+        """Test fallback when generated UUID has wrong length."""
+        mock_uuid4.return_value = Mock()
+        mock_uuid4.return_value.__str__ = Mock(return_value="short")  # Wrong length
+
+        with patch("uuid.uuid1") as mock_uuid1:
+            mock_uuid1.return_value = Mock()
+            mock_uuid1.return_value.__str__ = Mock(
+                return_value="550e8400-e29b-41d4-a716-446655440000"
+            )
+
+            uuid_str = _generate_uuid_dynamically()
+
+            assert uuid_str == "550e8400-e29b-41d4-a716-446655440000"
+            mock_uuid1.assert_called_once()
+
+
+class TestExtractFilenameFromPath:
+    """Test filename extraction functionality."""
+
+    def test_extract_filename_from_path_unix_style(self, honeyhive_tracer) -> None:
+        """Test filename extraction from Unix-style path using standard fixture."""
+        path = "/path/to/script.py"
+
+        result = extract_filename_from_path(path, honeyhive_tracer)
+
+        assert result == "script"
+
+    def test_extract_filename_from_path_windows_style(self) -> None:
+        """Test filename extraction from Windows-style path."""
+        path = "C:\\Users\\user\\app.py"
+
+        result = extract_filename_from_path(path)
+
+        assert result == "app"
+
+    def test_extract_filename_from_path_no_extension(self) -> None:
+        """Test filename extraction from path without extension."""
+        path = "/path/to/script"
+
+        result = extract_filename_from_path(path)
+
+        assert result == "script"
+
+    def test_extract_filename_from_path_empty_string(self) -> None:
+        """Test filename extraction from empty string."""
+        result = extract_filename_from_path("")
+
+        assert result is None
+
+    def test_extract_filename_from_path_none(self) -> None:
+        """Test filename extraction from None."""
+        result = extract_filename_from_path(None)
+
+        assert result is None
+
+    @patch("honeyhive.tracer.utils.session.safe_log")
+    def test_extract_filename_from_path_logs_failure(
+        self, mock_log: Mock, honeyhive_tracer
+    ) -> None:
+        """Test that extraction failures are logged."""
+        # Mock the extraction to raise an exception
+        with patch(
+            "honeyhive.tracer.utils.session._extract_base_filename_dynamically",
+            side_effect=ValueError("Test error"),
+        ):
+            result = extract_filename_from_path("/test/path.py", honeyhive_tracer)
+
+        assert result is None
+        mock_log.assert_called()
+
+    def test_extract_filename_from_path_complex_paths(self) -> None:
+        """Test filename extraction from complex paths."""
+        test_cases = [
+            ("/very/long/path/to/my_script.py", "my_script"),
+            ("./relative/path/test.py", "test"),
+            ("../parent/dir/app.py", "app"),
+            # Note: "single_file.py" returns None because
+            # _extract_base_filename_dynamically requires the result to be different
+            # from the input (indicating separation occurred)
+            ("/path/with spaces/file name.py", "file_name"),
+            ("/path/with-dashes/file-name.py", "file_name"),
+        ]
+
+        for path, expected in test_cases:
+            result = extract_filename_from_path(path)
+            assert result == expected, f"Failed for path: {path}"
+
+    def test_extract_filename_from_path_invalid_session_names(self) -> None:
+        """Test filename extraction that results in invalid session names."""
+        invalid_paths = [
+            "/path/to/__main__.py",  # Special name - should return None
+            "/path/to/main.py",  # Special name - should return None
+        ]
+
+        for path in invalid_paths:
+            result = extract_filename_from_path(path)
+            # Should return None for invalid session names
+            assert (
+                result is None
+            ), f"Should reject invalid session name from path: {path}"
+
+        # Special case: <stdin> gets cleaned to "stdin" which is valid
+        result = extract_filename_from_path("/path/to/<stdin>.py")
+        assert result == "stdin"  # The angle brackets get removed, making it valid
+
+    def test_extract_filename_from_path_pipeline_failure(self) -> None:
+        """Test behavior when filename extraction pipeline fails."""
+        with patch(
+            "honeyhive.tracer.utils.session._extract_base_filename_dynamically",
+            return_value=None,
+        ):
+            result = extract_filename_from_path("/test/path.py")
+
+            assert result is None
+
+    def test_extract_filename_from_path_cleaning_failure(self) -> None:
+        """Test behavior when filename cleaning fails."""
+        with patch(
+            "honeyhive.tracer.utils.session._clean_filename_dynamically",
+            return_value=None,
+        ):
+            result = extract_filename_from_path("/test/path.py")
+
+            assert result is None
+
+
+class TestExtractBaseFilenameDynamically:
+    """Test base filename extraction helper."""
+
+    def test_extract_base_filename_with_os_path_basename(self) -> None:
+        """Test extraction using os.path.basename."""
+        path = "/path/to/file.py"
+
+        result = _extract_base_filename_dynamically(path)
+
+        assert result == "file.py"
+
+    def test_extract_base_filename_with_empty_path(self) -> None:
+        """Test extraction with empty path."""
+        result = _extract_base_filename_dynamically("")
+
+        assert result is None
+
+    @patch("os.path.basename")
+    def test_extract_base_filename_fallback_methods(self, mock_basename: Mock) -> None:
+        """Test fallback methods when os.path.basename fails."""
+        mock_basename.side_effect = RuntimeError("Basename failed")
+        path = "/path/to/file.py"
+
+        result = _extract_base_filename_dynamically(path)
+
+        assert result == "file.py"
+
+    def test_extract_base_filename_with_different_separators(self) -> None:
+        """Test extraction with different path separators."""
+        test_cases = [
+            ("path/to/file.py", "file.py"),
+            ("path\\to\\file.py", "file.py"),
+            ("path/to\\mixed/file.py", "file.py"),
+        ]
+
+        for path, expected in test_cases:
+            result = _extract_base_filename_dynamically(path)
+            assert result == expected
+
+    def test_extract_base_filename_no_separation(self) -> None:
+        """Test extraction when path has no separators."""
+        path = "file.py"
+
+        result = _extract_base_filename_dynamically(path)
+
+        # Should return None because result == file_path (no separation occurred)
+        assert result is None
+
+    def test_extract_base_filename_all_methods_fail(self) -> None:
+        """Test when all extraction methods fail."""
+        with patch("os.path.basename", side_effect=RuntimeError("Failed")):
+            with patch("os.sep", "/"):  # Ensure os.sep is available
+                # Create a path that will cause all methods to fail
+                result = _extract_base_filename_dynamically("")
+
+                assert result is None
+
+
+class TestCleanFilenameDynamically:
+    """Test filename cleaning functionality."""
+
+    def test_clean_filename_with_extension(self) -> None:
+        """Test cleaning filename with extension."""
+        filename = "test_file.py"
+
+        result = _clean_filename_dynamically(filename)
+
+        assert result == "test_file"
+
+    def test_clean_filename_without_extension(self) -> None:
+        """Test cleaning filename without extension."""
+        filename = "test_file"
+
+        result = _clean_filename_dynamically(filename)
+
+        assert result == "test_file"
+
+    def test_clean_filename_with_special_characters(self) -> None:
+        """Test cleaning filename with special characters."""
+        filename = "test-file name.py"
+
+        result = _clean_filename_dynamically(filename)
+
+        assert result == "test_file_name"
+
+    def test_clean_filename_empty_string(self) -> None:
+        """Test cleaning empty filename."""
+        result = _clean_filename_dynamically("")
+
+        assert result is None
+
+    @patch("honeyhive.tracer.utils.session._remove_extension_dynamically")
+    def test_clean_filename_handles_extension_removal_failure(
+        self, mock_remove: Mock
+    ) -> None:
+        """Test handling of extension removal failure."""
+        mock_remove.return_value = None
+
+        result = _clean_filename_dynamically("test.py")
+
+        assert result is None
+
+    @patch("honeyhive.tracer.utils.session._clean_filename_characters_dynamically")
+    def test_clean_filename_handles_character_cleaning_failure(
+        self, mock_clean: Mock
+    ) -> None:
+        """Test handling of character cleaning failure."""
+        mock_clean.return_value = None
+
+        result = _clean_filename_dynamically("test.py")
+
+        assert result is None
+
+    def test_clean_filename_exception_handling(self) -> None:
+        """Test exception handling in filename cleaning."""
+        with patch(
+            "honeyhive.tracer.utils.session._remove_extension_dynamically",
+            side_effect=RuntimeError("Test error"),
+        ):
+            result = _clean_filename_dynamically("test.py")
+
+            assert result is None
+
+
+class TestRemoveExtensionDynamically:
+    """Test extension removal functionality."""
+
+    def test_remove_extension_with_single_extension(self) -> None:
+        """Test removing single extension."""
+        filename = "test.py"
+
+        result = _remove_extension_dynamically(filename)
+
+        assert result == "test"
+
+    def test_remove_extension_with_multiple_extensions(self) -> None:
+        """Test removing from filename with multiple extensions."""
+        filename = "test.tar.gz"
+
+        result = _remove_extension_dynamically(filename)
+
+        assert result == "test.tar"  # Only removes last extension
+
+    def test_remove_extension_without_extension(self) -> None:
+        """Test removing extension from filename without extension."""
+        filename = "test"
+
+        result = _remove_extension_dynamically(filename)
+
+        assert result == "test"
+
+    def test_remove_extension_empty_filename(self) -> None:
+        """Test removing extension from empty filename."""
+        result = _remove_extension_dynamically("")
+
+        assert result == ""
+
+    @patch("os.path.splitext")
+    def test_remove_extension_fallback_method(self, mock_splitext: Mock) -> None:
+        """Test fallback method when os.path.splitext fails."""
+        mock_splitext.side_effect = RuntimeError("Splitext failed")
+        filename = "test.py"
+
+        result = _remove_extension_dynamically(filename)
+
+        assert result == "test"
+
+    def test_remove_extension_no_change_strategies(self) -> None:
+        """Test when no strategy produces a change."""
+        # Test with filename that has no extension and strategies don't change it
+        filename = "test"
+
+        result = _remove_extension_dynamically(filename)
+
+        assert result == "test"  # Returns original when no extension found
+
+
+class TestCleanFilenameCharactersDynamically:
+    """Test filename character cleaning functionality."""
+
+    def test_clean_filename_characters_basic(self) -> None:
+        """Test basic character cleaning."""
+        filename = "test_file"
+
+        result = _clean_filename_characters_dynamically(filename)
+
+        assert result == "test_file"
+
+    def test_clean_filename_characters_with_replacements(self) -> None:
+        """Test character cleaning with replacements."""
+        filename = "test-file name.script"
+
+        result = _clean_filename_characters_dynamically(filename)
+
+        assert result == "test_file_name_script"
+
+    def test_clean_filename_characters_with_special_chars(self) -> None:
+        """Test character cleaning with special characters."""
+        filename = "test@file#name$"
+
+        result = _clean_filename_characters_dynamically(filename)
+
+        assert result == "testfilename"
+
+    def test_clean_filename_characters_empty_string(self) -> None:
+        """Test character cleaning with empty string."""
+        result = _clean_filename_characters_dynamically("")
+
+        assert result is None
+
+    def test_clean_filename_characters_none(self) -> None:
+        """Test character cleaning with None."""
+        result = _clean_filename_characters_dynamically(None)  # type: ignore
+
+        assert result is None
+
+    def test_clean_filename_characters_only_special_chars(self) -> None:
+        """Test character cleaning with only special characters."""
+        filename = "@#$%^&*()"
+
+        result = _clean_filename_characters_dynamically(filename)
+
+        # When all characters are removed, the function returns None
+        assert result is None
+
+    def test_clean_filename_characters_mixed_content(self) -> None:
+        """Test character cleaning with mixed content."""
+        test_cases = [
+            ("file123", "file123"),  # Alphanumeric only
+            ("file_123", "file_123"),  # With underscores
+            ("file-name", "file_name"),  # Hyphen replacement
+            ("file name", "file_name"),  # Space replacement
+            ("file.name", "file_name"),  # Dot replacement
+            ("FILE", "FILE"),  # Uppercase preserved
+        ]
+
+        for input_name, expected in test_cases:
+            result = _clean_filename_characters_dynamically(input_name)
+            assert result == expected, f"Failed for input: {input_name}"
+
+
+class TestIsValidSessionNameDynamically:
+    """Test session name validation functionality."""
+
+    def test_is_valid_session_name_with_valid_name(self) -> None:
+        """Test validation with valid session name."""
+        name = "test_session"
+
+        result = _is_valid_session_name_dynamically(name)
+
+        assert result is True
+
+    def test_is_valid_session_name_with_empty_string(self) -> None:
+        """Test validation with empty string."""
+        result = _is_valid_session_name_dynamically("")
+
+        assert result is False
+
+    def test_is_valid_session_name_with_none(self) -> None:
+        """Test validation with None."""
+        result = _is_valid_session_name_dynamically(None)
+
+        assert result is False
+
+    def test_is_valid_session_name_starts_with_underscore(self) -> None:
+        """Test validation with name starting with underscore."""
+        name = "_test_session"
+
+        result = _is_valid_session_name_dynamically(name)
+
+        assert result is False
+
+    def test_is_valid_session_name_special_names(self) -> None:
+        """Test validation with special reserved names."""
+        special_names = ["__main__", "<stdin>", "main"]
+
+        for name in special_names:
+            result = _is_valid_session_name_dynamically(name)
+            assert result is False, f"Should reject special name: {name}"
+
+    def test_is_valid_session_name_too_long(self) -> None:
+        """Test validation with name that's too long."""
+        name = "a" * 101  # Over 100 character limit
+
+        result = _is_valid_session_name_dynamically(name)
+
+        assert result is False
+
+    def test_is_valid_session_name_with_invalid_characters(self) -> None:
+        """Test validation with invalid characters."""
+        invalid_names = [
+            "test@session",  # Special character
+            "test session",  # Space (not cleaned yet)
+            "test-session",  # Hyphen (not cleaned yet)
+        ]
+
+        for name in invalid_names:
+            result = _is_valid_session_name_dynamically(name)
+            assert result is False, f"Should reject invalid name: {name}"
+
+    def test_is_valid_session_name_edge_cases(self) -> None:
+        """Test validation with edge cases."""
+        test_cases = [
+            ("test123", True),
+            ("123test", True),  # Numbers are allowed
+            ("test_123_session", True),
+            ("T", True),  # Single character
+            ("a" * 100, True),  # Exactly 100 characters
+            ("TEST", True),  # Uppercase
+            ("test_", True),  # Ending with underscore is OK
+        ]
+
+        for name, expected in test_cases:
+            result = _is_valid_session_name_dynamically(name)
+            assert result == expected, f"Failed for name: {name}"
+
+    def test_is_valid_session_name_validation_rules(self) -> None:
+        """Test individual validation rules."""
+        # Test each rule individually
+        assert _is_valid_session_name_dynamically("valid_name") is True
+        assert _is_valid_session_name_dynamically("") is False  # Empty
+        assert (
+            _is_valid_session_name_dynamically("_invalid") is False
+        )  # Starts with underscore
+        assert _is_valid_session_name_dynamically("__main__") is False  # Special name
+        assert _is_valid_session_name_dynamically("a" * 101) is False  # Too long
+        assert (
+            _is_valid_session_name_dynamically("test@invalid") is False
+        )  # Invalid characters
+
+
+class TestSessionUtilsIntegration:
+    """Integration tests for session utilities using standard fixtures."""
+
+    def test_full_session_workflow(self, honeyhive_tracer) -> None:
+        """Test complete session workflow with standard fixture."""
+        # Generate session ID
+        session_id = generate_session_id(honeyhive_tracer)
+
+        # Validate it
+        assert validate_session_id(session_id, honeyhive_tracer)
+
+        # Extract filename
+        filename = extract_filename_from_path(
+            "/path/to/test_script.py", honeyhive_tracer
+        )
+        assert filename == "test_script"
+
+        # Validate filename as session name
+        assert _is_valid_session_name_dynamically(filename)
+
+    def test_session_id_consistency(self, honeyhive_tracer) -> None:
+        """Test session ID generation consistency."""
+        session_ids = [generate_session_id(honeyhive_tracer) for _ in range(5)]
+
+        # All should be unique
+        assert len(set(session_ids)) == 5
+
+        # All should be valid
+        for session_id in session_ids:
+            assert validate_session_id(session_id, honeyhive_tracer)
+
+    def test_filename_extraction_edge_cases_with_tracer(self, honeyhive_tracer) -> None:
+        """Test filename extraction edge cases with tracer instance."""
+        edge_cases = [
+            ("", None),
+            (None, None),
+            ("/path/to/__main__.py", None),  # Invalid session name
+            ("/path/to/valid_script.py", "valid_script"),
+            ("C:\\Windows\\path\\script.py", "script"),
+        ]
+
+        for path, expected in edge_cases:
+            result = extract_filename_from_path(path, honeyhive_tracer)
+            assert result == expected, f"Failed for path: {path}"

--- a/tests_v2/unit/test_utils_baggage_dict.py
+++ b/tests_v2/unit/test_utils_baggage_dict.py
@@ -1,0 +1,533 @@
+"""Unit tests for HoneyHive baggage dictionary utilities."""
+
+# pylint: disable=too-many-public-methods,too-few-public-methods
+# Justification: Comprehensive test coverage requires many test methods,
+# and some test classes may have few methods for specific test scenarios.
+
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+
+from honeyhive.utils.baggage_dict import BaggageDict
+
+
+class TestBaggageDict:
+    """Test BaggageDict functionality."""
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_init_empty(self, mock_context: Any, _mock_baggage: Any) -> None:
+        """Test BaggageDict initialization with empty context."""
+        mock_context.get_current.return_value = Mock()
+        baggage = BaggageDict()
+        assert baggage is not None
+        assert baggage.context is not None
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_init_with_context(self, _mock_context: Any, _mock_baggage: Any) -> None:
+        """Test BaggageDict initialization with custom context."""
+        custom_context = Mock()
+        baggage = BaggageDict(custom_context)
+        assert baggage.context == custom_context
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_get_existing_key(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test getting existing baggage key."""
+        mock_context.get_current.return_value = Mock()
+        mock_baggage.get_baggage.return_value = "test_value"
+
+        baggage = BaggageDict()
+        value = baggage.get("test_key")
+        assert value == "test_value"
+        mock_baggage.get_baggage.assert_called_once_with("test_key", baggage.context)
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_get_missing_key(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test getting missing baggage key."""
+        mock_context.get_current.return_value = Mock()
+        mock_baggage.get_baggage.return_value = None
+
+        baggage = BaggageDict()
+        value = baggage.get("missing_key")
+        assert value is None
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_get_with_default(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test getting baggage key with default value."""
+        mock_context.get_current.return_value = Mock()
+        mock_baggage.get_baggage.return_value = None
+
+        baggage = BaggageDict()
+        value = baggage.get("missing_key", "default_value")
+        assert value == "default_value"
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_set_key(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test setting baggage key."""
+        mock_context.get_current.return_value = Mock()
+        new_context = Mock()
+        mock_baggage.set_baggage.return_value = new_context
+
+        baggage = BaggageDict()
+        result = baggage.set("test_key", "test_value")
+
+        assert isinstance(result, BaggageDict)
+        assert result.context == new_context
+        mock_baggage.set_baggage.assert_called_once_with(
+            "test_key", "test_value", baggage.context
+        )
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_delete_key(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test deleting baggage key."""
+        mock_context.get_current.return_value = Mock()
+        new_context = Mock()
+        mock_baggage.set_baggage.return_value = new_context
+
+        baggage = BaggageDict()
+        result = baggage.delete("test_key")
+
+        assert isinstance(result, BaggageDict)
+        assert result.context == new_context
+        mock_baggage.set_baggage.assert_called_once_with(
+            "test_key", None, baggage.context
+        )
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_update_multiple_keys(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test updating multiple baggage keys."""
+        mock_context.get_current.return_value = Mock()
+        new_context = Mock()
+        mock_baggage.set_baggage.return_value = new_context
+
+        baggage = BaggageDict()
+        result = baggage.update(key1="value1", key2="value2")
+
+        assert isinstance(result, BaggageDict)
+        assert result.context == new_context
+        assert mock_baggage.set_baggage.call_count == 2
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_clear(self, mock_context: Any, _mock_baggage: Any) -> None:
+        """Test clearing all baggage."""
+        mock_context.get_current.return_value = Mock()
+
+        baggage = BaggageDict()
+        result = baggage.clear()
+
+        assert isinstance(result, BaggageDict)
+        assert result.context is not None
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_items(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test getting all baggage items."""
+        mock_context.get_current.return_value = Mock()
+        mock_baggage.get_all.return_value = {"key1": "value1", "key2": "value2"}
+
+        baggage = BaggageDict()
+        items = baggage.items()
+
+        assert items == {"key1": "value1", "key2": "value2"}
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_items_empty(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test getting items when baggage is empty."""
+        mock_context.get_current.return_value = Mock()
+        mock_baggage.get_all.return_value = None
+
+        baggage = BaggageDict()
+        items = baggage.items()
+
+        assert items == {}
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_items_exception_handling(
+        self, mock_context: Any, mock_baggage: Any
+    ) -> None:
+        """Test items method with exception handling."""
+        mock_context.get_current.return_value = Mock()
+        mock_baggage.get_all.side_effect = Exception("Test exception")
+
+        baggage = BaggageDict()
+        items = baggage.items()
+
+        assert items == {}
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_keys(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test getting baggage keys."""
+        mock_context.get_current.return_value = Mock()
+        mock_baggage.get_all.return_value = {"key1": "value1", "key2": "value2"}
+
+        baggage = BaggageDict()
+        keys = list(baggage.keys())
+
+        assert set(keys) == {"key1", "key2"}
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_values(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test getting baggage values."""
+        mock_context.get_current.return_value = Mock()
+        mock_baggage.get_all.return_value = {"key1": "value1", "key2": "value2"}
+
+        baggage = BaggageDict()
+        values = list(baggage.values())
+
+        assert set(values) == {"value1", "value2"}
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_getitem_existing(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test getting item using bracket notation."""
+        mock_context.get_current.return_value = Mock()
+        mock_baggage.get_baggage.return_value = "test_value"
+
+        baggage = BaggageDict()
+        value = baggage["test_key"]
+
+        assert value == "test_value"
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_getitem_missing(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test getting missing item using bracket notation."""
+        mock_context.get_current.return_value = Mock()
+        mock_baggage.get_baggage.return_value = None
+
+        baggage = BaggageDict()
+        with pytest.raises(KeyError):
+            _ = baggage["missing_key"]
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_setitem(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test setting item using bracket notation."""
+        mock_context.get_current.return_value = Mock()
+        new_context = Mock()
+        mock_baggage.set_baggage.return_value = new_context
+
+        baggage = BaggageDict()
+        baggage["test_key"] = "test_value"
+
+        mock_baggage.set_baggage.assert_called_once_with(
+            "test_key", "test_value", baggage.context
+        )
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_delitem(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test deleting item using bracket notation."""
+        mock_context.get_current.return_value = Mock()
+        new_context = Mock()
+        mock_baggage.set_baggage.return_value = new_context
+
+        baggage = BaggageDict()
+        del baggage["test_key"]
+
+        mock_baggage.set_baggage.assert_called_once_with(
+            "test_key", None, baggage.context
+        )
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_contains_existing(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test checking if key exists."""
+        mock_context.get_current.return_value = Mock()
+        mock_baggage.get_baggage.return_value = "test_value"
+
+        baggage = BaggageDict()
+        assert "test_key" in baggage
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_contains_missing(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test checking if missing key exists."""
+        mock_context.get_current.return_value = Mock()
+        mock_baggage.get_baggage.return_value = None
+
+        baggage = BaggageDict()
+        assert "missing_key" not in baggage
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_len(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test getting baggage length."""
+        mock_context.get_current.return_value = Mock()
+        mock_baggage.get_all.return_value = {"key1": "value1", "key2": "value2"}
+
+        baggage = BaggageDict()
+        length = len(baggage)
+
+        assert length == 2
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_iter(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test iterating over baggage keys."""
+        mock_context.get_current.return_value = Mock()
+        mock_baggage.get_all.return_value = {"key1": "value1", "key2": "value2"}
+
+        baggage = BaggageDict()
+        keys = list(baggage)
+
+        assert set(keys) == {"key1", "key2"}
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_repr(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test string representation."""
+        mock_context.get_current.return_value = Mock()
+        mock_baggage.get_all.return_value = {"key1": "value1"}
+
+        baggage = BaggageDict()
+        repr_str = repr(baggage)
+
+        assert "BaggageDict" in repr_str
+        assert "key1" in repr_str
+        assert "value1" in repr_str
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_from_dict(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test creating BaggageDict from dictionary."""
+        mock_context.get_current.return_value = Mock()
+        new_context = Mock()
+        mock_baggage.set_baggage.return_value = new_context
+
+        data = {"key1": "value1", "key2": "value2"}
+        baggage = BaggageDict.from_dict(data)
+
+        assert isinstance(baggage, BaggageDict)
+        assert mock_baggage.set_baggage.call_count == 2
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_from_dict_with_context(
+        self, _mock_context: Any, mock_baggage: Any
+    ) -> None:
+        """Test creating BaggageDict from dictionary with custom context."""
+        custom_context = Mock()
+        new_context = Mock()
+        mock_baggage.set_baggage.return_value = new_context
+
+        data = {"key1": "value1"}
+        baggage = BaggageDict.from_dict(data, custom_context)
+
+        assert isinstance(baggage, BaggageDict)
+        assert baggage.context == new_context
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_as_context(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test using BaggageDict as context manager."""
+        mock_context.get_current.return_value = Mock()
+        mock_context.attach.return_value = Mock()
+        new_context = Mock()
+        mock_baggage.set_baggage.return_value = new_context
+
+        baggage = BaggageDict()
+        baggage = baggage.set("test_key", "test_value")
+
+        with baggage.as_context():
+            # Context should be attached
+            pass
+
+        mock_context.attach.assert_called_once()
+        mock_context.detach.assert_called_once()
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_as_context_exception(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test context manager with exception."""
+        mock_context.get_current.return_value = Mock()
+        mock_context.attach.return_value = Mock()
+        new_context = Mock()
+        mock_baggage.set_baggage.return_value = new_context
+
+        baggage = BaggageDict()
+        baggage = baggage.set("test_key", "test_value")
+
+        with pytest.raises(ValueError):
+            with baggage.as_context():
+                raise ValueError("Test exception")
+
+        mock_context.attach.assert_called_once()
+        mock_context.detach.assert_called_once()
+
+    # Note: OpenTelemetry is now a hard requirement, so no conditional import
+    # tests needed
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_non_string_values(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test handling of non-string values."""
+        mock_context.get_current.return_value = Mock()
+        new_context = Mock()
+        mock_baggage.set_baggage.return_value = new_context
+
+        baggage = BaggageDict()
+        result = baggage.set("number_key", 42)
+
+        assert isinstance(result, BaggageDict)
+        mock_baggage.set_baggage.assert_called_once_with(
+            "number_key", "42", baggage.context
+        )
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_boolean_values(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test handling of boolean values."""
+        mock_context.get_current.return_value = Mock()
+        new_context = Mock()
+        mock_baggage.set_baggage.return_value = new_context
+
+        baggage = BaggageDict()
+        result = baggage.set("bool_key", True)
+
+        assert isinstance(result, BaggageDict)
+        mock_baggage.set_baggage.assert_called_once_with(
+            "bool_key", "True", baggage.context
+        )
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_none_values(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test handling of None values."""
+        mock_context.get_current.return_value = Mock()
+        new_context = Mock()
+        mock_baggage.set_baggage.return_value = new_context
+
+        baggage = BaggageDict()
+        result = baggage.set("none_key", None)
+
+        assert isinstance(result, BaggageDict)
+        mock_baggage.set_baggage.assert_called_once_with(
+            "none_key", "None", baggage.context
+        )
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_complex_values(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test handling of complex values."""
+        mock_context.get_current.return_value = Mock()
+        new_context = Mock()
+        mock_baggage.set_baggage.return_value = new_context
+
+        complex_value = {"nested": "value", "list": [1, 2, 3]}
+        baggage = BaggageDict()
+        result = baggage.set("complex_key", complex_value)
+
+        assert isinstance(result, BaggageDict)
+        mock_baggage.set_baggage.assert_called_once_with(
+            "complex_key", str(complex_value), baggage.context
+        )
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_chained_operations(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test chaining multiple operations."""
+        mock_context.get_current.return_value = Mock()
+        new_context = Mock()
+        mock_baggage.set_baggage.return_value = new_context
+
+        baggage = BaggageDict()
+        result = baggage.set("key1", "value1").set("key2", "value2").delete("key1")
+
+        assert isinstance(result, BaggageDict)
+        assert mock_baggage.set_baggage.call_count == 3
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_context_property(self, _mock_context: Any, _mock_baggage: Any) -> None:
+        """Test context property."""
+        custom_context = Mock()
+        baggage = BaggageDict(custom_context)
+
+        assert baggage.context == custom_context
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_empty_items_repr(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test string representation with empty baggage."""
+        mock_context.get_current.return_value = Mock()
+        mock_baggage.get_all.return_value = {}
+
+        baggage = BaggageDict()
+        repr_str = repr(baggage)
+
+        assert repr_str == "BaggageDict({})"
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_multiple_updates(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test multiple update operations."""
+        mock_context.get_current.return_value = Mock()
+        new_context = Mock()
+        mock_baggage.set_baggage.return_value = new_context
+
+        baggage = BaggageDict()
+        result = baggage.update(a="1", b="2", c="3")
+
+        assert isinstance(result, BaggageDict)
+        assert mock_baggage.set_baggage.call_count == 3
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_get_with_none_value(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test getting a key that has None value."""
+        mock_context.get_current.return_value = Mock()
+        mock_baggage.get_baggage.return_value = None
+
+        baggage = BaggageDict()
+        value = baggage.get("none_key", "default")
+
+        assert value == "default"
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_get_with_empty_string(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test getting a key that has empty string value."""
+        mock_context.get_current.return_value = Mock()
+        mock_baggage.get_baggage.return_value = ""
+
+        baggage = BaggageDict()
+        value = baggage.get("empty_key")
+
+        assert value == ""
+
+    @patch("honeyhive.utils.baggage_dict.baggage")
+    @patch("honeyhive.utils.baggage_dict.context")
+    def test_get_with_zero_value(self, mock_context: Any, mock_baggage: Any) -> None:
+        """Test getting a key that has zero value."""
+        mock_context.get_current.return_value = Mock()
+        mock_baggage.get_baggage.return_value = "0"
+
+        baggage = BaggageDict()
+        value = baggage.get("zero_key")
+
+        assert value == "0"
+
+
+class TestBaggageDictImportHandling:
+    """Test OpenTelemetry baggage import error handling using sys.modules
+    manipulation."""
+
+    # Note: Removed OTEL availability test since OpenTelemetry is now a hard
+    # requirement
+
+    # Note: Removed obsolete OTEL availability tests since OpenTelemetry is now
+    # a hard requirement

--- a/tests_v2/unit/test_utils_cache.py
+++ b/tests_v2/unit/test_utils_cache.py
@@ -1,0 +1,845 @@
+"""Unit tests for HoneyHive cache utilities."""
+
+# pylint: disable=duplicate-code  # Unit tests share common patterns
+
+import threading
+import time
+from typing import Any, Dict, Optional
+
+from honeyhive.utils.cache import (  # AsyncFunctionCache, FunctionCache unused
+    Cache,
+    CacheConfig,
+    CacheEntry,
+    CacheManager,
+    cache_async_function,
+    cache_function,
+    close_global_cache,
+    get_global_cache,
+)
+
+# Removed unused imports: MagicMock, Mock, patch
+
+# Removed unused import: pytest
+
+
+class TestCacheConfig:
+    """Test CacheConfig functionality."""
+
+    def test_default_values(self) -> None:
+        """Test CacheConfig default values."""
+        config = CacheConfig()
+        assert config.max_size == 1000
+        assert config.default_ttl == 300.0
+        assert config.cleanup_interval == 60.0
+        assert config.enable_stats is True
+
+    def test_custom_values(self) -> None:
+        """Test CacheConfig with custom values."""
+        config = CacheConfig(
+            max_size=500,
+            default_ttl=600.0,
+            cleanup_interval=120.0,
+            enable_stats=False,
+        )
+        assert config.max_size == 500
+        assert config.default_ttl == 600.0
+        assert config.cleanup_interval == 120.0
+        assert config.enable_stats is False
+
+
+class TestCacheEntry:
+    """Test CacheEntry functionality."""
+
+    def test_init(self) -> None:
+        """Test CacheEntry initialization."""
+        entry = CacheEntry("key", "value", ttl=60.0)
+        assert entry.key == "key"
+        assert entry.value == "value"
+        assert entry.ttl == 60.0
+        assert entry.created_at > 0
+
+    def test_is_expired_not_expired(self) -> None:
+        """Test CacheEntry is_expired when not expired."""
+        entry = CacheEntry("key", "value", ttl=60.0)
+        assert not entry.is_expired()
+
+    def test_is_expired_expired(self) -> None:
+        """Test CacheEntry is_expired when expired."""
+        entry = CacheEntry("key", "value", ttl=0.1)
+        time.sleep(0.2)
+        assert entry.is_expired()
+
+    def test_access(self) -> None:
+        """Test CacheEntry access method."""
+        entry = CacheEntry("key", "value")
+        initial_count = entry.access_count
+        time.sleep(0.001)  # Small delay to ensure different timestamps
+        entry.access()
+        assert entry.access_count == initial_count + 1
+        assert entry.last_accessed >= entry.created_at
+
+    def test_get_age(self) -> None:
+        """Test CacheEntry get_age method."""
+        entry = CacheEntry("key", "value")
+        age = entry.get_age()
+        assert age >= 0
+        assert age < 1  # Should be very small
+
+    def test_get_remaining_ttl(self) -> None:
+        """Test CacheEntry get_remaining_ttl method."""
+        entry = CacheEntry("key", "value", ttl=60.0)
+        remaining = entry.get_remaining_ttl()
+        assert 0 < remaining <= 60.0
+
+    def test_get_remaining_ttl_expired(self) -> None:
+        """Test CacheEntry get_remaining_ttl when expired."""
+        entry = CacheEntry("key", "value", ttl=0.1)
+        time.sleep(0.2)
+        remaining = entry.get_remaining_ttl()
+        assert remaining == 0
+
+    def test_expiry_property(self) -> None:
+        """Test CacheEntry expiry property."""
+        entry = CacheEntry("key", "value", ttl=60.0)
+        assert entry.expiry == entry.created_at + 60.0
+
+
+class TestCache:  # pylint: disable=too-many-public-methods
+    """Test Cache functionality."""
+
+    def test_init_default(self) -> None:
+        """Test Cache initialization with defaults."""
+        cache = Cache()
+        assert cache.config.max_size == 1000
+        assert cache.config.default_ttl == 300.0
+        assert cache.config.enable_stats is True
+
+    def test_init_custom(self) -> None:
+        """Test Cache initialization with custom config."""
+        config = CacheConfig(max_size=100, default_ttl=60.0)
+        cache = Cache(config)
+        assert cache.config.max_size == 100
+        assert cache.config.default_ttl == 60.0
+
+    def test_set_and_get(self) -> None:
+        """Test setting and getting cache entries."""
+        cache = Cache()
+        cache.set("key", "value")
+        assert cache.get("key") == "value"
+
+    def test_set_with_ttl(self) -> None:
+        """Test setting cache entry with custom TTL."""
+        cache = Cache()
+        cache.set("key", "value", ttl=0.1)
+        assert cache.get("key") == "value"
+        time.sleep(0.2)
+        assert cache.get("key") is None
+
+    def test_get_missing_key(self) -> None:
+        """Test getting missing key."""
+        cache = Cache()
+        assert cache.get("missing_key") is None
+
+    def test_get_with_default(self) -> None:
+        """Test getting with default value."""
+        cache = Cache()
+        assert cache.get("missing_key", "default") == "default"
+
+    def test_delete(self) -> None:
+        """Test deleting cache entry."""
+        cache = Cache()
+        cache.set("key", "value")
+        result = cache.delete("key")
+        assert result is True
+        assert cache.get("key") is None
+
+    def test_delete_missing_key(self) -> None:
+        """Test deleting missing key."""
+        cache = Cache()
+        result = cache.delete("missing_key")
+        assert result is False
+
+    def test_exists(self) -> None:
+        """Test checking if key exists."""
+        cache = Cache()
+        cache.set("key", "value")
+        assert cache.exists("key") is True
+        assert cache.exists("missing_key") is False
+
+    def test_exists_expired(self) -> None:
+        """Test checking if expired key exists."""
+        cache = Cache()
+        cache.set("key", "value", ttl=0.1)
+        time.sleep(0.2)
+        assert cache.exists("key") is False
+
+    def test_clear(self) -> None:
+        """Test clearing cache."""
+        cache = Cache()
+        cache.set("key1", "value1")
+        cache.set("key2", "value2")
+        cache.clear()
+        assert cache.get("key1") is None
+        assert cache.get("key2") is None
+
+    def test_size_limit(self) -> None:
+        """Test cache size limit enforcement."""
+        config = CacheConfig(max_size=2)
+        cache = Cache(config)
+        cache.set("key1", "value1")
+        cache.set("key2", "value2")
+        cache.set("key3", "value3")  # Should evict key1
+        assert cache.get("key1") is None
+        assert cache.get("key2") == "value2"
+        assert cache.get("key3") == "value3"
+
+    def test_lru_eviction(self) -> None:
+        """Test LRU eviction policy."""
+        config = CacheConfig(max_size=2)
+        cache = Cache(config)
+        cache.set("key1", "value1")
+        cache.set("key2", "value2")
+        cache.get("key1")  # Access key1 to make it most recently used
+        cache.set("key3", "value3")  # Should evict key2
+        assert cache.get("key1") == "value1"
+        assert cache.get("key2") is None
+        assert cache.get("key3") == "value3"
+
+    def test_cache_property(self) -> None:
+        """Test cache property access."""
+        cache = Cache()
+        cache.set("key", "value")
+        cache_dict = cache.cache
+        assert "key" in cache_dict
+        assert isinstance(cache_dict["key"], CacheEntry)
+
+    def test_stats(self) -> None:
+        """Test cache statistics."""
+        cache = Cache()
+        cache.set("key", "value")
+        cache.get("key")
+        cache.get("missing_key")
+        stats = cache.stats()
+        assert stats["hits"] == 1
+        assert stats["misses"] == 1
+        assert stats["sets"] == 1
+        assert stats["size"] == 1
+
+    def test_get_stats(self) -> None:
+        """Test get_stats method."""
+        cache = Cache()
+        cache.set("key", "value")
+        cache.get("key")
+        stats = cache.get_stats()
+        assert "hits" in stats
+        assert "misses" in stats
+        assert "sets" in stats
+        assert "size" in stats
+
+    def test_cleanup_expired(self) -> None:
+        """Test cleanup of expired entries."""
+        cache = Cache()
+        cache.set("key1", "value1", ttl=0.1)
+        cache.set("key2", "value2", ttl=60.0)
+        time.sleep(0.2)
+        cleaned = cache.cleanup_expired()
+        assert cleaned == 1
+        assert cache.get("key1") is None
+        assert cache.get("key2") == "value2"
+
+    def test_cleanup(self) -> None:
+        """Test cleanup method."""
+        cache = Cache()
+        cache.set("key1", "value1", ttl=0.1)
+        cache.set("key2", "value2", ttl=60.0)
+        time.sleep(0.2)
+        cache.cleanup()
+        assert cache.get("key1") is None
+        assert cache.get("key2") == "value2"
+
+    def test_context_manager(self) -> None:
+        """Test cache as context manager."""
+        with Cache() as cache:
+            cache.set("key", "value")
+            assert cache.get("key") == "value"
+
+    def test_close(self) -> None:
+        """Test closing cache."""
+        cache = Cache()
+        cache.set("key", "value")
+        cache.close()
+        # Cache should be cleared after closing
+        assert cache.get("key") is None
+
+    def test_thread_safety(self) -> None:
+        """Test cache thread safety."""
+        cache = Cache()
+        results = []
+
+        def worker(thread_id: int) -> None:
+            for i in range(10):
+                key = f"key_{thread_id}_{i}"
+                cache.set(key, f"value_{thread_id}_{i}")
+                value = cache.get(key)
+                results.append(value)
+
+        threads = []
+        for i in range(3):
+            thread = threading.Thread(target=worker, args=(i,))
+            threads.append(thread)
+            thread.start()
+
+        for thread in threads:
+            thread.join()
+
+        assert len(results) == 30
+        assert all(result is not None for result in results)
+
+    def test_complex_objects(self) -> None:
+        """Test caching complex objects."""
+        cache = Cache()
+        complex_obj = {"nested": {"list": [1, 2, 3], "dict": {"key": "value"}}}
+        cache.set("complex", complex_obj)
+        retrieved = cache.get("complex")
+        assert retrieved == complex_obj
+
+    def test_none_values(self) -> None:
+        """Test caching None values."""
+        cache = Cache()
+        cache.set("none_key", None)
+        assert cache.get("none_key") is None
+
+    def test_zero_values(self) -> None:
+        """Test caching zero values."""
+        cache = Cache()
+        cache.set("zero_key", 0)
+        assert cache.get("zero_key") == 0
+
+    def test_empty_values(self) -> None:
+        """Test caching empty values."""
+        cache = Cache()
+        cache.set("empty_list", [])
+        cache.set("empty_dict", {})
+        cache.set("empty_string", "")
+        assert cache.get("empty_list") == []
+        assert cache.get("empty_dict") == {}
+        assert cache.get("empty_string") == ""
+
+    def test_update_existing_key(self) -> None:
+        """Test updating existing key."""
+        cache = Cache()
+        cache.set("key", "old_value")
+        cache.set("key", "new_value")
+        assert cache.get("key") == "new_value"
+
+    def test_set_multiple(self) -> None:
+        """Test setting multiple keys."""
+        cache = Cache()
+        cache.set("key1", "value1")
+        cache.set("key2", "value2")
+        cache.set("key3", "value3")
+        assert cache.get("key1") == "value1"
+        assert cache.get("key2") == "value2"
+        assert cache.get("key3") == "value3"
+
+    def test_delete_multiple(self) -> None:
+        """Test deleting multiple keys."""
+        cache = Cache()
+        cache.set("key1", "value1")
+        cache.set("key2", "value2")
+        cache.set("key3", "value3")
+        cache.delete("key1")
+        cache.delete("key3")
+        assert cache.get("key1") is None
+        assert cache.get("key2") == "value2"
+        assert cache.get("key3") is None
+
+    def test_cache_size_after_eviction(self) -> None:
+        """Test cache size after eviction."""
+        config = CacheConfig(max_size=2)
+        cache = Cache(config)
+        cache.set("key1", "value1")
+        cache.set("key2", "value2")
+        cache.set("key3", "value3")  # Should evict key1
+        stats = cache.stats()
+        assert stats["size"] == 2
+
+    def test_cache_size_after_clear(self) -> None:
+        """Test cache size after clear."""
+        cache = Cache()
+        cache.set("key1", "value1")
+        cache.set("key2", "value2")
+        stats = cache.stats()
+        assert stats["size"] == 2
+        cache.clear()
+        stats = cache.stats()
+        assert stats["size"] == 0
+
+    def test_cache_size_after_delete(self) -> None:
+        """Test cache size after delete."""
+        cache = Cache()
+        cache.set("key1", "value1")
+        cache.set("key2", "value2")
+        stats = cache.stats()
+        assert stats["size"] == 2
+        cache.delete("key1")
+        stats = cache.stats()
+        assert stats["size"] == 1
+
+    def test_cache_size_after_expiry(self) -> None:
+        """Test cache size after expiry."""
+        cache = Cache()
+        cache.set("key1", "value1", ttl=0.1)
+        cache.set("key2", "value2")
+        stats = cache.stats()
+        assert stats["size"] == 2
+        time.sleep(0.2)
+        cache.cleanup_expired()
+        stats = cache.stats()
+        assert stats["size"] == 1
+
+    def test_generate_key(self) -> None:
+        """Test key generation."""
+        cache = Cache()
+        key = cache.generate_key("test_function", "arg1", "arg2", kwarg1="value1")
+        assert isinstance(key, str)
+        assert len(key) > 0
+
+    def test_generate_key_with_complex_args(self) -> None:
+        """Test key generation with complex arguments."""
+        cache = Cache()
+        complex_arg = {"nested": "value", "list": [1, 2, 3]}
+        key = cache.generate_key("test_function", complex_arg, kwarg1="value1")
+        assert isinstance(key, str)
+        assert len(key) > 0
+
+
+class TestGlobalCache:
+    """Test global cache functionality."""
+
+    def test_get_global_cache(self) -> None:
+        """Test getting global cache."""
+        cache = get_global_cache()
+        assert isinstance(cache, Cache)
+        # Should return the same instance
+        cache2 = get_global_cache()
+        assert cache is cache2
+
+    def test_close_global_cache(self) -> None:
+        """Test closing global cache."""
+        cache = get_global_cache()
+        close_global_cache()
+        # Should create a new instance after closing
+        cache2 = get_global_cache()
+        assert cache is not cache2
+
+
+class TestFunctionCache:
+    """Test function cache decorator."""
+
+    def test_function_cache_decorator(self) -> None:
+        """Test function cache decorator."""
+        cache = Cache()
+
+        @cache_function(ttl=60.0, cache=cache)
+        def test_function(x: int) -> int:
+            return x * 2
+
+        result1 = test_function(5)
+        result2 = test_function(5)
+        assert result1 == 10
+        assert result2 == 10
+        # Check that result was cached - the key format might be different
+        stats = cache.stats()
+        assert stats["hits"] >= 1  # At least one hit from the second call
+
+    def test_function_cache_with_ttl(self) -> None:
+        """Test function cache decorator with TTL."""
+        cache = Cache()
+
+        @cache_function(ttl=0.1, cache=cache)
+        def test_function(x: int) -> int:
+            return x * 2
+
+        result1 = test_function(5)
+        assert result1 == 10
+        time.sleep(0.2)
+        result2 = test_function(5)  # Should recalculate
+        assert result2 == 10
+
+    def test_function_cache_different_args(self) -> None:
+        """Test function cache decorator with different arguments."""
+        cache = Cache()
+
+        @cache_function(cache=cache)
+        def test_function(x: int, y: str) -> str:
+            return f"{x}_{y}"
+
+        result1 = test_function(5, "test")
+        result2 = test_function(5, "test")
+        result3 = test_function(6, "test")
+        assert result1 == "5_test"
+        assert result2 == "5_test"
+        assert result3 == "6_test"
+
+    def test_function_cache_with_kwargs(self) -> None:
+        """Test function cache decorator with keyword arguments."""
+        cache = Cache()
+
+        @cache_function(cache=cache)
+        def test_function(x: int, y: str = "default") -> str:
+            return f"{x}_{y}"
+
+        result1 = test_function(5, y="custom")
+        result2 = test_function(5, y="custom")
+        assert result1 == "5_custom"
+        assert result2 == "5_custom"
+
+    def test_function_cache_with_none_args(self) -> None:
+        """Test function cache decorator with None arguments."""
+        cache = Cache()
+
+        @cache_function(cache=cache)
+        def test_function(x: Optional[int]) -> str:
+            return f"value_{x}"
+
+        result1 = test_function(None)
+        result2 = test_function(None)
+        assert result1 == "value_None"
+        assert result2 == "value_None"
+
+    def test_function_cache_with_complex_args(self) -> None:
+        """Test function cache decorator with complex arguments."""
+        cache = Cache()
+
+        @cache_function(cache=cache)
+        def test_function(data: Dict[str, Any]) -> str:
+            return f"processed_{data.get('key', 'default')}"
+
+        data1 = {"key": "value1"}
+        data2 = {"key": "value2"}
+        result1 = test_function(data1)
+        result2 = test_function(data1)
+        result3 = test_function(data2)
+        assert result1 == "processed_value1"
+        assert result2 == "processed_value1"
+        assert result3 == "processed_value2"
+
+
+class TestAsyncFunctionCache:
+    """Test async function cache decorator."""
+
+    def test_async_function_cache_decorator(self) -> None:
+        """Test async function cache decorator."""
+        cache = Cache()
+
+        @cache_async_function(ttl=60.0, cache=cache)
+        async def test_async_function(x: int) -> int:
+            return x * 2
+
+        # This would need to be tested in an async context
+        # For now, just test that the decorator creates a function
+        assert callable(test_async_function)
+
+    def test_async_function_cache_with_ttl(self) -> None:
+        """Test async function cache decorator with TTL."""
+        cache = Cache()
+
+        @cache_async_function(ttl=0.1, cache=cache)
+        async def test_async_function(x: int) -> int:
+            return x * 2
+
+        # This would need to be tested in an async context
+        # For now, just test that the decorator creates a function
+        assert callable(test_async_function)
+
+    def test_async_function_cache_different_args(self) -> None:
+        """Test async function cache decorator with different arguments."""
+        cache = Cache()
+
+        @cache_async_function(cache=cache)
+        async def test_async_function(x: int, y: str) -> str:
+            return f"{x}_{y}"
+
+        # This would need to be tested in an async context
+        # For now, just test that the decorator creates a function
+        assert callable(test_async_function)
+
+
+class TestCacheManager:
+    """Test CacheManager functionality for multi-instance architecture."""
+
+    def test_init_default_config(self) -> None:
+        """Test CacheManager initialization with default config."""
+        manager = CacheManager("test_instance")
+        assert manager.instance_id == "test_instance"
+        assert isinstance(manager.config, CacheConfig)
+        assert manager.config.max_size == 1000
+        assert manager.config.default_ttl == 300.0
+
+    def test_init_custom_config(self) -> None:
+        """Test CacheManager initialization with custom config."""
+        config = CacheConfig(max_size=500, default_ttl=600.0)
+        manager = CacheManager("test_instance", config)
+        assert manager.instance_id == "test_instance"
+        assert manager.config.max_size == 500
+        assert manager.config.default_ttl == 600.0
+
+    def test_get_cache_creates_new(self) -> None:
+        """Test that get_cache creates new cache instances."""
+        manager = CacheManager("test_instance")
+        cache1 = manager.get_cache("attributes")
+        assert isinstance(cache1, Cache)
+        assert "attributes" in manager._caches
+
+    def test_get_cache_returns_existing(self) -> None:
+        """Test that get_cache returns existing cache instances."""
+        manager = CacheManager("test_instance")
+        cache1 = manager.get_cache("attributes")
+        cache2 = manager.get_cache("attributes")
+        assert cache1 is cache2  # Same instance
+
+    def test_get_cache_with_custom_config(self) -> None:
+        """Test get_cache with custom cache-specific configuration."""
+        manager = CacheManager("test_instance")
+        custom_config = CacheConfig(max_size=100, default_ttl=60.0)
+        cache = manager.get_cache("resources", custom_config)
+        assert cache.config.max_size == 100
+        assert cache.config.default_ttl == 60.0
+
+    def test_get_multiple_named_caches(self) -> None:
+        """Test creating multiple named caches."""
+        manager = CacheManager("test_instance")
+        attributes_cache = manager.get_cache("attributes")
+        resources_cache = manager.get_cache("resources")
+        config_cache = manager.get_cache("config")
+
+        assert attributes_cache is not resources_cache
+        assert resources_cache is not config_cache
+        assert len(manager._caches) == 3
+
+    def test_cache_isolation_between_names(self) -> None:
+        """Test that named caches are isolated from each other."""
+        manager = CacheManager("test_instance")
+        attributes_cache = manager.get_cache("attributes")
+        resources_cache = manager.get_cache("resources")
+
+        # Set values in different caches
+        attributes_cache.set("key1", "attr_value")
+        resources_cache.set("key1", "resource_value")
+
+        # Values should be isolated
+        assert attributes_cache.get("key1") == "attr_value"
+        assert resources_cache.get("key1") == "resource_value"
+
+    def test_close_all_caches(self) -> None:
+        """Test closing all caches managed by the instance."""
+        manager = CacheManager("test_instance")
+        attributes_cache = manager.get_cache("attributes")
+        resources_cache = manager.get_cache("resources")
+
+        # Add some data
+        attributes_cache.set("key1", "value1")
+        resources_cache.set("key2", "value2")
+
+        # Close all caches
+        manager.close_all()
+
+        # Caches should be cleared and manager should have no caches
+        assert len(manager._caches) == 0
+        assert attributes_cache.get("key1") is None
+        assert resources_cache.get("key2") is None
+
+    def test_get_stats_empty(self) -> None:
+        """Test get_stats with no caches."""
+        manager = CacheManager("test_instance")
+        stats = manager.get_stats()
+        assert stats == {}
+
+    def test_get_stats_with_caches(self) -> None:
+        """Test get_stats with multiple caches."""
+        manager = CacheManager("test_instance")
+        attributes_cache = manager.get_cache("attributes")
+        resources_cache = manager.get_cache("resources")
+
+        # Add some data and access patterns
+        attributes_cache.set("key1", "value1")
+        attributes_cache.get("key1")  # Hit
+        attributes_cache.get("missing")  # Miss
+
+        resources_cache.set("key2", "value2")
+        resources_cache.get("key2")  # Hit
+
+        stats = manager.get_stats()
+        assert "attributes" in stats
+        assert "resources" in stats
+        assert stats["attributes"]["hits"] == 1
+        assert stats["attributes"]["misses"] == 1
+        assert stats["resources"]["hits"] == 1
+
+    def test_multi_instance_isolation(self) -> None:
+        """Test that different CacheManager instances are completely isolated."""
+        manager1 = CacheManager("instance_1")
+        manager2 = CacheManager("instance_2")
+
+        # Get same-named caches from different managers
+        cache1_attr = manager1.get_cache("attributes")
+        cache2_attr = manager2.get_cache("attributes")
+
+        # Set different values with same key
+        cache1_attr.set("shared_key", "value_from_instance_1")
+        cache2_attr.set("shared_key", "value_from_instance_2")
+
+        # Values should be isolated
+        assert cache1_attr.get("shared_key") == "value_from_instance_1"
+        assert cache2_attr.get("shared_key") == "value_from_instance_2"
+
+        # Managers should have different cache instances
+        assert cache1_attr is not cache2_attr
+        assert manager1._caches is not manager2._caches
+
+    def test_cache_manager_with_tracer_like_instance_id(self) -> None:
+        """Test CacheManager with tracer-like instance IDs."""
+        # Simulate tracer instance ID generation
+        tracer_id_1 = f"tracer_{id(object())}_{hash('tracer_1')}"
+        tracer_id_2 = f"tracer_{id(object())}_{hash('tracer_2')}"
+
+        manager1 = CacheManager(tracer_id_1)
+        manager2 = CacheManager(tracer_id_2)
+
+        assert manager1.instance_id != manager2.instance_id
+
+        # Test that they maintain separate caches
+        cache1 = manager1.get_cache("attributes")
+        cache2 = manager2.get_cache("attributes")
+
+        cache1.set("test_key", "manager1_value")
+        cache2.set("test_key", "manager2_value")
+
+        assert cache1.get("test_key") == "manager1_value"
+        assert cache2.get("test_key") == "manager2_value"
+
+    def test_cache_manager_error_handling(self) -> None:
+        """Test CacheManager error handling and graceful degradation."""
+        manager = CacheManager("test_instance")
+
+        # Test with invalid cache name (should still work)
+        cache = manager.get_cache("")
+        assert isinstance(cache, Cache)
+
+        # Test close_all with no caches (should not error)
+        empty_manager = CacheManager("empty_instance")
+        empty_manager.close_all()  # Should not raise exception
+
+    def test_cache_manager_thread_safety(self) -> None:
+        """Test CacheManager thread safety."""
+        manager = CacheManager("test_instance")
+        results = []
+
+        def worker(thread_id: int) -> None:
+            # Each thread gets its own named cache
+            cache = manager.get_cache(f"cache_{thread_id}")
+            for i in range(5):
+                key = f"key_{thread_id}_{i}"
+                cache.set(key, f"value_{thread_id}_{i}")
+                value = cache.get(key)
+                results.append(value)
+
+        threads = []
+        for i in range(3):
+            thread = threading.Thread(target=worker, args=(i,))
+            threads.append(thread)
+            thread.start()
+
+        for thread in threads:
+            thread.join()
+
+        # Should have 15 results (3 threads × 5 operations)
+        assert len(results) == 15
+        assert all(result is not None for result in results)
+
+        # Should have 3 different caches
+        assert len(manager._caches) == 3
+
+    def test_cache_manager_memory_cleanup(self) -> None:
+        """Test that CacheManager properly cleans up memory."""
+        manager = CacheManager("test_instance")
+
+        # Create multiple caches with data
+        for cache_name in ["attributes", "resources", "config"]:
+            cache = manager.get_cache(cache_name)
+            for i in range(10):
+                cache.set(f"key_{i}", f"value_{i}")
+
+        # Verify data exists
+        assert len(manager._caches) == 3
+        for cache in manager._caches.values():
+            assert cache.stats()["size"] == 10
+
+        # Close all and verify cleanup
+        manager.close_all()
+        assert len(manager._caches) == 0
+
+    def test_cache_manager_with_different_configs(self) -> None:
+        """Test CacheManager with different configurations for different caches."""
+        manager = CacheManager("test_instance")
+
+        # Create caches with different configurations
+        attr_config = CacheConfig(max_size=100, default_ttl=60.0)
+        resource_config = CacheConfig(max_size=50, default_ttl=3600.0)
+
+        attr_cache = manager.get_cache("attributes", attr_config)
+        resource_cache = manager.get_cache("resources", resource_config)
+
+        # Verify different configurations
+        assert attr_cache.config.max_size == 100
+        assert attr_cache.config.default_ttl == 60.0
+        assert resource_cache.config.max_size == 50
+        assert resource_cache.config.default_ttl == 3600.0
+
+    def test_cache_manager_stats_aggregation(self) -> None:
+        """Test CacheManager statistics aggregation across multiple caches."""
+        manager = CacheManager("test_instance")
+
+        # Create and use multiple caches
+        attr_cache = manager.get_cache("attributes")
+        resource_cache = manager.get_cache("resources")
+        config_cache = manager.get_cache("config")
+
+        # Generate different usage patterns
+        attr_cache.set("attr1", "value1")
+        attr_cache.set("attr2", "value2")
+        attr_cache.get("attr1")  # Hit
+        attr_cache.get("missing")  # Miss
+
+        resource_cache.set("res1", "resource1")
+        resource_cache.get("res1")  # Hit
+
+        config_cache.set("conf1", "config1")
+        config_cache.get("conf1")  # Hit
+        config_cache.get("conf2")  # Miss
+
+        # Get aggregated stats
+        stats = manager.get_stats()
+
+        # Verify structure and data
+        assert len(stats) == 3
+        assert "attributes" in stats
+        assert "resources" in stats
+        assert "config" in stats
+
+        # Verify individual cache stats
+        assert stats["attributes"]["hits"] == 1
+        assert stats["attributes"]["misses"] == 1
+        assert stats["attributes"]["sets"] == 2
+        assert stats["attributes"]["size"] == 2
+
+        assert stats["resources"]["hits"] == 1
+        assert stats["resources"]["misses"] == 0
+        assert stats["resources"]["sets"] == 1
+        assert stats["resources"]["size"] == 1
+
+        assert stats["config"]["hits"] == 1
+        assert stats["config"]["misses"] == 1
+        assert stats["config"]["sets"] == 1
+        assert stats["config"]["size"] == 1

--- a/tests_v2/unit/test_utils_connection_pool.py
+++ b/tests_v2/unit/test_utils_connection_pool.py
@@ -1,0 +1,1267 @@
+"""Unit tests for connection pool utilities."""
+
+# pylint: disable=too-many-lines,protected-access,redefined-outer-name,too-many-public-methods,line-too-long,too-few-public-methods,missing-class-docstring,import-outside-toplevel,reimported,unused-import,use-implicit-booleaness-not-comparison,unused-variable
+# Justification: Generated test file with comprehensive connection pool testing requiring extensive mocks and protected member access
+
+import asyncio
+import importlib
+import sys
+import threading
+import time
+from unittest.mock import AsyncMock, Mock, patch
+
+import httpx
+import pytest
+
+from honeyhive.utils.connection_pool import (
+    ConnectionPool,
+    PoolConfig,
+    PooledAsyncHTTPClient,
+    PooledHTTPClient,
+    close_global_pool,
+    get_global_pool,
+)
+
+
+class TestPoolConfig:
+    """Test PoolConfig dataclass."""
+
+    def test_pool_config_default_values(self):
+        """Test PoolConfig default values."""
+        config = PoolConfig()
+
+        assert config.max_connections == 100
+        assert config.max_keepalive_connections == 20
+        assert config.keepalive_expiry == 30.0
+        assert config.retries == 3
+        assert config.timeout == 30.0
+        assert config.pool_timeout == 10.0
+
+    def test_pool_config_custom_values(self):
+        """Test PoolConfig with custom values."""
+        config = PoolConfig(
+            max_connections=50,
+            max_keepalive_connections=10,
+            keepalive_expiry=60.0,
+            retries=5,
+            timeout=45.0,
+            pool_timeout=15.0,
+        )
+
+        assert config.max_connections == 50
+        assert config.max_keepalive_connections == 10
+        assert config.keepalive_expiry == 60.0
+        assert config.retries == 5
+        assert config.timeout == 45.0
+        assert config.pool_timeout == 15.0
+
+
+class TestConnectionPool:
+    """Test ConnectionPool functionality."""
+
+    @pytest.fixture
+    def pool_config(self):
+        """Create test pool configuration."""
+        return PoolConfig(
+            max_connections=10,
+            max_keepalive_connections=5,
+            keepalive_expiry=10.0,
+            retries=2,
+            timeout=15.0,
+            pool_timeout=5.0,
+        )
+
+    @pytest.fixture
+    def connection_pool(self, pool_config):
+        """Create test connection pool."""
+        with patch("honeyhive.utils.connection_pool.HTTPX_AVAILABLE", True):
+            return ConnectionPool(config=pool_config)
+
+    def test_pool_initialization_default_config(self):
+        """Test pool initialization with default config."""
+        with patch("honeyhive.utils.connection_pool.HTTPX_AVAILABLE", True):
+            pool = ConnectionPool()
+
+            assert pool.config is not None
+            assert pool.config.max_connections == 100
+            assert pool._clients == {}
+            assert pool._async_clients == {}
+            assert hasattr(pool._lock, "acquire") and hasattr(pool._lock, "release")
+            assert pool._last_used == {}
+
+    def test_pool_initialization_custom_config(self, pool_config):
+        """Test pool initialization with custom config."""
+        with patch("honeyhive.utils.connection_pool.HTTPX_AVAILABLE", True):
+            pool = ConnectionPool(config=pool_config)
+
+            assert pool.config == pool_config
+            assert pool.config.max_connections == 10
+
+    def test_pool_initialization_httpx_not_available(self):
+        """Test pool initialization when httpx is not available."""
+        with patch("honeyhive.utils.connection_pool.HTTPX_AVAILABLE", False):
+            with pytest.raises(ImportError, match="httpx is required"):
+                ConnectionPool()
+
+    def test_get_client_new_connection(self, connection_pool):
+        """Test getting a new client connection."""
+        base_url = "https://api.example.com"
+
+        with patch("httpx.Client") as mock_client_class:
+            mock_client = Mock()
+            mock_client_class.return_value = mock_client
+
+            # Mock the _is_client_healthy method to return True
+            with patch.object(connection_pool, "_is_client_healthy", return_value=True):
+                client = connection_pool.get_client(base_url)
+
+                assert client == mock_client
+                assert base_url in connection_pool._clients
+                assert base_url in connection_pool._last_used
+                assert connection_pool._stats["connections_created"] == 1
+
+    def test_get_client_existing_healthy_connection(self, connection_pool):
+        """Test getting an existing healthy client connection."""
+        base_url = "https://api.example.com"
+
+        # Setup existing client
+        existing_client = Mock()
+        connection_pool._clients[base_url] = existing_client
+        connection_pool._last_used[base_url] = time.time()
+
+        with patch.object(connection_pool, "_is_client_healthy", return_value=True):
+            client = connection_pool.get_client(base_url)
+
+            assert client == existing_client
+            assert connection_pool._stats["pool_hits"] == 1
+            assert connection_pool._stats["connections_reused"] == 1
+
+    def test_get_connection_method(self, connection_pool):
+        """Test get_connection method."""
+        base_url = "https://api.example.com"
+
+        # Should return None when no connection exists
+        connection = connection_pool.get_connection(base_url)
+        assert connection is None
+
+        # Add a connection and test retrieval
+        mock_client = Mock()
+        connection_pool._clients[base_url] = mock_client
+        connection_pool._last_used[base_url] = time.time()
+
+        # The actual implementation may have health checks, so we just test the method exists
+        connection = connection_pool.get_connection(base_url)
+        # Just verify the method can be called
+        assert connection is not None or connection is None
+
+    def test_return_connection(self, connection_pool):
+        """Test returning a connection to the pool."""
+        base_url = "https://api.example.com"
+        client = Mock()
+
+        connection_pool.return_connection(base_url, client)
+
+        assert base_url in connection_pool._last_used
+
+    def test_is_client_healthy_good_client(self, connection_pool):
+        """Test health check for a healthy client."""
+        client = Mock()
+        client.is_closed = False
+
+        result = connection_pool._is_client_healthy(client)
+
+        # The actual implementation may return False for Mock objects
+        # Let's just test that the method can be called
+        assert isinstance(result, bool)
+
+    def test_is_client_healthy_closed_client(self, connection_pool):
+        """Test health check for a closed client."""
+        client = Mock()
+        client.is_closed = True
+
+        result = connection_pool._is_client_healthy(client)
+
+        assert result is False
+
+    def test_close_connection(self, connection_pool):
+        """Test closing a connection."""
+        base_url = "https://api.example.com"
+
+        # Setup client in pool
+        client = Mock()
+        connection_pool._clients[base_url] = client
+
+        connection_pool.close_connection(base_url)
+
+        assert base_url not in connection_pool._clients
+
+    def test_cleanup_idle_connections(self, connection_pool):
+        """Test cleanup of idle connections."""
+        # Setup old connection
+        base_url = "https://api.example.com"
+        old_client = Mock()
+        connection_pool._clients[base_url] = old_client
+        connection_pool._last_used[base_url] = (
+            time.time() - 400
+        )  # Very old (> 300s default)
+
+        connection_pool.cleanup_idle_connections(max_idle_time=300.0)
+
+        # Should be cleaned up
+        assert base_url not in connection_pool._clients
+
+    def test_get_stats(self, connection_pool):
+        """Test getting pool statistics."""
+        # Setup some stats
+        connection_pool._stats["total_requests"] = 10
+        connection_pool._stats["pool_hits"] = 5
+
+        stats = connection_pool.get_stats()
+
+        assert stats["total_requests"] == 10
+        assert stats["pool_hits"] == 5
+        assert "active_connections" in stats
+        assert "active_async_connections" in stats
+
+    def test_close_all_connections(self, connection_pool):
+        """Test closing all connections."""
+        # Setup clients
+        client1 = Mock()
+        client2 = Mock()
+
+        connection_pool._clients["url1"] = client1
+        connection_pool._clients["url2"] = client2
+
+        connection_pool.close_all()
+
+        assert connection_pool._clients == {}
+        assert connection_pool._last_used == {}
+
+    def test_pool_context_manager(self, pool_config):
+        """Test connection pool as context manager."""
+        with patch("honeyhive.utils.connection_pool.HTTPX_AVAILABLE", True):
+            with patch.object(ConnectionPool, "close_all") as mock_close:
+                with ConnectionPool(config=pool_config) as pool:
+                    assert isinstance(pool, ConnectionPool)
+
+                mock_close.assert_called_once()
+
+
+class TestConnectionPoolImportHandling:
+    """Test HTTP library import error handling using sys.modules manipulation."""
+
+    def test_httpx_availability_flag(self):
+        """Test HTTPX availability flag works correctly."""
+        # Test that we can access the HTTPX_AVAILABLE flag
+        from honeyhive.utils.connection_pool import HTTPX_AVAILABLE
+
+        assert isinstance(HTTPX_AVAILABLE, bool)
+
+        # Test that the flag affects ConnectionPool behavior appropriately
+        if HTTPX_AVAILABLE:
+            # Should be able to create ConnectionPool when HTTPX is available
+            from honeyhive.utils.connection_pool import ConnectionPool
+
+            pool = ConnectionPool()
+            assert pool is not None
+
+    def test_connection_pool_graceful_degradation(self):
+        """Test connection pool behavior when httpx is not available."""
+        # Save the current state
+        original_available = None
+        try:
+            from honeyhive.utils.connection_pool import HTTPX_AVAILABLE
+
+            original_available = HTTPX_AVAILABLE
+        except ImportError:
+            pass
+
+        # Test with HTTPX_AVAILABLE = False
+        with patch("honeyhive.utils.connection_pool.HTTPX_AVAILABLE", False):
+            with pytest.raises(ImportError, match="httpx is required"):
+                ConnectionPool()
+
+    def test_import_edge_cases(self):
+        """Test import edge cases and module availability."""
+        # Test that we can access the HTTPX_AVAILABLE flag
+        from honeyhive.utils.connection_pool import HTTPX_AVAILABLE
+
+        assert isinstance(HTTPX_AVAILABLE, bool)
+
+        # Test module constants exist
+        assert hasattr(
+            sys.modules.get("honeyhive.utils.connection_pool"), "HTTPX_AVAILABLE"
+        )
+
+        # Test that PoolConfig is always available regardless of HTTPX
+        from honeyhive.utils.connection_pool import PoolConfig
+
+        config = PoolConfig(max_connections=5)
+        assert config.max_connections == 5
+
+    def test_poolconfig_always_available(self):
+        """Test that PoolConfig is always available regardless of HTTPX."""
+        # PoolConfig should work regardless of HTTPX availability
+        from honeyhive.utils.connection_pool import PoolConfig
+
+        config = PoolConfig()
+        assert config is not None
+
+        # Test configuration parameters work
+        config = PoolConfig(max_connections=10)
+        assert config.max_connections == 10
+
+
+class TestConnectionPoolAsync:
+    """Test async functionality of ConnectionPool."""
+
+    @pytest.fixture
+    def pool_config(self):
+        """Create test pool configuration."""
+        return PoolConfig(
+            max_connections=5,
+            max_keepalive_connections=3,
+            keepalive_expiry=10.0,
+            timeout=15.0,
+        )
+
+    @pytest.fixture
+    def connection_pool(self, pool_config):
+        """Create test connection pool."""
+        with patch("honeyhive.utils.connection_pool.HTTPX_AVAILABLE", True):
+            return ConnectionPool(config=pool_config)
+
+    def test_get_async_client_new_connection(self, connection_pool):
+        """Test getting a new async client connection."""
+        base_url = "https://api.example.com"
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client_class.return_value = mock_client
+
+            with patch.object(
+                connection_pool, "_is_async_client_healthy", return_value=True
+            ):
+                client = connection_pool.get_async_client(base_url)
+
+                assert client == mock_client
+                assert base_url in connection_pool._async_clients
+                assert base_url in connection_pool._last_used
+                assert connection_pool._stats["connections_created"] == 1
+
+    def test_get_async_client_existing_healthy_connection(self, connection_pool):
+        """Test getting an existing healthy async client connection."""
+        base_url = "https://api.example.com"
+
+        # Setup existing client
+        existing_client = Mock()
+        connection_pool._async_clients[base_url] = existing_client
+        connection_pool._last_used[base_url] = time.time()
+
+        with patch.object(
+            connection_pool, "_is_async_client_healthy", return_value=True
+        ):
+            client = connection_pool.get_async_client(base_url)
+
+            assert client == existing_client
+            assert connection_pool._stats["pool_hits"] == 1
+            assert connection_pool._stats["connections_reused"] == 1
+
+    def test_get_async_client_unhealthy_connection(self, connection_pool):
+        """Test replacing unhealthy async client connection."""
+        base_url = "https://api.example.com"
+
+        # Setup existing unhealthy client
+        old_client = Mock()
+        connection_pool._async_clients[base_url] = old_client
+        connection_pool._last_used[base_url] = time.time()
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_new_client = Mock()
+            mock_client_class.return_value = mock_new_client
+
+            with patch.object(
+                connection_pool, "_is_async_client_healthy", return_value=False
+            ):
+                client = connection_pool.get_async_client(base_url)
+
+                assert client == mock_new_client
+                assert connection_pool._stats["pool_misses"] == 1
+                assert connection_pool._stats["connections_created"] == 1
+
+    def test_is_async_client_healthy_closed_client(self, connection_pool):
+        """Test health check for a closed async client."""
+        client = Mock()
+        client.is_closed = True
+
+        result = connection_pool._is_async_client_healthy(client)
+        assert result is False
+
+    def test_is_async_client_healthy_open_client(self, connection_pool):
+        """Test health check for an open async client."""
+        client = Mock()
+        client.is_closed = False
+
+        result = connection_pool._is_async_client_healthy(client)
+        assert result is True
+
+    def test_is_async_client_healthy_exception(self, connection_pool):
+        """Test health check when exception occurs."""
+        client = Mock()
+        client.is_closed = Mock(side_effect=Exception("Test error"))
+
+        result = connection_pool._is_async_client_healthy(client)
+        assert result is False
+
+    def test_get_async_connection_method(self, connection_pool):
+        """Test get_async_connection method."""
+        base_url = "https://api.example.com"
+
+        # Should return None when no connection exists
+        connection = connection_pool.get_async_connection(base_url)
+        assert connection is None
+
+        # Add a connection and test retrieval
+        mock_client = Mock()
+        connection_pool._async_clients[base_url] = mock_client
+        connection_pool._last_used[base_url] = time.time()
+
+        with patch.object(
+            connection_pool, "_is_async_client_healthy", return_value=True
+        ):
+            connection = connection_pool.get_async_connection(base_url)
+            assert connection == mock_client
+
+    def test_return_async_connection(self, connection_pool):
+        """Test returning an async connection to the pool."""
+        base_url = "https://api.example.com"
+        client = Mock()
+
+        connection_pool.return_async_connection(base_url, client)
+
+        assert base_url in connection_pool._async_clients
+        assert base_url in connection_pool._last_used
+
+    @pytest.mark.asyncio
+    async def test_async_context_manager(self, pool_config):
+        """Test async context manager functionality."""
+        with patch("honeyhive.utils.connection_pool.HTTPX_AVAILABLE", True):
+            async with ConnectionPool(config=pool_config) as pool:
+                assert isinstance(pool, ConnectionPool)
+
+                # Add some async clients to test cleanup
+                mock_client = AsyncMock()
+                pool._async_clients["test"] = mock_client
+
+            # Verify aclose was called
+            mock_client.aclose.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_aclose_all_clients(self, connection_pool):
+        """Test closing all async clients."""
+        # Setup async clients
+        client1 = AsyncMock()
+        client2 = AsyncMock()
+
+        connection_pool._async_clients["url1"] = client1
+        connection_pool._async_clients["url2"] = client2
+        connection_pool._last_used["url1"] = time.time()
+        connection_pool._last_used["url2"] = time.time()
+
+        await connection_pool.aclose_all_clients()
+
+        # Verify clients were closed
+        client1.aclose.assert_called_once()
+        client2.aclose.assert_called_once()
+        assert connection_pool._async_clients == {}
+
+    @pytest.mark.asyncio
+    async def test_aclose_all_clients_with_error(self, connection_pool):
+        """Test closing async clients when one throws an error."""
+        # Setup async clients
+        client1 = AsyncMock()
+        client2 = AsyncMock()
+        client1.aclose.side_effect = Exception("Close error")
+
+        connection_pool._async_clients["url1"] = client1
+        connection_pool._async_clients["url2"] = client2
+
+        # Should not raise exception
+        await connection_pool.aclose_all_clients()
+
+        # Both should have been attempted
+        client1.aclose.assert_called_once()
+        client2.aclose.assert_called_once()
+        assert connection_pool._async_clients == {}
+
+
+class TestConnectionPoolConcurrency:
+    """Test concurrent access and pool exhaustion."""
+
+    @pytest.fixture
+    def small_pool_config(self):
+        """Create config with small limits for testing."""
+        return PoolConfig(
+            max_connections=2,
+            max_keepalive_connections=1,
+            timeout=5.0,
+        )
+
+    @pytest.fixture
+    def connection_pool(self, small_pool_config):
+        """Create test connection pool with small limits."""
+        with patch("honeyhive.utils.connection_pool.HTTPX_AVAILABLE", True):
+            return ConnectionPool(config=small_pool_config)
+
+    def test_concurrent_get_client(self, connection_pool):
+        """Test concurrent access to get_client method."""
+        results = []
+        errors = []
+
+        def get_client_worker(base_url):
+            try:
+                with patch("httpx.Client") as mock_client_class:
+                    mock_client = Mock()
+                    mock_client_class.return_value = mock_client
+                    with patch.object(
+                        connection_pool, "_is_client_healthy", return_value=True
+                    ):
+                        client = connection_pool.get_client(base_url)
+                        results.append(client)
+            except Exception as e:
+                errors.append(e)
+
+        # Launch multiple threads trying to get clients
+        threads = []
+        for i in range(5):
+            thread = threading.Thread(
+                target=get_client_worker, args=(f"https://api{i}.example.com",)
+            )
+            threads.append(thread)
+            thread.start()
+
+        # Wait for all threads to complete
+        for thread in threads:
+            thread.join()
+
+        # Should have no errors and all results
+        assert len(errors) == 0
+        assert len(results) == 5
+        assert connection_pool._stats["total_requests"] >= 5
+
+    def test_concurrent_statistics_access(self, connection_pool):
+        """Test concurrent access to statistics."""
+        stats_results = []
+        errors = []
+
+        def stats_worker():
+            try:
+                for _ in range(10):
+                    stats = connection_pool.get_stats()
+                    stats_results.append(stats)
+                    time.sleep(0.001)  # Small delay
+            except Exception as e:
+                errors.append(e)
+
+        # Launch multiple threads accessing stats
+        threads = []
+        for _ in range(3):
+            thread = threading.Thread(target=stats_worker)
+            threads.append(thread)
+            thread.start()
+
+        # Wait for all threads to complete
+        for thread in threads:
+            thread.join()
+
+        # Should have no errors
+        assert len(errors) == 0
+        assert len(stats_results) == 30  # 3 threads * 10 calls each
+
+    def test_connection_reuse_verification(self, connection_pool):
+        """Test that connections are actually reused."""
+        base_url = "https://api.example.com"
+
+        with patch("httpx.Client") as mock_client_class:
+            mock_client = Mock()
+            mock_client_class.return_value = mock_client
+
+            with patch.object(connection_pool, "_is_client_healthy", return_value=True):
+                # First call creates client
+                client1 = connection_pool.get_client(base_url)
+                create_count = connection_pool._stats["connections_created"]
+
+                # Second call should reuse
+                client2 = connection_pool.get_client(base_url)
+
+                assert client1 == client2
+                assert (
+                    connection_pool._stats["connections_created"] == create_count
+                )  # No new creation
+                assert connection_pool._stats["connections_reused"] >= 1
+
+    def test_cleanup_during_concurrent_access(self, connection_pool):
+        """Test cleanup while other threads are accessing the pool."""
+        results = []
+        errors = []
+
+        def access_worker():
+            try:
+                for i in range(10):
+                    with patch("httpx.Client") as mock_client_class:
+                        mock_client = Mock()
+                        mock_client_class.return_value = mock_client
+                        with patch.object(
+                            connection_pool, "_is_client_healthy", return_value=True
+                        ):
+                            client = connection_pool.get_client(
+                                f"https://api{i}.example.com"
+                            )
+                            results.append(client)
+                            time.sleep(0.001)
+            except Exception as e:
+                errors.append(e)
+
+        def cleanup_worker():
+            try:
+                time.sleep(0.005)  # Let some connections be created
+                connection_pool.cleanup_idle_connections(max_idle_time=0.001)
+                connection_pool.cleanup()
+            except Exception as e:
+                errors.append(e)
+
+        # Launch access and cleanup threads
+        access_thread = threading.Thread(target=access_worker)
+        cleanup_thread = threading.Thread(target=cleanup_worker)
+
+        access_thread.start()
+        cleanup_thread.start()
+
+        access_thread.join()
+        cleanup_thread.join()
+
+        # Should complete without errors
+        assert len(errors) == 0
+
+
+class TestConnectionPoolErrorHandling:
+    """Test error conditions and edge cases."""
+
+    @pytest.fixture
+    def connection_pool(self):
+        """Create test connection pool."""
+        with patch("honeyhive.utils.connection_pool.HTTPX_AVAILABLE", True):
+            return ConnectionPool()
+
+    def test_get_client_unhealthy_connection_replacement(self, connection_pool):
+        """Test that unhealthy connections are replaced."""
+        base_url = "https://api.example.com"
+
+        # Setup existing unhealthy client
+        old_client = Mock()
+        connection_pool._clients[base_url] = old_client
+        connection_pool._last_used[base_url] = time.time()
+
+        with patch("httpx.Client") as mock_client_class:
+            mock_new_client = Mock()
+            mock_client_class.return_value = mock_new_client
+
+            # First call returns False (unhealthy), triggers replacement
+            with patch.object(
+                connection_pool, "_is_client_healthy", return_value=False
+            ):
+                client = connection_pool.get_client(base_url)
+
+                assert client == mock_new_client
+                assert (
+                    base_url not in connection_pool._clients
+                    or connection_pool._clients[base_url] == mock_new_client
+                )
+
+    def test_client_health_check_with_transport_details(self, connection_pool):
+        """Test client health check with transport details."""
+        # Test healthy client with transport
+        client = Mock()
+        client.is_closed = False
+
+        # Mock transport with connections
+        transport = Mock()
+        pool = Mock()
+        pool.connections = [Mock(), Mock()]  # Some connections available
+        transport.pool = pool
+        client._transport = transport
+
+        result = connection_pool._is_client_healthy(client)
+        assert result is True
+
+        # Test client with no connections
+        pool.connections = []
+        result = connection_pool._is_client_healthy(client)
+        assert result is False
+
+    def test_client_health_check_no_transport(self, connection_pool):
+        """Test client health check when transport is not accessible."""
+
+        # Create a simple object that mimics a client without transport details
+        class SimpleClient:
+            def __init__(self):
+                self.is_closed = False
+
+        client = SimpleClient()
+
+        result = connection_pool._is_client_healthy(client)
+        assert result is True  # Should assume healthy when details not accessible
+
+    def test_close_connection_with_error(self, connection_pool):
+        """Test closing connection when close() raises an error."""
+        base_url = "https://api.example.com"
+
+        # Setup client that raises error on close
+        client = Mock()
+        client.close.side_effect = Exception("Close error")
+        connection_pool._clients[base_url] = client
+        connection_pool._last_used[base_url] = time.time()
+
+        # Should not raise exception
+        connection_pool.close_connection(base_url)
+
+        # Connection should still be removed from pool
+        assert base_url not in connection_pool._clients
+        assert base_url not in connection_pool._last_used
+
+    def test_close_all_connections_with_errors(self, connection_pool):
+        """Test closing all connections when some raise errors."""
+        # Setup clients with one that raises error
+        client1 = Mock()
+        client2 = Mock()
+        client1.close.side_effect = Exception("Close error")
+
+        connection_pool._clients["url1"] = client1
+        connection_pool._clients["url2"] = client2
+
+        # Should not raise exception
+        connection_pool.close_all()
+
+        # All connections should be cleared
+        assert connection_pool._clients == {}
+        assert connection_pool._async_clients == {}
+        assert connection_pool._last_used == {}
+
+    def test_cleanup_expired_connections(self, connection_pool):
+        """Test cleanup of expired connections."""
+        base_url = "https://api.example.com"
+
+        # Setup expired connection
+        client = Mock()
+        connection_pool._clients[base_url] = client
+        connection_pool._last_used[base_url] = time.time() - 100  # Very old
+
+        # Set short expiry time
+        connection_pool.config.keepalive_expiry = 5.0
+
+        connection_pool.cleanup()
+
+        # Should be cleaned up
+        assert base_url not in connection_pool._clients
+        assert base_url not in connection_pool._last_used
+
+    def test_reset_stats(self, connection_pool):
+        """Test resetting pool statistics."""
+        # Set some stats
+        connection_pool._stats["total_requests"] = 10
+        connection_pool._stats["pool_hits"] = 5
+
+        connection_pool.reset_stats()
+
+        # All stats should be reset to 0
+        assert connection_pool._stats["total_requests"] == 0
+        assert connection_pool._stats["pool_hits"] == 0
+        assert connection_pool._stats["pool_misses"] == 0
+        assert connection_pool._stats["connections_created"] == 0
+        assert connection_pool._stats["connections_reused"] == 0
+
+    def test_active_connections_property(self, connection_pool):
+        """Test active_connections property."""
+        assert connection_pool.active_connections == 0
+
+        # Add some clients
+        connection_pool._clients["url1"] = Mock()
+        connection_pool._clients["url2"] = Mock()
+
+        assert connection_pool.active_connections == 2
+
+    def test_close_all_clients_alias(self, connection_pool):
+        """Test close_all_clients method (alias for close_all)."""
+        # Setup clients
+        client1 = Mock()
+        connection_pool._clients["url1"] = client1
+
+        connection_pool.close_all_clients()
+
+        assert connection_pool._clients == {}
+
+
+class TestPooledHTTPClient:
+    """Test PooledHTTPClient functionality."""
+
+    @pytest.fixture
+    def connection_pool(self):
+        """Create test connection pool."""
+        with patch("honeyhive.utils.connection_pool.HTTPX_AVAILABLE", True):
+            return ConnectionPool()
+
+    @pytest.fixture
+    def pooled_client(self, connection_pool):
+        """Create test pooled HTTP client."""
+        return PooledHTTPClient(connection_pool)
+
+    def test_get_request(self, pooled_client):
+        """Test GET request through pooled client."""
+        url = "https://api.example.com/data"
+
+        with patch.object(pooled_client.pool, "get_connection", return_value=None):
+            with patch("httpx.Client") as mock_client_class:
+                mock_client = Mock()
+                mock_response = Mock()
+                mock_response.status_code = 200
+                mock_client.get.return_value = mock_response
+                mock_client_class.return_value = mock_client
+
+                with patch.object(
+                    pooled_client.pool, "return_connection"
+                ) as mock_return:
+                    response = pooled_client.get(url)
+
+                    assert response == mock_response
+                    mock_client.get.assert_called_once_with(url)
+                    mock_return.assert_called_once()
+                    assert pooled_client.pool._stats["total_requests"] >= 1
+
+    def test_get_request_with_existing_client(self, pooled_client):
+        """Test GET request with existing client from pool."""
+        url = "https://api.example.com/data"
+
+        # Mock existing client in pool
+        existing_client = Mock()
+        mock_response = Mock()
+        mock_response.status_code = 200
+        existing_client.get.return_value = mock_response
+
+        with patch.object(
+            pooled_client.pool, "get_connection", return_value=existing_client
+        ):
+            with patch.object(pooled_client.pool, "return_connection") as mock_return:
+                response = pooled_client.get(url)
+
+                assert response == mock_response
+                existing_client.get.assert_called_once_with(url)
+                mock_return.assert_called_once_with(
+                    "https://api.example.com", existing_client
+                )
+
+    def test_post_request(self, pooled_client):
+        """Test POST request through pooled client."""
+        url = "https://api.example.com/data"
+        data = {"key": "value"}
+
+        with patch.object(pooled_client.pool, "get_connection", return_value=None):
+            with patch("httpx.Client") as mock_client_class:
+                mock_client = Mock()
+                mock_response = Mock()
+                mock_response.status_code = 201
+                mock_client.post.return_value = mock_response
+                mock_client_class.return_value = mock_client
+
+                with patch.object(pooled_client.pool, "return_connection"):
+                    response = pooled_client.post(url, json=data)
+
+                    assert response == mock_response
+                    mock_client.post.assert_called_once_with(url, json=data)
+
+    def test_put_request(self, pooled_client):
+        """Test PUT request through pooled client."""
+        url = "https://api.example.com/data/1"
+
+        with patch.object(pooled_client.pool, "get_connection", return_value=None):
+            with patch("httpx.Client") as mock_client_class:
+                mock_client = Mock()
+                mock_response = Mock()
+                mock_response.status_code = 200
+                mock_client.put.return_value = mock_response
+                mock_client_class.return_value = mock_client
+
+                with patch.object(pooled_client.pool, "return_connection"):
+                    response = pooled_client.put(url)
+
+                    assert response == mock_response
+                    mock_client.put.assert_called_once_with(url)
+
+    def test_delete_request(self, pooled_client):
+        """Test DELETE request through pooled client."""
+        url = "https://api.example.com/data/1"
+
+        with patch.object(pooled_client.pool, "get_connection", return_value=None):
+            with patch("httpx.Client") as mock_client_class:
+                mock_client = Mock()
+                mock_response = Mock()
+                mock_response.status_code = 204
+                mock_client.delete.return_value = mock_response
+                mock_client_class.return_value = mock_client
+
+                with patch.object(pooled_client.pool, "return_connection"):
+                    response = pooled_client.delete(url)
+
+                    assert response == mock_response
+                    mock_client.delete.assert_called_once_with(url)
+
+    def test_patch_request(self, pooled_client):
+        """Test PATCH request through pooled client."""
+        url = "https://api.example.com/data/1"
+        data = {"field": "updated"}
+
+        with patch.object(pooled_client.pool, "get_connection", return_value=None):
+            with patch("httpx.Client") as mock_client_class:
+                mock_client = Mock()
+                mock_response = Mock()
+                mock_response.status_code = 200
+                mock_client.patch.return_value = mock_response
+                mock_client_class.return_value = mock_client
+
+                with patch.object(pooled_client.pool, "return_connection"):
+                    response = pooled_client.patch(url, json=data)
+
+                    assert response == mock_response
+                    mock_client.patch.assert_called_once_with(url, json=data)
+
+    def test_request_error_handling(self, pooled_client):
+        """Test error handling in HTTP requests."""
+        url = "https://api.example.com/data"
+
+        with patch.object(pooled_client.pool, "get_connection", return_value=None):
+            with patch("httpx.Client") as mock_client_class:
+                mock_client = Mock()
+                mock_client.get.side_effect = httpx.RequestError("Network error")
+                mock_client_class.return_value = mock_client
+
+                with patch.object(
+                    pooled_client.pool, "return_connection"
+                ) as mock_return:
+                    with pytest.raises(httpx.RequestError):
+                        pooled_client.get(url)
+
+                    # Connection should still be returned even on error
+                    mock_return.assert_called_once()
+
+    def test_url_parsing_http_url(self, pooled_client):
+        """Test URL parsing for HTTP URLs."""
+        url = "http://localhost:8080/api/data"
+
+        with patch.object(pooled_client.pool, "get_connection", return_value=None):
+            with patch("httpx.Client") as mock_client_class:
+                mock_client = Mock()
+                mock_response = Mock()
+                mock_client.get.return_value = mock_response
+                mock_client_class.return_value = mock_client
+
+                with patch.object(
+                    pooled_client.pool, "return_connection"
+                ) as mock_return:
+                    pooled_client.get(url)
+
+                    # Should extract correct base URL
+                    mock_return.assert_called_once_with(
+                        "http://localhost:8080", mock_client
+                    )
+
+    def test_url_parsing_relative_url(self, pooled_client):
+        """Test URL parsing for relative URLs."""
+        url = "/api/data"
+
+        with patch.object(pooled_client.pool, "get_connection", return_value=None):
+            with patch("httpx.Client") as mock_client_class:
+                mock_client = Mock()
+                mock_response = Mock()
+                mock_client.get.return_value = mock_response
+                mock_client_class.return_value = mock_client
+
+                with patch.object(
+                    pooled_client.pool, "return_connection"
+                ) as mock_return:
+                    pooled_client.get(url)
+
+                    # Should use default base URL
+                    mock_return.assert_called_once_with("http://localhost", mock_client)
+
+
+class TestPooledAsyncHTTPClient:
+    """Test PooledAsyncHTTPClient functionality."""
+
+    @pytest.fixture
+    def connection_pool(self):
+        """Create test connection pool."""
+        with patch("honeyhive.utils.connection_pool.HTTPX_AVAILABLE", True):
+            return ConnectionPool()
+
+    @pytest.fixture
+    def pooled_async_client(self, connection_pool):
+        """Create test pooled async HTTP client."""
+        return PooledAsyncHTTPClient(connection_pool)
+
+    @pytest.mark.asyncio
+    async def test_async_get_request(self, pooled_async_client):
+        """Test async GET request through pooled client."""
+        url = "https://api.example.com/data"
+
+        with patch.object(
+            pooled_async_client.pool, "get_async_connection", return_value=None
+        ):
+            with patch("httpx.AsyncClient") as mock_client_class:
+                mock_client = AsyncMock()
+                mock_response = Mock()
+                mock_response.status_code = 200
+                mock_client.get.return_value = mock_response
+                mock_client_class.return_value = mock_client
+
+                with patch.object(
+                    pooled_async_client.pool, "return_async_connection"
+                ) as mock_return:
+                    response = await pooled_async_client.get(url)
+
+                    assert response == mock_response
+                    mock_client.get.assert_called_once_with(url)
+                    mock_return.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_async_post_request(self, pooled_async_client):
+        """Test async POST request through pooled client."""
+        url = "https://api.example.com/data"
+        data = {"key": "value"}
+
+        with patch.object(
+            pooled_async_client.pool, "get_async_connection", return_value=None
+        ):
+            with patch("httpx.AsyncClient") as mock_client_class:
+                mock_client = AsyncMock()
+                mock_response = Mock()
+                mock_response.status_code = 201
+                mock_client.post.return_value = mock_response
+                mock_client_class.return_value = mock_client
+
+                with patch.object(pooled_async_client.pool, "return_async_connection"):
+                    response = await pooled_async_client.post(url, json=data)
+
+                    assert response == mock_response
+                    mock_client.post.assert_called_once_with(url, json=data)
+
+    @pytest.mark.asyncio
+    async def test_async_put_request(self, pooled_async_client):
+        """Test async PUT request through pooled client."""
+        url = "https://api.example.com/data/1"
+
+        with patch.object(
+            pooled_async_client.pool, "get_async_connection", return_value=None
+        ):
+            with patch("httpx.AsyncClient") as mock_client_class:
+                mock_client = AsyncMock()
+                mock_response = Mock()
+                mock_response.status_code = 200
+                mock_client.put.return_value = mock_response
+                mock_client_class.return_value = mock_client
+
+                with patch.object(pooled_async_client.pool, "return_async_connection"):
+                    response = await pooled_async_client.put(url)
+
+                    assert response == mock_response
+                    mock_client.put.assert_called_once_with(url)
+
+    @pytest.mark.asyncio
+    async def test_async_delete_request(self, pooled_async_client):
+        """Test async DELETE request through pooled client."""
+        url = "https://api.example.com/data/1"
+
+        with patch.object(
+            pooled_async_client.pool, "get_async_connection", return_value=None
+        ):
+            with patch("httpx.AsyncClient") as mock_client_class:
+                mock_client = AsyncMock()
+                mock_response = Mock()
+                mock_response.status_code = 204
+                mock_client.delete.return_value = mock_response
+                mock_client_class.return_value = mock_client
+
+                with patch.object(pooled_async_client.pool, "return_async_connection"):
+                    response = await pooled_async_client.delete(url)
+
+                    assert response == mock_response
+                    mock_client.delete.assert_called_once_with(url)
+
+    @pytest.mark.asyncio
+    async def test_async_patch_request(self, pooled_async_client):
+        """Test async PATCH request through pooled client."""
+        url = "https://api.example.com/data/1"
+        data = {"field": "updated"}
+
+        with patch.object(
+            pooled_async_client.pool, "get_async_connection", return_value=None
+        ):
+            with patch("httpx.AsyncClient") as mock_client_class:
+                mock_client = AsyncMock()
+                mock_response = Mock()
+                mock_response.status_code = 200
+                mock_client.patch.return_value = mock_response
+                mock_client_class.return_value = mock_client
+
+                with patch.object(pooled_async_client.pool, "return_async_connection"):
+                    response = await pooled_async_client.patch(url, json=data)
+
+                    assert response == mock_response
+                    mock_client.patch.assert_called_once_with(url, json=data)
+
+    @pytest.mark.asyncio
+    async def test_async_request_error_handling(self, pooled_async_client):
+        """Test error handling in async HTTP requests."""
+        url = "https://api.example.com/data"
+
+        with patch.object(
+            pooled_async_client.pool, "get_async_connection", return_value=None
+        ):
+            with patch("httpx.AsyncClient") as mock_client_class:
+                mock_client = AsyncMock()
+                mock_client.get.side_effect = httpx.RequestError("Network error")
+                mock_client_class.return_value = mock_client
+
+                with patch.object(
+                    pooled_async_client.pool, "return_async_connection"
+                ) as mock_return:
+                    with pytest.raises(httpx.RequestError):
+                        await pooled_async_client.get(url)
+
+                    # Connection should still be returned even on error
+                    mock_return.assert_called_once()
+
+
+class TestGlobalPool:
+    """Test global pool management functions."""
+
+    def test_get_global_pool_creates_new(self):
+        """Test that get_global_pool creates a new pool when none exists."""
+        # Ensure no global pool exists
+        close_global_pool()
+
+        with patch("honeyhive.utils.connection_pool.HTTPX_AVAILABLE", True):
+            pool = get_global_pool()
+            assert isinstance(pool, ConnectionPool)
+
+    def test_get_global_pool_returns_existing(self):
+        """Test get_global_pool returns new instances (deprecated behavior)."""
+        # Note: get_global_pool now returns new instances for multi-instance compatibility
+        close_global_pool()
+
+        with patch("honeyhive.utils.connection_pool.HTTPX_AVAILABLE", True):
+            pool1 = get_global_pool()
+            pool2 = get_global_pool()
+            # After refactor: each call returns a new instance to prevent deadlocks
+            assert pool1 is not pool2
+            assert isinstance(pool1, ConnectionPool)
+            assert isinstance(pool2, ConnectionPool)
+
+    def test_get_global_pool_with_config(self):
+        """Test get_global_pool with custom config."""
+        # Ensure no global pool exists
+        close_global_pool()
+
+        config = PoolConfig(max_connections=50)
+
+        with patch("honeyhive.utils.connection_pool.HTTPX_AVAILABLE", True):
+            pool = get_global_pool(config)
+            assert pool.config.max_connections == 50
+
+    def test_close_global_pool(self):
+        """Test closing global pool (deprecated no-op behavior)."""
+        with patch("honeyhive.utils.connection_pool.HTTPX_AVAILABLE", True):
+            # Create global pool
+            pool = get_global_pool()
+
+            # After refactor: close_global_pool is now a no-op for multi-instance compatibility
+            # Each ConnectionPool is closed when its parent client is garbage collected
+            close_global_pool()  # Should not raise any exceptions
+
+            # Verify the pool is still functional (not closed by the no-op function)
+            assert isinstance(pool, ConnectionPool)
+
+    def test_close_global_pool_when_none_exists(self):
+        """Test closing global pool when none exists."""
+        # Ensure no global pool exists
+        close_global_pool()
+
+        # Should not raise error
+        close_global_pool()
+
+
+class TestConnectionPoolStatistics:
+    """Test pool statistics and monitoring functionality."""
+
+    @pytest.fixture
+    def connection_pool(self):
+        """Create test connection pool."""
+        with patch("honeyhive.utils.connection_pool.HTTPX_AVAILABLE", True):
+            return ConnectionPool()
+
+    def test_initial_statistics(self, connection_pool):
+        """Test initial statistics values."""
+        stats = connection_pool.get_stats()
+
+        assert stats["total_requests"] == 0
+        assert stats["pool_hits"] == 0
+        assert stats["pool_misses"] == 0
+        assert stats["connections_created"] == 0
+        assert stats["connections_reused"] == 0
+        assert stats["active_connections"] == 0
+        assert stats["active_async_connections"] == 0
+        assert stats["total_connections"] == 0
+
+    def test_statistics_update_on_new_connection(self, connection_pool):
+        """Test statistics update when creating new connections."""
+        base_url = "https://api.example.com"
+
+        with patch("httpx.Client") as mock_client_class:
+            mock_client = Mock()
+            mock_client_class.return_value = mock_client
+
+            with patch.object(connection_pool, "_is_client_healthy", return_value=True):
+                connection_pool.get_client(base_url)
+
+                stats = connection_pool.get_stats()
+                assert stats["total_requests"] == 1
+                assert stats["pool_misses"] == 1
+                assert stats["connections_created"] == 1
+                assert stats["active_connections"] == 1
+
+    def test_statistics_update_on_connection_reuse(self, connection_pool):
+        """Test statistics update when reusing connections."""
+        base_url = "https://api.example.com"
+
+        # Setup existing client
+        existing_client = Mock()
+        connection_pool._clients[base_url] = existing_client
+        connection_pool._last_used[base_url] = time.time()
+
+        with patch.object(connection_pool, "_is_client_healthy", return_value=True):
+            connection_pool.get_client(base_url)
+
+            stats = connection_pool.get_stats()
+            assert stats["pool_hits"] == 1
+            assert stats["connections_reused"] == 1
+
+    def test_statistics_with_mixed_connections(self, connection_pool):
+        """Test statistics with both sync and async connections."""
+        # Add sync client
+        connection_pool._clients["sync"] = Mock()
+
+        # Add async client
+        connection_pool._async_clients["async"] = Mock()
+
+        stats = connection_pool.get_stats()
+        assert stats["active_connections"] == 1
+        assert stats["active_async_connections"] == 1
+        assert stats["total_connections"] == 2

--- a/tests_v2/unit/test_utils_dotdict.py
+++ b/tests_v2/unit/test_utils_dotdict.py
@@ -1,0 +1,651 @@
+"""Unit tests for DotDict utility class.
+
+Comprehensive test suite for the DotDict class that provides dictionary access
+with dot notation support. Tests all methods, edge cases, and error conditions.
+
+Test Coverage:
+- Initialization patterns (dict, kwargs, mixed)
+- Attribute access (__getattr__, __setattr__, __delattr__)
+- Item access (__getitem__, __setitem__ with dot notation)
+- Dictionary methods (get, setdefault, update)
+- Conversion methods (to_dict, copy, deepcopy)
+- Nested dictionary handling and conversion
+- Error conditions and edge cases
+
+Following Agent OS testing standards with proper fixtures and isolation.
+Generated using enhanced comprehensive analysis framework for 90%+ coverage.
+"""
+
+# pylint: disable=too-many-lines,line-too-long,redefined-outer-name,no-member
+# Reason: Comprehensive testing file requires extensive test coverage for 90%+ target
+# Line length disabled for test readability and comprehensive assertions
+# Redefined outer name disabled for pytest fixture usage pattern
+# No-member disabled for DotDict attribute access (false positives)
+
+from typing import Any, Dict
+
+import pytest
+
+from honeyhive.utils.dotdict import DotDict
+
+
+class TestDotDictInitialization:
+    """Test cases for DotDict initialization patterns."""
+
+    def test_init_empty(self) -> None:
+        """Test DotDict initialization with no arguments."""
+        dotdict = DotDict()
+
+        assert len(dotdict) == 0
+        assert isinstance(dotdict, dict)
+        assert isinstance(dotdict, DotDict)
+
+    def test_init_with_dict(self) -> None:
+        """Test DotDict initialization with dictionary argument."""
+        data: Dict[str, Any] = {"foo": "bar", "nested": {"key": "value"}}
+        dotdict = DotDict(data)
+
+        assert dotdict.foo == "bar"
+        assert isinstance(dotdict.nested, DotDict)
+        assert dotdict.nested.key == "value"
+
+    def test_init_with_kwargs(self) -> None:
+        """Test DotDict initialization with keyword arguments."""
+        dotdict = DotDict(foo="bar", nested={"key": "value"})
+
+        assert dotdict.foo == "bar"
+        assert isinstance(dotdict.nested, DotDict)
+        assert dotdict.nested.key == "value"
+
+    def test_init_with_dict_and_kwargs(self) -> None:
+        """Test DotDict initialization with both dict and kwargs."""
+        data: Dict[str, Any] = {"a": 1, "b": 2}
+        dotdict = DotDict(data, c=3, d=4)
+
+        assert dotdict.a == 1
+        assert dotdict.b == 2
+        assert dotdict.c == 3
+        assert dotdict.d == 4
+
+    def test_init_nested_dict_conversion(self) -> None:
+        """Test that nested dictionaries are converted to DotDict instances."""
+        data: Dict[str, Any] = {"level1": {"level2": {"level3": "value"}}}
+        dotdict = DotDict(data)
+
+        assert isinstance(dotdict.level1, DotDict)
+        assert isinstance(dotdict.level1.level2, DotDict)
+        assert dotdict.level1.level2.level3 == "value"
+
+    def test_init_mixed_nested_types(self) -> None:
+        """Test initialization with mixed nested types."""
+        data: Dict[str, Any] = {
+            "string": "value",
+            "number": 42,
+            "list": [1, 2, 3],
+            "dict": {"nested": "value"},
+            "none": None,
+        }
+        dotdict = DotDict(data)
+
+        assert dotdict.string == "value"
+        assert dotdict.number == 42
+        assert dotdict.list == [1, 2, 3]
+        assert isinstance(dotdict.dict, DotDict)
+        assert dotdict.dict.nested == "value"
+        assert dotdict.none is None
+
+
+class TestDotDictAttributeAccess:
+    """Test cases for attribute-style access methods."""
+
+    def test_getattr_success(self) -> None:
+        """Test successful attribute access."""
+        dotdict = DotDict({"foo": "bar"})
+
+        assert dotdict.foo == "bar"
+
+    def test_getattr_missing_key(self) -> None:
+        """Test attribute access for missing key raises AttributeError."""
+        dotdict = DotDict({"foo": "bar"})
+
+        with pytest.raises(
+            AttributeError, match="'DotDict' object has no attribute 'missing'"
+        ):
+            _ = dotdict.missing
+
+    def test_getattr_nested_access(self) -> None:
+        """Test attribute access for nested DotDict instances."""
+        dotdict = DotDict({"nested": {"key": "value"}})
+
+        assert isinstance(dotdict.nested, DotDict)
+        assert dotdict.nested.key == "value"
+
+    def test_setattr_new_key(self) -> None:
+        """Test setting new attribute creates dictionary entry."""
+        dotdict = DotDict()
+        dotdict.new_key = "new_value"
+
+        assert dotdict.new_key == "new_value"
+        assert dotdict["new_key"] == "new_value"
+
+    def test_setattr_existing_key(self) -> None:
+        """Test setting existing attribute updates value."""
+        dotdict = DotDict({"existing": "old_value"})
+        dotdict.existing = "new_value"
+
+        assert dotdict.existing == "new_value"
+        assert dotdict["existing"] == "new_value"
+
+    def test_setattr_dict_value_conversion(self) -> None:
+        """Test setting attribute with dict value converts to DotDict."""
+        dotdict = DotDict()
+        dotdict.nested = {"key": "value"}
+
+        assert isinstance(dotdict.nested, DotDict)
+        assert dotdict.nested.key == "value"
+
+    def test_setattr_nested_dict_conversion(self) -> None:
+        """Test setting deeply nested dict converts all levels."""
+        dotdict = DotDict()
+        dotdict.deep = {"level1": {"level2": {"level3": "value"}}}
+
+        assert isinstance(dotdict.deep, DotDict)
+        assert isinstance(dotdict.deep.level1, DotDict)
+        assert isinstance(dotdict.deep.level1.level2, DotDict)
+        assert dotdict.deep.level1.level2.level3 == "value"
+
+    def test_delattr_success(self) -> None:
+        """Test successful attribute deletion."""
+        dotdict = DotDict({"foo": "bar", "other": "value"})
+        del dotdict.foo
+
+        assert "foo" not in dotdict
+        assert dotdict.other == "value"
+
+    def test_delattr_missing_key(self) -> None:
+        """Test deletion of missing attribute raises AttributeError."""
+        dotdict = DotDict({"foo": "bar"})
+
+        with pytest.raises(
+            AttributeError, match="'DotDict' object has no attribute 'missing'"
+        ):
+            del dotdict.missing
+
+
+class TestDotDictItemAccess:
+    """Test cases for item-style access methods."""
+
+    def test_getitem_simple(self) -> None:
+        """Test simple item access."""
+        dotdict = DotDict({"foo": "bar"})
+
+        assert dotdict["foo"] == "bar"
+
+    def test_getitem_missing_key(self) -> None:
+        """Test item access for missing key raises KeyError."""
+        dotdict = DotDict({"foo": "bar"})
+
+        with pytest.raises(KeyError):
+            _ = dotdict["missing"]
+
+    def test_getitem_dot_notation(self) -> None:
+        """Test item access with dot notation."""
+        dotdict = DotDict({"nested": {"key": "value"}})
+
+        assert dotdict["nested.key"] == "value"
+
+    def test_getitem_deep_dot_notation(self) -> None:
+        """Test deep dot notation access."""
+        dotdict = DotDict({"level1": {"level2": {"level3": "value"}}})
+
+        assert dotdict["level1.level2.level3"] == "value"
+
+    def test_getitem_missing_dot_notation(self) -> None:
+        """Test item access for missing dot notation key."""
+        dotdict = DotDict({"nested": {"key": "value"}})
+
+        with pytest.raises(KeyError):
+            _ = dotdict["nested.missing"]
+
+    def test_getitem_partial_missing_dot_notation(self) -> None:
+        """Test dot notation with missing intermediate keys."""
+        dotdict = DotDict({"nested": {"key": "value"}})
+
+        with pytest.raises(KeyError):
+            _ = dotdict["missing.key"]
+
+    def test_setitem_simple(self) -> None:
+        """Test simple item setting."""
+        dotdict = DotDict()
+        dotdict["foo"] = "bar"
+
+        assert dotdict.foo == "bar"
+        assert dotdict["foo"] == "bar"
+
+    def test_setitem_dict_value_conversion(self) -> None:
+        """Test setting item with dict value converts to DotDict."""
+        dotdict = DotDict()
+        dotdict["nested"] = {"key": "value"}
+
+        assert isinstance(dotdict.nested, DotDict)
+        assert dotdict.nested.key == "value"
+
+    def test_setitem_dot_notation_creates_structure(self) -> None:
+        """Test setting item with dot notation creates nested structure."""
+        dotdict = DotDict()
+        dotdict["nested.key"] = "value"
+
+        assert isinstance(dotdict.nested, DotDict)
+        assert dotdict.nested.key == "value"
+
+    def test_setitem_deep_dot_notation(self) -> None:
+        """Test setting item with deep dot notation."""
+        dotdict = DotDict()
+        dotdict["level1.level2.level3"] = "value"
+
+        assert isinstance(dotdict.level1, DotDict)
+        assert isinstance(dotdict.level1.level2, DotDict)
+        assert dotdict.level1.level2.level3 == "value"
+
+    def test_setitem_existing_dot_notation(self) -> None:
+        """Test setting existing dot notation path updates value."""
+        dotdict = DotDict({"nested": {"key": "old_value"}})
+        dotdict["nested.key"] = "new_value"
+
+        assert dotdict.nested.key == "new_value"
+
+    def test_setitem_partial_existing_dot_notation(self) -> None:
+        """Test setting dot notation with partially existing path."""
+        dotdict = DotDict({"nested": {"existing": "value"}})
+        dotdict["nested.new_key"] = "new_value"
+
+        assert dotdict.nested.existing == "value"
+        assert dotdict.nested.new_key == "new_value"
+
+
+class TestDotDictDictionaryMethods:
+    """Test cases for dictionary method implementations."""
+
+    def test_get_with_existing_key(self) -> None:
+        """Test get method with existing key."""
+        dotdict = DotDict({"foo": "bar"})
+
+        assert dotdict.get("foo") == "bar"
+
+    def test_get_with_missing_key_no_default(self) -> None:
+        """Test get method with missing key returns None."""
+        dotdict = DotDict({"foo": "bar"})
+
+        assert dotdict.get("missing") is None
+
+    def test_get_with_missing_key_with_default(self) -> None:
+        """Test get method with missing key returns default."""
+        dotdict = DotDict({"foo": "bar"})
+
+        assert dotdict.get("missing", "default") == "default"
+
+    def test_get_with_dot_notation(self) -> None:
+        """Test get method with dot notation."""
+        dotdict = DotDict({"nested": {"key": "value"}})
+
+        assert dotdict.get("nested.key") == "value"
+
+    def test_get_with_missing_dot_notation(self) -> None:
+        """Test get method with missing dot notation returns default."""
+        dotdict = DotDict({"nested": {"key": "value"}})
+
+        assert dotdict.get("nested.missing", "default") == "default"
+
+    def test_get_with_partial_missing_dot_notation(self) -> None:
+        """Test get method with missing intermediate dot notation."""
+        dotdict = DotDict({"nested": {"key": "value"}})
+
+        assert dotdict.get("missing.path", "default") == "default"
+
+    def test_setdefault_new_key(self) -> None:
+        """Test setdefault with new key sets and returns default."""
+        dotdict = DotDict()
+        result = dotdict.setdefault("new_key", "default_value")
+
+        assert result == "default_value"
+        assert dotdict.new_key == "default_value"
+
+    def test_setdefault_existing_key(self) -> None:
+        """Test setdefault with existing key returns existing value."""
+        dotdict = DotDict({"existing": "value"})
+        result = dotdict.setdefault("existing", "default_value")
+
+        assert result == "value"
+        assert dotdict.existing == "value"
+
+    def test_setdefault_dot_notation_new(self) -> None:
+        """Test setdefault with dot notation creates nested structure."""
+        dotdict = DotDict()
+        result = dotdict.setdefault("nested.key", "value")
+
+        assert result == "value"
+        assert isinstance(dotdict.nested, DotDict)
+        assert dotdict.nested.key == "value"
+
+    def test_setdefault_dot_notation_existing(self) -> None:
+        """Test setdefault with existing dot notation path."""
+        dotdict = DotDict({"nested": {"key": "existing_value"}})
+        result = dotdict.setdefault("nested.key", "default_value")
+
+        assert result == "existing_value"
+        assert dotdict.nested.key == "existing_value"
+
+    def test_setdefault_none_default(self) -> None:
+        """Test setdefault with None as default value."""
+        dotdict = DotDict()
+        result = dotdict.setdefault("key", None)
+
+        assert result is None
+        assert dotdict.key is None
+
+    def test_update_with_dict(self) -> None:
+        """Test update method with dictionary."""
+        dotdict = DotDict({"existing": "value"})
+        dotdict.update({"new_key": "new_value", "existing": "updated"})
+
+        assert dotdict.existing == "updated"
+        assert dotdict.new_key == "new_value"
+
+    def test_update_with_kwargs(self) -> None:
+        """Test update method with keyword arguments."""
+        dotdict = DotDict({"existing": "value"})
+        dotdict.update(new_key="new_value", existing="updated")
+
+        assert dotdict.existing == "updated"
+        assert dotdict.new_key == "new_value"
+
+    def test_update_with_dict_and_kwargs(self) -> None:
+        """Test update method with both dict and kwargs."""
+        dotdict = DotDict({"existing": "value"})
+        dotdict.update({"dict_key": "dict_value"}, kwargs_key="kwargs_value")
+
+        assert dotdict.existing == "value"
+        assert dotdict.dict_key == "dict_value"
+        assert dotdict.kwargs_key == "kwargs_value"
+
+    def test_update_with_nested_dict(self) -> None:
+        """Test update method with nested dictionary converts to DotDict."""
+        dotdict = DotDict()
+        dotdict.update({"nested": {"key": "value"}})
+
+        assert isinstance(dotdict.nested, DotDict)
+        assert dotdict.nested.key == "value"
+
+    def test_update_none_other(self) -> None:
+        """Test update method with None as other parameter."""
+        dotdict = DotDict({"existing": "value"})
+        dotdict.update(None, new_key="new_value")
+
+        assert dotdict.existing == "value"
+        assert dotdict.new_key == "new_value"
+
+
+class TestDotDictConversionMethods:
+    """Test cases for conversion and copying methods."""
+
+    def test_to_dict_simple(self) -> None:
+        """Test to_dict method with simple data."""
+        data: Dict[str, Any] = {"foo": "bar", "number": 42}
+        dotdict = DotDict(data)
+        result = dotdict.to_dict()
+
+        assert result == data
+        assert isinstance(result, dict)
+        assert not isinstance(result, DotDict)
+
+    def test_to_dict_nested(self) -> None:
+        """Test to_dict method with nested DotDict instances."""
+        data: Dict[str, Any] = {"nested": {"key": "value", "deep": {"level": "data"}}}
+        dotdict = DotDict(data)
+        result = dotdict.to_dict()
+
+        assert result == data
+        assert isinstance(result["nested"], dict)
+        assert not isinstance(result["nested"], DotDict)
+        assert isinstance(result["nested"]["deep"], dict)
+        assert not isinstance(result["nested"]["deep"], DotDict)
+
+    def test_to_dict_mixed_types(self) -> None:
+        """Test to_dict method preserves non-dict types."""
+        data: Dict[str, Any] = {
+            "string": "value",
+            "number": 42,
+            "list": [1, 2, 3],
+            "dict": {"nested": "value"},
+            "none": None,
+        }
+        dotdict = DotDict(data)
+        result = dotdict.to_dict()
+
+        assert result["string"] == "value"
+        assert result["number"] == 42
+        assert result["list"] == [1, 2, 3]
+        assert isinstance(result["dict"], dict)
+        assert not isinstance(result["dict"], DotDict)
+        assert result["none"] is None
+
+    def test_copy_shallow(self) -> None:
+        """Test shallow copy method."""
+        original = DotDict({"nested": {"key": "value"}})
+        copied = original.copy()
+
+        assert copied is not original
+        assert isinstance(copied, DotDict)
+        assert copied.nested.key == "value"
+        # Nested objects are new DotDict instances due to initialization
+        assert copied.nested is not original.nested
+
+    def test_copy_independence(self) -> None:
+        """Test that shallow copy creates independent top-level structure."""
+        original = DotDict({"top": "value", "nested": {"key": "value"}})
+        copied = original.copy()
+
+        copied.top = "modified"
+        copied.new_key = "new"
+
+        assert original.top == "value"
+        assert "new_key" not in original
+        assert copied.top == "modified"
+        assert copied.new_key == "new"
+
+    def test_deepcopy_complete_independence(self) -> None:
+        """Test deep copy method creates completely independent copy."""
+        original = DotDict({"nested": {"key": "value"}})
+        copied = original.deepcopy()
+
+        assert copied is not original
+        assert isinstance(copied, DotDict)
+        assert copied.nested.key == "value"
+        assert copied.nested is not original.nested
+
+    def test_deepcopy_modification_independence(self) -> None:
+        """Test that deep copy modifications don't affect original."""
+        original = DotDict({"nested": {"key": "value", "list": [1, 2, 3]}})
+        copied = original.deepcopy()
+
+        copied.nested.key = "modified"
+        copied.nested.list.append(4)
+
+        assert original.nested.key == "value"
+        assert original.nested.list == [1, 2, 3]
+        assert copied.nested.key == "modified"
+        assert copied.nested.list == [1, 2, 3, 4]
+
+
+class TestDotDictInheritanceBehavior:
+    """Test cases for dict inheritance behavior."""
+
+    def test_dict_methods_available(self) -> None:
+        """Test that standard dict methods are available."""
+        dotdict = DotDict({"a": 1, "b": 2, "c": 3})
+
+        assert len(dotdict) == 3
+        assert "a" in dotdict
+        assert "d" not in dotdict
+        assert list(dotdict.keys()) == ["a", "b", "c"]
+        assert list(dotdict.values()) == [1, 2, 3]
+        assert list(dotdict.items()) == [("a", 1), ("b", 2), ("c", 3)]
+
+    def test_dict_iteration(self) -> None:
+        """Test that iteration works like standard dict."""
+        dotdict = DotDict({"a": 1, "b": 2})
+        keys = []
+
+        for key in dotdict:
+            keys.append(key)
+
+        assert keys == ["a", "b"]
+
+    def test_dict_bool_conversion(self) -> None:
+        """Test boolean conversion behavior."""
+        empty_dotdict = DotDict()
+        filled_dotdict = DotDict({"key": "value"})
+
+        assert not empty_dotdict
+        assert bool(filled_dotdict)
+
+    def test_dict_equality(self) -> None:
+        """Test equality comparison with regular dicts."""
+        dotdict = DotDict({"a": 1, "b": 2})
+        regular_dict = {"a": 1, "b": 2}
+
+        assert dotdict == regular_dict
+        assert regular_dict == dotdict
+
+    def test_dict_string_representation(self) -> None:
+        """Test string representation includes DotDict type."""
+        dotdict = DotDict({"a": 1})
+        str_repr = str(dotdict)
+
+        # Should contain the data, exact format may vary
+        assert "a" in str_repr
+        assert "1" in str_repr
+
+
+class TestDotDictEdgeCases:
+    """Test cases for edge cases and error conditions."""
+
+    def test_empty_key_access(self) -> None:
+        """Test behavior with empty string keys."""
+        dotdict = DotDict()
+        dotdict[""] = "empty_key_value"
+
+        assert dotdict[""] == "empty_key_value"
+        assert dotdict.get("") == "empty_key_value"
+
+    def test_empty_dot_notation_raises_error(self) -> None:
+        """Test that empty dot notation raises KeyError."""
+        dotdict = DotDict({"key": "value"})
+
+        with pytest.raises(KeyError):
+            _ = dotdict[""]
+
+    def test_dot_notation_with_empty_segments(self) -> None:
+        """Test dot notation with empty segments raises appropriate errors."""
+        dotdict = DotDict({"key": "value"})
+
+        with pytest.raises(KeyError):
+            _ = dotdict[".."]
+
+        # This will raise TypeError because "value" is a string, not a dict
+        with pytest.raises(TypeError):
+            _ = dotdict["key..other"]
+
+    def test_none_values(self) -> None:
+        """Test handling of None values."""
+        dotdict = DotDict()
+        dotdict.none_value = None
+        dotdict["none_key"] = None
+
+        assert dotdict.none_value is None
+        assert dotdict["none_key"] is None
+        assert dotdict.get("none_value") is None
+
+    def test_numeric_string_keys(self) -> None:
+        """Test handling of numeric string keys."""
+        dotdict = DotDict({"123": "numeric_key", "0": "zero"})
+
+        assert dotdict["123"] == "numeric_key"
+        assert dotdict["0"] == "zero"
+
+    def test_special_character_keys(self) -> None:
+        """Test handling of keys with special characters."""
+        dotdict = DotDict(
+            {"key-with-dashes": "value1", "key_with_underscores": "value2"}
+        )
+
+        assert dotdict["key-with-dashes"] == "value1"
+        assert dotdict["key_with_underscores"] == "value2"
+
+    def test_overwrite_dict_methods_as_attributes(self) -> None:
+        """Test that dict method names can be used as keys."""
+        dotdict = DotDict()
+        dotdict["keys"] = "not_a_method"
+        dotdict["items"] = "also_not_a_method"
+
+        # Should be able to access as dictionary items
+        assert dotdict["keys"] == "not_a_method"
+        assert dotdict["items"] == "also_not_a_method"
+
+        # Dict methods should still work
+        assert "keys" in dotdict
+        assert "items" in dotdict
+        assert len(list(dotdict.keys())) == 2
+
+    def test_complex_nested_operations(self) -> None:
+        """Test complex nested operations and modifications."""
+        dotdict = DotDict()
+
+        # Create nested structure
+        dotdict["a.b.c"] = "value1"
+        dotdict["x.y.z"] = "value2"
+
+        # Verify structure
+        assert dotdict.a.b.c == "value1"
+        assert dotdict.x.y.z == "value2"
+
+        # Update nested values
+        dotdict.a.b.c = "new_value1"
+        dotdict["x.y.z"] = "new_value2"
+
+        assert dotdict.a.b.c == "new_value1"
+        assert dotdict.x.y.z == "new_value2"
+
+        # Add to existing nested structure
+        dotdict.a.b.d = "additional"
+        dotdict["x.y.w"] = "more"
+
+        assert dotdict.a.b.d == "additional"
+        assert dotdict.x.y.w == "more"
+        assert dotdict.a.b.c == "new_value1"  # Existing values preserved
+
+    def test_attribute_error_message_format(self) -> None:
+        """Test that AttributeError messages are properly formatted."""
+        dotdict = DotDict({"existing": "value"})
+
+        with pytest.raises(AttributeError) as exc_info:
+            _ = dotdict.nonexistent
+
+        error_message = str(exc_info.value)
+        assert "'DotDict' object has no attribute 'nonexistent'" in error_message
+
+    def test_key_error_propagation(self) -> None:
+        """Test that KeyError is properly propagated for missing keys."""
+        dotdict = DotDict({"nested": {"key": "value"}})
+
+        # Simple missing key
+        with pytest.raises(KeyError):
+            _ = dotdict["missing"]
+
+        # Missing in dot notation
+        with pytest.raises(KeyError):
+            _ = dotdict["nested.missing"]
+
+        # Missing intermediate in dot notation
+        with pytest.raises(KeyError):
+            _ = dotdict["missing.key"]

--- a/tests_v2/unit/test_utils_error_handler.py
+++ b/tests_v2/unit/test_utils_error_handler.py
@@ -1,0 +1,1221 @@
+"""Unit tests for honeyhive.utils.error_handler.
+
+This module contains comprehensive unit tests for standardized error handling.
+"""
+
+# pylint: disable=too-many-lines,duplicate-code
+# Justification: Comprehensive unit test coverage requires extensive test cases
+
+# pylint: disable=redefined-outer-name
+# Justification: Pytest fixture pattern requires parameter shadowing
+
+# pylint: disable=protected-access,unused-argument
+# Justification: Unit tests need to verify private method behavior
+# unused-argument: Mock fixtures are required for patching even when not directly used
+
+import json
+from unittest.mock import MagicMock, Mock, patch
+
+import httpx
+import pytest
+
+from honeyhive.utils.error_handler import (
+    APIError,
+    AuthenticationError,
+    ErrorContext,
+    ErrorHandler,
+    ErrorResponse,
+    HoneyHiveConnectionError,
+    HoneyHiveError,
+    RateLimitError,
+    ValidationError,
+    get_error_handler,
+    handle_api_errors,
+)
+
+
+class TestErrorContext:
+    """Test suite for ErrorContext dataclass."""
+
+    def test_initialization_with_required_fields(self) -> None:
+        """Test ErrorContext initialization with only required fields."""
+        # Arrange & Act
+        context = ErrorContext(operation="test_operation")
+
+        # Assert
+        assert context.operation == "test_operation"
+        assert context.method is None
+        assert context.url is None
+        assert context.params is None
+        assert context.json_data is None
+        assert context.client_name is None
+        assert context.additional_context == {}
+
+    def test_initialization_with_all_fields(self) -> None:
+        """Test ErrorContext initialization with all fields provided."""
+        # Arrange
+        params = {"param1": "value1"}
+        json_data = {"key": "value"}
+        additional_context = {"extra": "info"}
+
+        # Act
+        context = ErrorContext(
+            operation="create_project",
+            method="POST",
+            url="/api/projects",
+            params=params,
+            json_data=json_data,
+            client_name="test_client",
+            additional_context=additional_context,
+        )
+
+        # Assert
+        assert context.operation == "create_project"
+        assert context.method == "POST"
+        assert context.url == "/api/projects"
+        assert context.params == params
+        assert context.json_data == json_data
+        assert context.client_name == "test_client"
+        assert context.additional_context == additional_context
+
+    def test_default_factory_for_additional_context(self) -> None:
+        """Test that additional_context uses default factory correctly."""
+        # Arrange & Act
+        context1 = ErrorContext(operation="op1")
+        context2 = ErrorContext(operation="op2")
+
+        # Modify one context
+        context1.additional_context["test"] = "value"
+
+        # Assert - contexts should have separate dictionaries
+        assert context1.additional_context == {"test": "value"}
+        assert context2.additional_context == {}
+
+
+class TestErrorResponse:
+    """Test suite for ErrorResponse dataclass."""
+
+    def test_initialization_with_defaults(self) -> None:
+        """Test ErrorResponse initialization with default values."""
+        # Arrange & Act
+        response = ErrorResponse()
+
+        # Assert
+        assert response.success is False
+        assert response.error_type == "UnknownError"
+        assert response.error_message == "An unknown error occurred"
+        assert response.error_code is None
+        assert response.status_code is None
+        assert response.details is None
+        assert response.context is None
+        assert response.retry_after is None
+
+    def test_initialization_with_custom_values(self) -> None:
+        """Test ErrorResponse initialization with custom values."""
+        # Arrange
+        context = ErrorContext(operation="test_op")
+        details = {"info": "test"}
+
+        # Act
+        response = ErrorResponse(
+            success=True,
+            error_type="TestError",
+            error_message="Test message",
+            error_code="TEST_001",
+            status_code=400,
+            details=details,
+            context=context,
+            retry_after=5.0,
+        )
+
+        # Assert
+        assert response.success is True
+        assert response.error_type == "TestError"
+        assert response.error_message == "Test message"
+        assert response.error_code == "TEST_001"
+        assert response.status_code == 400
+        assert response.details == details
+        assert response.context == context
+        assert response.retry_after == 5.0
+
+    def test_to_dict_with_minimal_data(self) -> None:
+        """Test to_dict method with minimal data."""
+        # Arrange
+        response = ErrorResponse()
+
+        # Act
+        result = response.to_dict()
+
+        # Assert
+        expected = {
+            "success": False,
+            "error_type": "UnknownError",
+            "error_message": "An unknown error occurred",
+        }
+        assert result == expected
+
+    def test_to_dict_with_all_optional_fields(self) -> None:
+        """Test to_dict method with all optional fields populated."""
+        # Arrange
+        response = ErrorResponse(
+            error_code="TEST_001",
+            status_code=500,
+            details={"key": "value"},
+            retry_after=10.0,
+        )
+
+        # Act
+        result = response.to_dict()
+
+        # Assert
+        expected = {
+            "success": False,
+            "error_type": "UnknownError",
+            "error_message": "An unknown error occurred",
+            "error_code": "TEST_001",
+            "status_code": 500,
+            "details": {"key": "value"},
+            "retry_after": 10.0,
+        }
+        assert result == expected
+
+    def test_to_dict_excludes_none_values(self) -> None:
+        """Test that to_dict excludes None values for optional fields."""
+        # Arrange
+        response = ErrorResponse(
+            error_code="TEST_001",
+            status_code=None,  # This should be excluded
+            details=None,  # This should be excluded
+            retry_after=5.0,
+        )
+
+        # Act
+        result = response.to_dict()
+
+        # Assert
+        expected = {
+            "success": False,
+            "error_type": "UnknownError",
+            "error_message": "An unknown error occurred",
+            "error_code": "TEST_001",
+            "retry_after": 5.0,
+        }
+        assert result == expected
+        assert "status_code" not in result
+        assert "details" not in result
+
+
+class TestHoneyHiveError:
+    """Test suite for HoneyHiveError exception class."""
+
+    def test_initialization_with_message_only(self) -> None:
+        """Test HoneyHiveError initialization with message only."""
+        # Arrange & Act
+        error = HoneyHiveError("Test error message")
+
+        # Assert
+        assert str(error) == "Test error message"
+        assert error.error_response is None
+        assert error.original_exception is None
+
+    def test_initialization_with_all_parameters(self) -> None:
+        """Test HoneyHiveError initialization with all parameters."""
+        # Arrange
+        error_response = ErrorResponse(error_type="TestError")
+        original_exception = ValueError("Original error")
+
+        # Act
+        error = HoneyHiveError(
+            "Test error message",
+            error_response=error_response,
+            original_exception=original_exception,
+        )
+
+        # Assert
+        assert str(error) == "Test error message"
+        assert error.error_response == error_response
+        assert error.original_exception == original_exception
+
+    def test_inheritance_from_exception(self) -> None:
+        """Test that HoneyHiveError properly inherits from Exception."""
+        # Arrange & Act
+        error = HoneyHiveError("Test message")
+
+        # Assert
+        assert isinstance(error, Exception)
+        assert isinstance(error, HoneyHiveError)
+
+
+class TestHoneyHiveErrorSubclasses:
+    """Test suite for HoneyHive error subclasses."""
+
+    def test_api_error_inheritance(self) -> None:
+        """Test APIError inherits from HoneyHiveError."""
+        # Arrange & Act
+        error = APIError("API error")
+
+        # Assert
+        assert isinstance(error, HoneyHiveError)
+        assert isinstance(error, APIError)
+
+    def test_validation_error_inheritance(self) -> None:
+        """Test ValidationError inherits from HoneyHiveError."""
+        # Arrange & Act
+        error = ValidationError("Validation error")
+
+        # Assert
+        assert isinstance(error, HoneyHiveError)
+        assert isinstance(error, ValidationError)
+
+    def test_connection_error_inheritance(self) -> None:
+        """Test HoneyHiveConnectionError inherits from HoneyHiveError."""
+        # Arrange & Act
+        error = HoneyHiveConnectionError("Connection error")
+
+        # Assert
+        assert isinstance(error, HoneyHiveError)
+        assert isinstance(error, HoneyHiveConnectionError)
+
+    def test_rate_limit_error_inheritance(self) -> None:
+        """Test RateLimitError inherits from HoneyHiveError."""
+        # Arrange & Act
+        error = RateLimitError("Rate limit error")
+
+        # Assert
+        assert isinstance(error, HoneyHiveError)
+        assert isinstance(error, RateLimitError)
+
+    def test_authentication_error_inheritance(self) -> None:
+        """Test AuthenticationError inherits from HoneyHiveError."""
+        # Arrange & Act
+        error = AuthenticationError("Auth error")
+
+        # Assert
+        assert isinstance(error, HoneyHiveError)
+        assert isinstance(error, AuthenticationError)
+
+
+class TestErrorHandler:  # pylint: disable=too-many-public-methods
+    """Test suite for ErrorHandler class."""
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_initialization_with_default_logger_name(
+        self, mock_get_logger: Mock
+    ) -> None:
+        """Test ErrorHandler initialization with default logger name."""
+        # Arrange
+        mock_logger = Mock()
+        mock_get_logger.return_value = mock_logger
+
+        # Act
+        handler = ErrorHandler()
+
+        # Assert
+        mock_get_logger.assert_called_once_with("honeyhive.error_handler")
+        assert handler.logger == mock_logger
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_initialization_with_custom_logger_name(
+        self, mock_get_logger: Mock
+    ) -> None:
+        """Test ErrorHandler initialization with custom logger name."""
+        # Arrange
+        mock_logger = Mock()
+        mock_get_logger.return_value = mock_logger
+        custom_name = "custom.logger"
+
+        # Act
+        handler = ErrorHandler(logger_name=custom_name)
+
+        # Assert
+        mock_get_logger.assert_called_once_with(custom_name)
+        assert handler.logger == mock_logger
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_error_handlers_mapping_initialization(self, mock_get_logger: Mock) -> None:
+        """Test that error handlers mapping is properly initialized."""
+        # Arrange & Act
+        handler = ErrorHandler()
+
+        # Assert
+        expected_exceptions = {
+            httpx.ConnectError,
+            httpx.ConnectTimeout,
+            httpx.ReadTimeout,
+            httpx.WriteTimeout,
+            httpx.PoolTimeout,
+            httpx.HTTPStatusError,
+            httpx.RequestError,
+            ValueError,
+            TypeError,
+            KeyError,
+            json.JSONDecodeError,
+        }
+
+        assert set(handler._error_handlers.keys()) == expected_exceptions
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_handle_operation_success_no_exception(self, mock_get_logger: Mock) -> None:
+        """Test handle_operation context manager with no exception."""
+        # Arrange
+        handler = ErrorHandler()
+        context = ErrorContext(operation="test_op")
+
+        # Act & Assert - should not raise any exception
+        with handler.handle_operation(context):
+            pass  # No exception raised
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_handle_operation_with_exception_raise_on_error_true(
+        self, mock_get_logger: Mock
+    ) -> None:
+        """Test handle_operation with exception and raise_on_error=True."""
+        # Arrange
+        mock_logger = Mock()
+        mock_get_logger.return_value = mock_logger
+        handler = ErrorHandler()
+        context = ErrorContext(operation="test_op")
+        test_exception = ValueError("Test error")
+
+        # Act & Assert
+        with pytest.raises(ValidationError) as exc_info:
+            with handler.handle_operation(context, raise_on_error=True):
+                raise test_exception
+
+        # Verify the exception was converted to HoneyHive exception
+        assert isinstance(exc_info.value, ValidationError)
+        assert exc_info.value.original_exception == test_exception
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_handle_operation_with_exception_raise_on_error_false(
+        self, mock_get_logger: Mock
+    ) -> None:
+        """Test handle_operation with exception and raise_on_error=False."""
+        # Arrange
+        mock_logger = Mock()
+        mock_get_logger.return_value = mock_logger
+        handler = ErrorHandler()
+        context = ErrorContext(operation="test_op")
+        test_exception = ValueError("Test error")
+
+        # Act - should not raise exception
+        with handler.handle_operation(context, raise_on_error=False):
+            raise test_exception
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_handle_operation_with_return_error_response_true(
+        self, mock_get_logger: Mock
+    ) -> None:
+        """Test handle_operation with return_error_response=True."""
+        # Arrange
+        mock_logger = Mock()
+        mock_get_logger.return_value = mock_logger
+        handler = ErrorHandler()
+        context = ErrorContext(operation="test_op")
+        test_exception = ValueError("Test error")
+
+        # Act - should not raise exception
+        with handler.handle_operation(context, return_error_response=True):
+            raise test_exception
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_process_error_with_known_exception_type(
+        self, mock_get_logger: Mock
+    ) -> None:
+        """Test _process_error with a known exception type."""
+        # Arrange
+        handler = ErrorHandler()
+        context = ErrorContext(operation="test_op")
+        exception = ValueError("Test validation error")
+
+        # Act
+        result = handler._process_error(exception, context)
+
+        # Assert
+        assert isinstance(result, ErrorResponse)
+        assert result.error_type == "ValidationError"
+        assert "Validation failed: Test validation error" in result.error_message
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_process_error_with_unknown_exception_type(
+        self, mock_get_logger: Mock
+    ) -> None:
+        """Test _process_error with an unknown exception type."""
+        # Arrange
+        handler = ErrorHandler()
+        context = ErrorContext(operation="test_op")
+
+        class CustomException(Exception):
+            """Custom exception for testing unknown error handling."""
+
+        exception = CustomException("Custom error")
+
+        # Act
+        result = handler._process_error(exception, context)
+
+        # Assert
+        assert isinstance(result, ErrorResponse)
+        assert result.error_type == "UnknownError"
+        assert "Unexpected error: Custom error" in result.error_message
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_handle_connection_error(self, mock_get_logger: Mock) -> None:
+        """Test _handle_connection_error method."""
+        # Arrange
+        handler = ErrorHandler()
+        context = ErrorContext(operation="test_op", url="https://api.test.com")
+        exception = httpx.ConnectError("Connection failed")
+
+        # Act
+        result = handler._handle_connection_error(exception, context)
+
+        # Assert
+        assert result.error_type == "ConnectionError"
+        assert "Connection failed" in result.error_message
+        assert result.error_code == "CONNECTION_FAILED"
+        assert result.retry_after == 1.0
+        assert result.details is not None
+        assert result.details["operation"] == "test_op"
+        assert result.details["url"] == "https://api.test.com"
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_handle_http_error_401_unauthorized(self, mock_get_logger: Mock) -> None:
+        """Test _handle_http_error with 401 Unauthorized."""
+        # Arrange
+        handler = ErrorHandler()
+        context = ErrorContext(operation="test_op", url="https://api.test.com")
+
+        # Create mock response
+        mock_response = Mock()
+        mock_response.status_code = 401
+        mock_response.reason_phrase = "Unauthorized"
+
+        # Create mock headers object that supports both 'in' and subscript access
+        mock_headers = {"content-type": "application/json"}
+        mock_response.headers = mock_headers
+        mock_response.json.return_value = {"error": "Invalid credentials"}
+
+        exception = httpx.HTTPStatusError(
+            "401 Unauthorized", request=Mock(), response=mock_response
+        )
+
+        # Act
+        result = handler._handle_http_error(exception, context)
+
+        # Assert
+        assert result.error_type == "AuthenticationError"
+        assert result.error_code == "UNAUTHORIZED"
+        assert result.status_code == 401
+        assert "HTTP 401: Unauthorized" in result.error_message
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_handle_http_error_429_rate_limit(self, mock_get_logger: Mock) -> None:
+        """Test _handle_http_error with 429 Rate Limited."""
+        # Arrange
+        handler = ErrorHandler()
+        context = ErrorContext(operation="test_op")
+
+        # Create mock response with retry-after header
+        mock_response = Mock()
+        mock_response.status_code = 429
+        mock_response.reason_phrase = "Too Many Requests"
+
+        # Create mock headers object that supports both 'in' and subscript access
+        mock_headers = {"retry-after": "60", "content-type": "application/json"}
+        mock_response.headers = mock_headers
+        mock_response.json.return_value = {"error": "Rate limit exceeded"}
+
+        exception = httpx.HTTPStatusError(
+            "429 Too Many Requests", request=Mock(), response=mock_response
+        )
+
+        # Act
+        result = handler._handle_http_error(exception, context)
+
+        # Assert
+        assert result.error_type == "RateLimitError"
+        assert result.error_code == "RATE_LIMITED"
+        assert result.status_code == 429
+        assert result.retry_after == 60.0
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_handle_http_error_500_server_error(self, mock_get_logger: Mock) -> None:
+        """Test _handle_http_error with 500 Server Error."""
+        # Arrange
+        handler = ErrorHandler()
+        context = ErrorContext(operation="test_op")
+
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_response.reason_phrase = "Internal Server Error"
+
+        # Create mock headers object that supports both 'in' and subscript access
+        mock_headers = {"content-type": "text/html"}
+        mock_response.headers = mock_headers
+        mock_response.json.side_effect = json.JSONDecodeError("Invalid JSON", "", 0)
+        mock_response.text = "Internal server error occurred"
+
+        exception = httpx.HTTPStatusError(
+            "500 Internal Server Error", request=Mock(), response=mock_response
+        )
+
+        # Act
+        result = handler._handle_http_error(exception, context)
+
+        # Assert
+        assert result.error_type == "APIError"
+        assert result.error_code == "SERVER_ERROR"
+        assert result.status_code == 500
+        # Check that details contains expected information
+        assert result.details is not None
+        assert result.details["operation"] == "test_op"
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_handle_http_error_403_forbidden(self, mock_get_logger: Mock) -> None:
+        """Test _handle_http_error with 403 Forbidden."""
+        # Arrange
+        handler = ErrorHandler()
+        context = ErrorContext(operation="test_op")
+
+        mock_response = Mock()
+        mock_response.status_code = 403
+        mock_response.reason_phrase = "Forbidden"
+
+        # Create mock headers object that supports both 'in' and subscript access
+        mock_headers = {"content-type": "application/json"}
+        mock_response.headers = mock_headers
+        mock_response.json.return_value = {"error": "Access denied"}
+
+        exception = httpx.HTTPStatusError(
+            "403 Forbidden", request=Mock(), response=mock_response
+        )
+
+        # Act
+        result = handler._handle_http_error(exception, context)
+
+        # Assert
+        assert result.error_type == "AuthenticationError"
+        assert result.error_code == "FORBIDDEN"
+        assert result.status_code == 403
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_handle_http_error_400_client_error(self, mock_get_logger: Mock) -> None:
+        """Test _handle_http_error with 400 Client Error."""
+        # Arrange
+        handler = ErrorHandler()
+        context = ErrorContext(operation="test_op")
+
+        mock_response = Mock()
+        mock_response.status_code = 400
+        mock_response.reason_phrase = "Bad Request"
+
+        # Create mock headers object that supports both 'in' and subscript access
+        mock_headers = {"content-type": "application/json"}
+        mock_response.headers = mock_headers
+        mock_response.json.return_value = {"error": "Bad request"}
+
+        exception = httpx.HTTPStatusError(
+            "400 Bad Request", request=Mock(), response=mock_response
+        )
+
+        # Act
+        result = handler._handle_http_error(exception, context)
+
+        # Assert
+        assert result.error_type == "APIError"
+        assert result.error_code == "CLIENT_ERROR"
+        assert result.status_code == 400
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_handle_http_error_json_parsing_exception(
+        self, mock_get_logger: Mock
+    ) -> None:
+        """Test _handle_http_error when JSON parsing fails."""
+        # Arrange
+        handler = ErrorHandler()
+        context = ErrorContext(operation="test_op")
+
+        mock_response = Mock()
+        mock_response.status_code = 422
+        mock_response.reason_phrase = "Unprocessable Entity"
+
+        # Create headers dict that indicates JSON but parsing fails
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.json.side_effect = Exception("JSON parsing failed")
+        mock_response.text = "Invalid JSON response"
+
+        exception = httpx.HTTPStatusError(
+            "422 Unprocessable Entity", request=Mock(), response=mock_response
+        )
+
+        # Act
+        result = handler._handle_http_error(exception, context)
+
+        # Assert
+        assert result.error_type == "APIError"
+        assert result.error_code == "CLIENT_ERROR"
+        assert result.status_code == 422
+        assert result.details is not None
+        assert result.details["response_text"] == "Invalid JSON response"
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_handle_http_error_invalid_retry_after_header(
+        self, mock_get_logger: Mock
+    ) -> None:
+        """Test _handle_http_error with invalid retry-after header."""
+        # Arrange
+        handler = ErrorHandler()
+        context = ErrorContext(operation="test_op")
+
+        mock_response = Mock()
+        mock_response.status_code = 429
+        mock_response.reason_phrase = "Too Many Requests"
+
+        # Create mock headers object that supports both 'in' and subscript access
+        mock_headers = {"retry-after": "invalid", "content-type": "application/json"}
+        mock_response.headers = mock_headers
+        mock_response.json.return_value = {"error": "Rate limit exceeded"}
+
+        exception = httpx.HTTPStatusError(
+            "429 Too Many Requests", request=Mock(), response=mock_response
+        )
+
+        # Act
+        result = handler._handle_http_error(exception, context)
+
+        # Assert
+        assert result.retry_after is None  # Should be None due to invalid header
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_handle_request_error(self, mock_get_logger: Mock) -> None:
+        """Test _handle_request_error method."""
+        # Arrange
+        handler = ErrorHandler()
+        context = ErrorContext(operation="test_op", url="https://api.test.com")
+        exception = httpx.RequestError("Request failed")
+
+        # Act
+        result = handler._handle_request_error(exception, context)
+
+        # Assert
+        assert result.error_type == "RequestError"
+        assert "Request failed" in result.error_message
+        assert result.error_code == "REQUEST_FAILED"
+        assert result.retry_after == 1.0
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_handle_validation_error_with_params(self, mock_get_logger: Mock) -> None:
+        """Test _handle_validation_error with context params."""
+        # Arrange
+        handler = ErrorHandler()
+        context = ErrorContext(
+            operation="test_op", params={"param1": "value1"}, json_data={"key": "value"}
+        )
+        exception = TypeError("Invalid type")
+
+        # Act
+        result = handler._handle_validation_error(exception, context)
+
+        # Assert
+        assert result.error_type == "ValidationError"
+        assert "Validation failed: Invalid type" in result.error_message
+        assert result.error_code == "VALIDATION_FAILED"
+        assert result.details is not None
+        assert result.details["params"] == {"param1": "value1"}
+        assert result.details["json_data"] == {"key": "value"}
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_handle_json_error_with_position(self, mock_get_logger: Mock) -> None:
+        """Test _handle_json_error with position information."""
+        # Arrange
+        handler = ErrorHandler()
+        context = ErrorContext(operation="test_op", url="https://api.test.com")
+        exception = json.JSONDecodeError("Invalid JSON", "test string", 5)
+
+        # Act
+        result = handler._handle_json_error(exception, context)
+
+        # Assert
+        assert result.error_type == "JSONError"
+        assert "Failed to parse JSON response" in result.error_message
+        assert result.error_code == "JSON_PARSE_FAILED"
+        assert result.details is not None
+        assert result.details["json_position"] == 5
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_handle_unknown_error_with_traceback(self, mock_get_logger: Mock) -> None:
+        """Test _handle_unknown_error includes traceback."""
+        # Arrange
+        handler = ErrorHandler()
+        context = ErrorContext(operation="test_op")
+
+        class CustomError(Exception):
+            """Custom error for testing unknown error handling."""
+
+        exception = CustomError("Unknown error")
+
+        # Act
+        with patch("traceback.format_exc", return_value="Mock traceback"):
+            result = handler._handle_unknown_error(exception, context)
+
+        # Assert
+        assert result.error_type == "UnknownError"
+        assert "Unexpected error: Unknown error" in result.error_message
+        assert result.error_code == "UNKNOWN_ERROR"
+        assert result.details is not None
+        assert result.details["traceback"] == "Mock traceback"
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_create_honeyhive_error_connection_error(
+        self, mock_get_logger: Mock
+    ) -> None:
+        """Test _create_honeyhive_error for connection errors."""
+        # Arrange
+        handler = ErrorHandler()
+        error_response = ErrorResponse(
+            error_type="ConnectionError", error_message="Connection failed"
+        )
+        original_exception = httpx.ConnectError("Connection failed")
+
+        # Act
+        result = handler._create_honeyhive_error(error_response, original_exception)
+
+        # Assert
+        assert isinstance(result, HoneyHiveConnectionError)
+        assert result.error_response == error_response
+        assert result.original_exception == original_exception
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_create_honeyhive_error_authentication_error(
+        self, mock_get_logger: Mock
+    ) -> None:
+        """Test _create_honeyhive_error for authentication errors."""
+        # Arrange
+        handler = ErrorHandler()
+        error_response = ErrorResponse(
+            error_type="AuthenticationError", error_message="Auth failed"
+        )
+        original_exception = Exception("Auth failed")
+
+        # Act
+        result = handler._create_honeyhive_error(error_response, original_exception)
+
+        # Assert
+        assert isinstance(result, AuthenticationError)
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_create_honeyhive_error_rate_limit_error(
+        self, mock_get_logger: Mock
+    ) -> None:
+        """Test _create_honeyhive_error for rate limit errors."""
+        # Arrange
+        handler = ErrorHandler()
+        error_response = ErrorResponse(
+            error_type="RateLimitError", error_message="Rate limited"
+        )
+        original_exception = Exception("Rate limited")
+
+        # Act
+        result = handler._create_honeyhive_error(error_response, original_exception)
+
+        # Assert
+        assert isinstance(result, RateLimitError)
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_create_honeyhive_error_validation_error(
+        self, mock_get_logger: Mock
+    ) -> None:
+        """Test _create_honeyhive_error for validation errors."""
+        # Arrange
+        handler = ErrorHandler()
+        error_response = ErrorResponse(
+            error_type="ValidationError", error_message="Validation failed"
+        )
+        original_exception = ValueError("Validation failed")
+
+        # Act
+        result = handler._create_honeyhive_error(error_response, original_exception)
+
+        # Assert
+        assert isinstance(result, ValidationError)
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_create_honeyhive_error_api_error_types(
+        self, mock_get_logger: Mock
+    ) -> None:
+        """Test _create_honeyhive_error for various API error types."""
+        # Arrange
+        handler = ErrorHandler()
+        original_exception = Exception("API failed")
+
+        api_error_types = ["APIError", "RequestError", "JSONError"]
+
+        for error_type in api_error_types:
+            # Act
+            error_response = ErrorResponse(
+                error_type=error_type, error_message="API failed"
+            )
+            result = handler._create_honeyhive_error(error_response, original_exception)
+
+            # Assert
+            assert isinstance(result, APIError)
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_create_honeyhive_error_unknown_type(self, mock_get_logger: Mock) -> None:
+        """Test _create_honeyhive_error for unknown error types."""
+        # Arrange
+        handler = ErrorHandler()
+        error_response = ErrorResponse(
+            error_type="UnknownType", error_message="Unknown error"
+        )
+        original_exception = Exception("Unknown error")
+
+        # Act
+        result = handler._create_honeyhive_error(error_response, original_exception)
+
+        # Assert
+        assert isinstance(result, HoneyHiveError)
+        assert not isinstance(result, (APIError, ValidationError, AuthenticationError))
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_log_error_rate_limit_warning_level(self, mock_get_logger: Mock) -> None:
+        """Test _log_error uses warning level for rate limit errors."""
+        # Arrange
+        mock_logger = Mock()
+        mock_get_logger.return_value = mock_logger
+        handler = ErrorHandler()
+
+        context = ErrorContext(
+            operation="test_op", method="GET", url="https://api.test.com"
+        )
+        error_response = ErrorResponse(
+            error_type="RateLimitError",
+            error_code="RATE_LIMITED",
+            error_message="Rate limit exceeded",
+            status_code=429,
+            context=context,
+        )
+        exception = Exception("Rate limit exceeded")
+
+        # Act
+        handler._log_error(error_response, exception)
+
+        # Assert
+        mock_logger.warning.assert_called_once()
+        call_args = mock_logger.warning.call_args
+        assert call_args[0][0] == "API operation failed"
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_log_error_connection_warning_level(self, mock_get_logger: Mock) -> None:
+        """Test _log_error uses warning level for connection errors."""
+        # Arrange
+        mock_logger = Mock()
+        mock_get_logger.return_value = mock_logger
+        handler = ErrorHandler()
+
+        error_response = ErrorResponse(error_type="ConnectionError")
+        exception = httpx.ConnectError("Connection failed")
+
+        # Act
+        handler._log_error(error_response, exception)
+
+        # Assert
+        mock_logger.warning.assert_called_once()
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_log_error_validation_error_level(self, mock_get_logger: Mock) -> None:
+        """Test _log_error uses error level for validation errors."""
+        # Arrange
+        mock_logger = Mock()
+        mock_get_logger.return_value = mock_logger
+        handler = ErrorHandler()
+
+        error_response = ErrorResponse(error_type="ValidationError")
+        exception = ValueError("Validation failed")
+
+        # Act
+        handler._log_error(error_response, exception)
+
+        # Assert
+        mock_logger.error.assert_called_once()
+        call_args = mock_logger.error.call_args
+        assert call_args[0][0] == "Validation error"
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_log_error_api_error_level(self, mock_get_logger: Mock) -> None:
+        """Test _log_error uses error level for API errors."""
+        # Arrange
+        mock_logger = Mock()
+        mock_get_logger.return_value = mock_logger
+        handler = ErrorHandler()
+
+        error_response = ErrorResponse(error_type="APIError")
+        exception = Exception("API failed")
+
+        # Act
+        handler._log_error(error_response, exception)
+
+        # Assert
+        mock_logger.error.assert_called_once()
+        call_args = mock_logger.error.call_args
+        assert call_args[0][0] == "API error"
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_log_error_includes_details_when_present(
+        self, mock_get_logger: Mock
+    ) -> None:
+        """Test _log_error includes details in log data when present."""
+        # Arrange
+        mock_logger = Mock()
+        mock_get_logger.return_value = mock_logger
+        handler = ErrorHandler()
+
+        details = {"additional": "info", "request_id": "123"}
+        error_response = ErrorResponse(error_type="APIError", details=details)
+        exception = Exception("API failed")
+
+        # Act
+        handler._log_error(error_response, exception)
+
+        # Assert
+        mock_logger.error.assert_called_once()
+        call_args = mock_logger.error.call_args
+        log_data = call_args[1]["honeyhive_data"]
+        assert log_data["details"] == details
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_log_error_without_context(self, mock_get_logger: Mock) -> None:
+        """Test _log_error handles missing context gracefully."""
+        # Arrange
+        mock_logger = Mock()
+        mock_get_logger.return_value = mock_logger
+        handler = ErrorHandler()
+
+        error_response = ErrorResponse(
+            error_type="APIError", context=None  # No context
+        )
+        exception = Exception("API failed")
+
+        # Act
+        handler._log_error(error_response, exception)
+
+        # Assert
+        mock_logger.error.assert_called_once()
+        call_args = mock_logger.error.call_args
+        log_data = call_args[1]["honeyhive_data"]
+        assert log_data["operation"] is None
+        assert log_data["method"] is None
+        assert log_data["url"] is None
+
+
+class TestGetErrorHandler:  # pylint: disable=too-few-public-methods
+    """Test suite for get_error_handler function."""
+
+    def test_get_error_handler_returns_default_instance(self) -> None:
+        """Test get_error_handler returns the default error handler instance."""
+        # Act
+        handler1 = get_error_handler()
+        handler2 = get_error_handler()
+
+        # Assert - should return the same instance (singleton pattern)
+        assert handler1 is handler2
+        assert isinstance(handler1, ErrorHandler)
+
+
+class TestHandleApiErrors:
+    """Test suite for handle_api_errors context manager."""
+
+    @patch("honeyhive.utils.error_handler._default_error_handler")
+    def test_handle_api_errors_success_no_exception(
+        self, mock_default_handler: Mock
+    ) -> None:
+        """Test handle_api_errors context manager with no exception."""
+        # Arrange - create a proper context manager mock
+        mock_context_manager = MagicMock()
+        mock_context_manager.__enter__ = Mock(return_value=None)
+        mock_context_manager.__exit__ = Mock(return_value=None)
+        mock_default_handler.handle_operation.return_value = mock_context_manager
+
+        # Act & Assert - should not raise any exception
+        with handle_api_errors("test_operation"):
+            pass
+
+    @patch("honeyhive.utils.error_handler._default_error_handler")
+    def test_handle_api_errors_creates_correct_context(
+        self, mock_default_handler: Mock
+    ) -> None:
+        """Test handle_api_errors creates ErrorContext with correct parameters."""
+        # Arrange - create a proper context manager mock
+        mock_context_manager = MagicMock()
+        mock_context_manager.__enter__ = Mock(return_value=None)
+        mock_context_manager.__exit__ = Mock(return_value=None)
+        mock_default_handler.handle_operation.return_value = mock_context_manager
+
+        # Act
+        with handle_api_errors(
+            "create_project",
+            method="POST",
+            url="/api/projects",
+            params={"param1": "value1"},
+            json_data={"key": "value"},
+            client_name="test_client",
+            custom_field="custom_value",
+        ):
+            pass
+
+        # Assert
+        mock_default_handler.handle_operation.assert_called_once()
+        call_args = mock_default_handler.handle_operation.call_args[0]
+        context = call_args[0]
+
+        assert isinstance(context, ErrorContext)
+        assert context.operation == "create_project"
+        assert context.method == "POST"
+        assert context.url == "/api/projects"
+        assert context.params == {"param1": "value1"}
+        assert context.json_data == {"key": "value"}
+        assert context.client_name == "test_client"
+        assert context.additional_context == {"custom_field": "custom_value"}
+
+    @patch("honeyhive.utils.error_handler._default_error_handler")
+    def test_handle_api_errors_passes_raise_on_error_parameter(
+        self, mock_default_handler: Mock
+    ) -> None:
+        """Test handle_api_errors passes raise_on_error parameter correctly."""
+        # Arrange - create a proper context manager mock
+        mock_context_manager = MagicMock()
+        mock_context_manager.__enter__ = Mock(return_value=None)
+        mock_context_manager.__exit__ = Mock(return_value=None)
+        mock_default_handler.handle_operation.return_value = mock_context_manager
+
+        # Act
+        with handle_api_errors("test_operation", raise_on_error=False):
+            pass
+
+        # Assert
+        call_args = mock_default_handler.handle_operation.call_args
+        # Check that raise_on_error was passed as positional argument
+        assert len(call_args) >= 2
+        assert call_args[0][1] is False  # raise_on_error parameter
+
+    @patch("honeyhive.utils.error_handler._default_error_handler")
+    def test_handle_api_errors_with_minimal_parameters(
+        self, mock_default_handler: Mock
+    ) -> None:
+        """Test handle_api_errors with only required parameters."""
+        # Arrange - create a proper context manager mock
+        mock_context_manager = MagicMock()
+        mock_context_manager.__enter__ = Mock(return_value=None)
+        mock_context_manager.__exit__ = Mock(return_value=None)
+        mock_default_handler.handle_operation.return_value = mock_context_manager
+
+        # Act
+        with handle_api_errors("minimal_operation"):
+            pass
+
+        # Assert
+        call_args = mock_default_handler.handle_operation.call_args[0]
+        context = call_args[0]
+
+        assert context.operation == "minimal_operation"
+        assert context.method is None
+        assert context.url is None
+        assert context.params is None
+        assert context.json_data is None
+        assert context.client_name is None
+        assert context.additional_context == {}
+
+
+class TestErrorHandlerIntegration:
+    """Integration tests for ErrorHandler with real exception scenarios."""
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_full_error_handling_workflow_with_httpx_exception(
+        self, mock_get_logger: Mock
+    ) -> None:
+        """Test complete error handling workflow with real httpx exception."""
+        # Arrange
+        mock_logger = Mock()
+        mock_get_logger.return_value = mock_logger
+        handler = ErrorHandler()
+        context = ErrorContext(
+            operation="api_call",
+            method="POST",
+            url="https://api.honeyhive.ai/projects",
+            client_name="test_client",
+        )
+
+        # Simulate a connection timeout
+        connection_error = httpx.ConnectTimeout("Connection timed out")
+
+        # Act & Assert
+        with pytest.raises(HoneyHiveConnectionError) as exc_info:
+            with handler.handle_operation(context, raise_on_error=True):
+                raise connection_error
+
+        # Verify the exception was properly converted
+        honeyhive_error = exc_info.value
+        assert isinstance(honeyhive_error, HoneyHiveConnectionError)
+        assert honeyhive_error.original_exception == connection_error
+        assert honeyhive_error.error_response is not None
+        assert honeyhive_error.error_response.error_type == "ConnectionError"
+        assert honeyhive_error.error_response.retry_after == 1.0
+
+        # Verify logging occurred
+        mock_logger.warning.assert_called_once()
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_error_handling_with_no_raise_returns_silently(
+        self, mock_get_logger: Mock
+    ) -> None:
+        """Test error handling with raise_on_error=False returns silently."""
+        # Arrange
+        mock_logger = Mock()
+        mock_get_logger.return_value = mock_logger
+        handler = ErrorHandler()
+        context = ErrorContext(operation="test_op")
+
+        # Act - should not raise exception
+        with handler.handle_operation(context, raise_on_error=False):
+            raise ValueError("Test validation error")
+
+        # Verify logging still occurred
+        mock_logger.error.assert_called_once()
+
+    @patch("honeyhive.utils.error_handler.get_logger")
+    def test_complex_http_error_with_json_response_parsing(
+        self, mock_get_logger: Mock
+    ) -> None:
+        """Test complex HTTP error with JSON response parsing."""
+        # Arrange
+        mock_logger = Mock()
+        mock_get_logger.return_value = mock_logger
+        handler = ErrorHandler()
+        context = ErrorContext(
+            operation="create_project", url="https://api.honeyhive.ai"
+        )
+
+        # Create realistic HTTP error
+        mock_response = Mock()
+        mock_response.status_code = 422
+        mock_response.reason_phrase = "Unprocessable Entity"
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.json.return_value = {
+            "error": "Validation failed",
+            "details": {"field": "project_name", "message": "Required field missing"},
+        }
+
+        http_error = httpx.HTTPStatusError(
+            "422 Unprocessable Entity", request=Mock(), response=mock_response
+        )
+
+        # Act
+        result = handler._process_error(http_error, context)
+
+        # Assert
+        assert result.error_type == "APIError"
+        assert result.error_code == "CLIENT_ERROR"
+        assert result.status_code == 422
+        assert result.details is not None
+        assert result.details["error"] == "Validation failed"
+        assert result.details["details"]["field"] == "project_name"

--- a/tests_v2/unit/test_utils_logger.py
+++ b/tests_v2/unit/test_utils_logger.py
@@ -1,0 +1,1399 @@
+"""Unit tests for honeyhive.utils.logger.
+
+This module contains comprehensive unit tests for the HoneyHive logging utilities,
+including structured logging, shutdown detection, and safe logging functionality.
+"""
+
+# pylint: disable=too-many-lines
+# Justification: Comprehensive unit test coverage requires extensive test cases
+
+# pylint: disable=redefined-outer-name
+# Justification: Pytest fixture pattern requires parameter shadowing
+
+# pylint: disable=protected-access
+# Justification: Unit tests need to verify private method behavior
+
+import json
+import logging
+import sys
+from datetime import timezone
+from unittest.mock import Mock, PropertyMock, patch
+
+import pytest
+
+from honeyhive.utils.logger import (
+    HoneyHiveFormatter,
+    HoneyHiveLogger,
+    _detect_shutdown_conditions,
+    _extract_verbose_from_tracer_dynamically,
+    _shutdown_detected,
+    default_logger,
+    get_logger,
+    get_tracer_logger,
+    is_shutdown_detected,
+    reset_logging_state,
+    safe_debug,
+    safe_error,
+    safe_info,
+    safe_log,
+    safe_warning,
+)
+
+
+class TestHoneyHiveFormatter:
+    """Test suite for HoneyHiveFormatter class."""
+
+    def test_initialization_with_defaults(self) -> None:
+        """Test HoneyHiveFormatter initialization with default parameters."""
+        formatter = HoneyHiveFormatter()
+
+        assert formatter.include_timestamp is True
+        assert formatter.include_level is True
+
+    def test_initialization_with_custom_parameters(self) -> None:
+        """Test HoneyHiveFormatter initialization with custom parameters."""
+        formatter = HoneyHiveFormatter(include_timestamp=False, include_level=False)
+
+        assert formatter.include_timestamp is False
+        assert formatter.include_level is False
+
+    @patch("honeyhive.utils.logger.datetime")
+    def test_format_with_all_fields(self, mock_datetime: Mock) -> None:
+        """Test formatting log record with all fields included."""
+        # Arrange
+        mock_now = Mock()
+        mock_now.isoformat.return_value = "2023-01-01T12:00:00+00:00"
+        mock_datetime.now.return_value = mock_now
+
+        formatter = HoneyHiveFormatter(include_timestamp=True, include_level=True)
+        record = logging.LogRecord(
+            name="test.logger",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=10,
+            msg="Test message",
+            args=(),
+            exc_info=None,
+        )
+
+        # Act
+        result = formatter.format(record)
+
+        # Assert
+        parsed_result = json.loads(result)
+        assert parsed_result["timestamp"] == "2023-01-01T12:00:00+00:00"
+        assert parsed_result["level"] == "INFO"
+        assert parsed_result["logger"] == "test.logger"
+        assert parsed_result["message"] == "Test message"
+        mock_datetime.now.assert_called_once_with(timezone.utc)
+
+    def test_format_without_timestamp(self) -> None:
+        """Test formatting log record without timestamp."""
+        # Arrange
+        formatter = HoneyHiveFormatter(include_timestamp=False, include_level=True)
+        record = logging.LogRecord(
+            name="test.logger",
+            level=logging.WARNING,
+            pathname="test.py",
+            lineno=10,
+            msg="Warning message",
+            args=(),
+            exc_info=None,
+        )
+
+        # Act
+        result = formatter.format(record)
+
+        # Assert
+        parsed_result = json.loads(result)
+        assert "timestamp" not in parsed_result
+        assert parsed_result["level"] == "WARNING"
+        assert parsed_result["logger"] == "test.logger"
+        assert parsed_result["message"] == "Warning message"
+
+    def test_format_without_level(self) -> None:
+        """Test formatting log record without level."""
+        # Arrange
+        formatter = HoneyHiveFormatter(include_timestamp=False, include_level=False)
+        record = logging.LogRecord(
+            name="test.logger",
+            level=logging.ERROR,
+            pathname="test.py",
+            lineno=10,
+            msg="Error message",
+            args=(),
+            exc_info=None,
+        )
+
+        # Act
+        result = formatter.format(record)
+
+        # Assert
+        parsed_result = json.loads(result)
+        assert "timestamp" not in parsed_result
+        assert "level" not in parsed_result
+        assert parsed_result["logger"] == "test.logger"
+        assert parsed_result["message"] == "Error message"
+
+    def test_format_with_honeyhive_data(self) -> None:
+        """Test formatting log record with HoneyHive context data."""
+        # Arrange
+        formatter = HoneyHiveFormatter(include_timestamp=False, include_level=False)
+        record = logging.LogRecord(
+            name="test.logger",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=10,
+            msg="Context message",
+            args=(),
+            exc_info=None,
+        )
+        honeyhive_data = {"session_id": "test-123", "project": "test-project"}
+        record.honeyhive_data = honeyhive_data
+
+        # Act
+        result = formatter.format(record)
+
+        # Assert
+        parsed_result = json.loads(result)
+        assert parsed_result["logger"] == "test.logger"
+        assert parsed_result["message"] == "Context message"
+        assert parsed_result["session_id"] == "test-123"
+        assert parsed_result["project"] == "test-project"
+
+    def test_format_with_exception_info(self) -> None:
+        """Test formatting log record with exception information."""
+        # Arrange
+        formatter = HoneyHiveFormatter(include_timestamp=False, include_level=False)
+
+        exc_info = None
+        try:
+            raise ValueError("Test exception")
+        except ValueError:
+            exc_info = sys.exc_info()
+
+        record = logging.LogRecord(
+            name="test.logger",
+            level=logging.ERROR,
+            pathname="test.py",
+            lineno=10,
+            msg="Exception occurred",
+            args=(),
+            exc_info=exc_info,
+        )
+
+        # Act
+        result = formatter.format(record)
+
+        # Assert
+        parsed_result = json.loads(result)
+        assert parsed_result["logger"] == "test.logger"
+        assert parsed_result["message"] == "Exception occurred"
+        assert "exception" in parsed_result
+        assert "ValueError: Test exception" in parsed_result["exception"]
+
+    def test_format_removes_none_values(self) -> None:
+        """Test that formatting removes None values from output."""
+        # Arrange
+        formatter = HoneyHiveFormatter(include_timestamp=False, include_level=False)
+        record = logging.LogRecord(
+            name="test.logger",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=10,
+            msg="Clean message",
+            args=(),
+            exc_info=None,
+        )
+
+        # Act
+        result = formatter.format(record)
+
+        # Assert
+        parsed_result = json.loads(result)
+        assert "timestamp" not in parsed_result
+        assert "level" not in parsed_result
+        assert parsed_result["logger"] == "test.logger"
+        assert parsed_result["message"] == "Clean message"
+
+
+class TestHoneyHiveLogger:
+    """Test suite for HoneyHiveLogger class."""
+
+    @patch("honeyhive.utils.logger.logging.getLogger")
+    def test_initialization_with_defaults(self, mock_get_logger: Mock) -> None:
+        """Test HoneyHiveLogger initialization with default parameters."""
+        # Arrange
+        mock_logger = Mock()
+        mock_logger.handlers = []
+        mock_get_logger.return_value = mock_logger
+
+        # Act
+        logger = HoneyHiveLogger("test.logger")
+
+        # Assert
+        assert logger.logger == mock_logger
+        assert logger.verbose is None
+        mock_get_logger.assert_called_once_with("test.logger")
+        mock_logger.setLevel.assert_called_once_with(logging.WARNING)
+        assert mock_logger.propagate is False
+
+    @patch("honeyhive.utils.logger.logging.getLogger")
+    def test_initialization_with_explicit_level(self, mock_get_logger: Mock) -> None:
+        """Test HoneyHiveLogger initialization with explicit log level."""
+        # Arrange
+        mock_logger = Mock()
+        mock_logger.handlers = []
+        mock_get_logger.return_value = mock_logger
+
+        # Act
+        logger = HoneyHiveLogger("test.logger", level=logging.DEBUG)
+
+        # Assert
+        assert logger.logger == mock_logger
+        mock_logger.setLevel.assert_called_once_with(logging.DEBUG)
+
+    @patch("honeyhive.utils.logger.logging.getLogger")
+    def test_initialization_with_string_level(self, mock_get_logger: Mock) -> None:
+        """Test HoneyHiveLogger initialization with string log level."""
+        # Arrange
+        mock_logger = Mock()
+        mock_logger.handlers = []
+        mock_get_logger.return_value = mock_logger
+
+        # Act
+        logger = HoneyHiveLogger("test.logger", level="WARNING")
+
+        # Assert
+        assert logger.logger == mock_logger
+        mock_logger.setLevel.assert_called_once_with(logging.WARNING)
+
+    @patch("honeyhive.utils.logger.logging.getLogger")
+    def test_initialization_with_verbose_true(self, mock_get_logger: Mock) -> None:
+        """Test HoneyHiveLogger initialization with verbose=True."""
+        # Arrange
+        mock_logger = Mock()
+        mock_logger.handlers = []
+        mock_get_logger.return_value = mock_logger
+
+        # Act
+        logger = HoneyHiveLogger("test.logger", verbose=True)
+
+        # Assert
+        assert logger.verbose is True
+        mock_logger.setLevel.assert_called_once_with(logging.DEBUG)
+
+    @patch("honeyhive.utils.logger.logging.getLogger")
+    def test_initialization_with_verbose_false(self, mock_get_logger: Mock) -> None:
+        """Test HoneyHiveLogger initialization with verbose=False."""
+        # Arrange
+        mock_logger = Mock()
+        mock_logger.handlers = []
+        mock_get_logger.return_value = mock_logger
+
+        # Act
+        logger = HoneyHiveLogger("test.logger", verbose=False)
+
+        # Assert
+        assert logger.verbose is False
+        mock_logger.setLevel.assert_called_once_with(logging.WARNING)
+
+    @patch("honeyhive.utils.logger.logging.getLogger")
+    def test_initialization_with_custom_handler(self, mock_get_logger: Mock) -> None:
+        """Test HoneyHiveLogger initialization with custom handler."""
+        # Arrange
+        mock_logger = Mock()
+        mock_logger.handlers = []
+        mock_get_logger.return_value = mock_logger
+        custom_handler = Mock()
+
+        # Act
+        logger = HoneyHiveLogger("test.logger", handler=custom_handler)
+
+        # Assert
+        assert logger.logger == mock_logger
+        mock_logger.addHandler.assert_called_once_with(custom_handler)
+
+    @patch("honeyhive.utils.logger.logging.getLogger")
+    @patch("honeyhive.utils.logger.logging.StreamHandler")
+    @patch("honeyhive.utils.logger.HoneyHiveFormatter")
+    def test_initialization_creates_default_handler(
+        self,
+        mock_formatter_class: Mock,
+        mock_handler_class: Mock,
+        mock_get_logger: Mock,
+    ) -> None:
+        """Test HoneyHiveLogger creates default handler when none provided."""
+        # Arrange
+        mock_logger = Mock()
+        mock_logger.handlers = []
+        mock_get_logger.return_value = mock_logger
+        mock_handler = Mock()
+        mock_handler_class.return_value = mock_handler
+        mock_formatter = Mock()
+        mock_formatter_class.return_value = mock_formatter
+
+        # Act
+        _ = HoneyHiveLogger("test.logger")
+
+        # Assert
+        mock_handler_class.assert_called_once_with(sys.stdout)
+        mock_formatter_class.assert_called_once()
+        mock_handler.setFormatter.assert_called_once_with(mock_formatter)
+        mock_logger.addHandler.assert_called_once_with(mock_handler)
+
+    @patch("honeyhive.utils.logger.logging.getLogger")
+    def test_initialization_with_existing_handlers(self, mock_get_logger: Mock) -> None:
+        """Test HoneyHiveLogger initialization when logger already has handlers."""
+        # Arrange
+        mock_logger = Mock()
+        existing_handler = Mock()
+        mock_logger.handlers = [existing_handler]
+        mock_get_logger.return_value = mock_logger
+
+        # Act
+        logger = HoneyHiveLogger("test.logger")
+
+        # Assert
+        assert logger.logger == mock_logger
+        mock_logger.addHandler.assert_not_called()
+
+    def test_determine_log_level_dynamically_with_explicit_level(self) -> None:
+        """Test dynamic log level determination with explicit level parameter."""
+        # Arrange
+        logger = HoneyHiveLogger.__new__(HoneyHiveLogger)
+
+        # Act
+        result = logger._determine_log_level_dynamically(logging.ERROR, None)
+
+        # Assert
+        assert result == logging.ERROR
+
+    def test_determine_log_level_dynamically_with_string_level(self) -> None:
+        """Test dynamic log level determination with string level parameter."""
+        # Arrange
+        logger = HoneyHiveLogger.__new__(HoneyHiveLogger)
+
+        # Act
+        result = logger._determine_log_level_dynamically("CRITICAL", None)
+
+        # Assert
+        assert result == logging.CRITICAL
+
+    def test_determine_log_level_dynamically_with_invalid_string(self) -> None:
+        """Test dynamic log level determination with invalid string level."""
+        # Arrange
+        logger = HoneyHiveLogger.__new__(HoneyHiveLogger)
+
+        # Act
+        result = logger._determine_log_level_dynamically("INVALID", None)
+
+        # Assert
+        assert result == logging.WARNING
+
+    def test_determine_log_level_dynamically_with_verbose_true(self) -> None:
+        """Test dynamic log level determination with verbose=True."""
+        # Arrange
+        logger = HoneyHiveLogger.__new__(HoneyHiveLogger)
+
+        # Act
+        result = logger._determine_log_level_dynamically(None, True)
+
+        # Assert
+        assert result == logging.DEBUG
+
+    def test_determine_log_level_dynamically_with_verbose_false(self) -> None:
+        """Test dynamic log level determination with verbose=False."""
+        # Arrange
+        logger = HoneyHiveLogger.__new__(HoneyHiveLogger)
+
+        # Act
+        result = logger._determine_log_level_dynamically(None, False)
+
+        # Assert
+        assert result == logging.WARNING
+
+    def test_determine_log_level_dynamically_with_defaults(self) -> None:
+        """Test dynamic log level determination with default values."""
+        # Arrange
+        logger = HoneyHiveLogger.__new__(HoneyHiveLogger)
+
+        # Act
+        result = logger._determine_log_level_dynamically(None, None)
+
+        # Assert
+        assert result == logging.WARNING
+
+    @patch("honeyhive.utils.logger.logging.getLogger")
+    def test_update_verbose_setting_to_true(self, mock_get_logger: Mock) -> None:
+        """Test updating verbose setting to True."""
+        # Arrange
+        mock_logger = Mock()
+        mock_logger.handlers = []
+        mock_get_logger.return_value = mock_logger
+        logger = HoneyHiveLogger("test.logger", verbose=False)
+
+        # Act
+        logger.update_verbose_setting(True)
+
+        # Assert
+        assert logger.verbose is True
+        mock_logger.setLevel.assert_called_with(logging.DEBUG)
+
+    @patch("honeyhive.utils.logger.logging.getLogger")
+    def test_update_verbose_setting_to_false(self, mock_get_logger: Mock) -> None:
+        """Test updating verbose setting to False."""
+        # Arrange
+        mock_logger = Mock()
+        mock_logger.handlers = []
+        mock_get_logger.return_value = mock_logger
+        logger = HoneyHiveLogger("test.logger", verbose=True)
+
+        # Act
+        logger.update_verbose_setting(False)
+
+        # Assert
+        assert logger.verbose is False
+        mock_logger.setLevel.assert_called_with(logging.WARNING)
+
+    @patch("honeyhive.utils.logger.logging.getLogger")
+    def test_log_with_context_basic(self, mock_get_logger: Mock) -> None:
+        """Test _log_with_context with basic parameters."""
+        # Arrange
+        mock_logger = Mock()
+        mock_logger.handlers = []
+        mock_get_logger.return_value = mock_logger
+        logger = HoneyHiveLogger("test.logger")
+
+        # Act
+        logger._log_with_context(logging.INFO, "Test message", ("arg1", "arg2"))
+
+        # Assert
+        mock_logger.log.assert_called_once_with(
+            logging.INFO, "Test message", "arg1", "arg2", extra={}
+        )
+
+    @patch("honeyhive.utils.logger.logging.getLogger")
+    def test_log_with_context_with_honeyhive_data(self, mock_get_logger: Mock) -> None:
+        """Test _log_with_context with HoneyHive context data."""
+        # Arrange
+        mock_logger = Mock()
+        mock_logger.handlers = []
+        mock_get_logger.return_value = mock_logger
+        logger = HoneyHiveLogger("test.logger")
+        honeyhive_data = {"session_id": "test-123"}
+
+        # Act
+        logger._log_with_context(
+            logging.WARNING,
+            "Warning message",
+            (),
+            honeyhive_data,
+            extra_key="extra_value",
+        )
+
+        # Assert
+        mock_logger.log.assert_called_once_with(
+            logging.WARNING,
+            "Warning message",
+            extra={"honeyhive_data": honeyhive_data, "extra_key": "extra_value"},
+        )
+
+    @patch("honeyhive.utils.logger.logging.getLogger")
+    def test_debug_method(self, mock_get_logger: Mock) -> None:
+        """Test debug logging method."""
+        # Arrange
+        mock_logger = Mock()
+        mock_logger.handlers = []
+        mock_get_logger.return_value = mock_logger
+        logger = HoneyHiveLogger("test.logger")
+        honeyhive_data = {"debug_info": "test"}
+
+        # Act
+        logger.debug(
+            "Debug message %s", "arg1", honeyhive_data=honeyhive_data, extra="value"
+        )
+
+        # Assert
+        mock_logger.log.assert_called_once_with(
+            logging.DEBUG,
+            "Debug message %s",
+            "arg1",
+            extra={"honeyhive_data": honeyhive_data, "extra": "value"},
+        )
+
+    @patch("honeyhive.utils.logger.logging.getLogger")
+    def test_info_method(self, mock_get_logger: Mock) -> None:
+        """Test info logging method."""
+        # Arrange
+        mock_logger = Mock()
+        mock_logger.handlers = []
+        mock_get_logger.return_value = mock_logger
+        logger = HoneyHiveLogger("test.logger")
+
+        # Act
+        logger.info("Info message")
+
+        # Assert
+        mock_logger.log.assert_called_once_with(logging.INFO, "Info message", extra={})
+
+    @patch("honeyhive.utils.logger.logging.getLogger")
+    def test_warning_method(self, mock_get_logger: Mock) -> None:
+        """Test warning logging method."""
+        # Arrange
+        mock_logger = Mock()
+        mock_logger.handlers = []
+        mock_get_logger.return_value = mock_logger
+        logger = HoneyHiveLogger("test.logger")
+
+        # Act
+        logger.warning("Warning message")
+
+        # Assert
+        mock_logger.log.assert_called_once_with(
+            logging.WARNING, "Warning message", extra={}
+        )
+
+    @patch("honeyhive.utils.logger.logging.getLogger")
+    def test_error_method(self, mock_get_logger: Mock) -> None:
+        """Test error logging method."""
+        # Arrange
+        mock_logger = Mock()
+        mock_logger.handlers = []
+        mock_get_logger.return_value = mock_logger
+        logger = HoneyHiveLogger("test.logger")
+
+        # Act
+        logger.error("Error message")
+
+        # Assert
+        mock_logger.log.assert_called_once_with(
+            logging.ERROR, "Error message", extra={}
+        )
+
+    @patch("honeyhive.utils.logger.logging.getLogger")
+    def test_critical_method(self, mock_get_logger: Mock) -> None:
+        """Test critical logging method."""
+        # Arrange
+        mock_logger = Mock()
+        mock_logger.handlers = []
+        mock_get_logger.return_value = mock_logger
+        logger = HoneyHiveLogger("test.logger")
+
+        # Act
+        logger.critical("Critical message")
+
+        # Assert
+        mock_logger.log.assert_called_once_with(
+            logging.CRITICAL, "Critical message", extra={}
+        )
+
+    @patch("honeyhive.utils.logger.logging.getLogger")
+    def test_exception_method(self, mock_get_logger: Mock) -> None:
+        """Test exception logging method."""
+        # Arrange
+        mock_logger = Mock()
+        mock_logger.handlers = []
+        mock_get_logger.return_value = mock_logger
+        logger = HoneyHiveLogger("test.logger")
+        honeyhive_data = {"error_context": "test"}
+
+        # Act
+        logger.exception(
+            "Exception message", honeyhive_data=honeyhive_data, extra="value"
+        )
+
+        # Assert
+        mock_logger.exception.assert_called_once_with(
+            "Exception message",
+            extra={"honeyhive_data": honeyhive_data, "extra": "value"},
+        )
+
+
+class TestShutdownDetection:
+    """Test suite for shutdown detection functionality."""
+
+    def setup_method(self) -> None:
+        """Reset shutdown state before each test."""
+        reset_logging_state()
+
+    def test_reset_logging_state(self) -> None:
+        """Test that reset_logging_state clears shutdown detection."""
+        # Arrange
+        _shutdown_detected.set()
+        assert _shutdown_detected.is_set() is True
+
+        # Act
+        reset_logging_state()
+
+        # Assert
+        assert _shutdown_detected.is_set() is False
+
+    def test_is_shutdown_detected_when_not_shutdown(self) -> None:
+        """Test is_shutdown_detected returns False when not shutdown."""
+        # Act
+        result = is_shutdown_detected()
+
+        # Assert
+        assert result is False
+
+    @patch("honeyhive.utils.logger.sys", None)
+    def test_detect_shutdown_conditions_with_none_sys(self) -> None:
+        """Test shutdown detection when sys module is None."""
+        # Act
+        result = _detect_shutdown_conditions()
+
+        # Assert
+        assert result is True
+        assert _shutdown_detected.is_set() is True
+
+    @patch("honeyhive.utils.logger.threading", None)
+    def test_detect_shutdown_conditions_with_none_threading(self) -> None:
+        """Test shutdown detection when threading module is None."""
+        # Act
+        result = _detect_shutdown_conditions()
+
+        # Assert
+        assert result is True
+        assert _shutdown_detected.is_set() is True
+
+    def test_detect_shutdown_conditions_with_attribute_error(self) -> None:
+        """Test shutdown detection when AttributeError is raised."""
+        # Arrange
+        with patch("honeyhive.utils.logger.sys") as mock_sys:
+            mock_sys.stdout = None
+            del mock_sys.stdout  # This will cause AttributeError
+
+            # Act
+            result = _detect_shutdown_conditions()
+
+            # Assert
+            assert result is True
+            assert _shutdown_detected.is_set() is True
+
+    @patch("honeyhive.utils.logger.sys")
+    def test_detect_shutdown_conditions_with_closed_stdout(
+        self, mock_sys: Mock
+    ) -> None:
+        """Test shutdown detection when stdout is closed."""
+        # Arrange
+        mock_stdout = Mock()
+        mock_stdout.closed = True
+        mock_sys.stdout = mock_stdout
+        mock_sys.stderr = Mock()
+        mock_sys.stderr.closed = False
+
+        # Act
+        result = _detect_shutdown_conditions()
+
+        # Assert
+        assert result is True
+        assert _shutdown_detected.is_set() is True
+
+    @patch("honeyhive.utils.logger.sys")
+    def test_detect_shutdown_conditions_with_closed_stderr(
+        self, mock_sys: Mock
+    ) -> None:
+        """Test shutdown detection when stderr is closed."""
+        # Arrange
+        mock_stdout = Mock()
+        mock_stdout.closed = False
+        mock_stderr = Mock()
+        mock_stderr.closed = True
+        mock_sys.stdout = mock_stdout
+        mock_sys.stderr = mock_stderr
+
+        # Act
+        result = _detect_shutdown_conditions()
+
+        # Assert
+        assert result is True
+        assert _shutdown_detected.is_set() is True
+
+    @patch("honeyhive.utils.logger.sys")
+    def test_detect_shutdown_conditions_with_os_error(self, mock_sys: Mock) -> None:
+        """Test shutdown detection when OSError is raised."""
+        # Arrange
+        mock_stdout = Mock()
+        mock_stdout.closed = PropertyMock(side_effect=OSError("Stream error"))
+        mock_sys.stdout = mock_stdout
+
+        # Act
+        result = _detect_shutdown_conditions()
+
+        # Assert
+        assert result is True
+        assert _shutdown_detected.is_set() is True
+
+    @patch("honeyhive.utils.logger.sys")
+    def test_detect_shutdown_conditions_normal_operation(self, mock_sys: Mock) -> None:
+        """Test shutdown detection during normal operation."""
+        # Arrange
+        mock_stdout = Mock()
+        mock_stdout.closed = False
+        mock_stderr = Mock()
+        mock_stderr.closed = False
+        mock_sys.stdout = mock_stdout
+        mock_sys.stderr = mock_stderr
+
+        # Act
+        result = _detect_shutdown_conditions()
+
+        # Assert
+        assert result is False
+        assert _shutdown_detected.is_set() is False
+
+    def test_detect_shutdown_conditions_already_detected(self) -> None:
+        """Test shutdown detection when already detected."""
+        # Arrange
+        _shutdown_detected.set()
+
+        # Act
+        result = _detect_shutdown_conditions()
+
+        # Assert
+        assert result is True
+
+    def test_is_shutdown_detected_calls_detect_shutdown_conditions(self) -> None:
+        """Test that is_shutdown_detected calls _detect_shutdown_conditions."""
+        # Arrange
+        with patch("honeyhive.utils.logger._detect_shutdown_conditions") as mock_detect:
+            mock_detect.return_value = True
+
+            # Act
+            result = is_shutdown_detected()
+
+            # Assert
+            assert result is True
+            mock_detect.assert_called_once()
+
+
+class TestModuleLevelFunctions:
+    """Test suite for module-level logger functions."""
+
+    def setup_method(self) -> None:
+        """Reset shutdown state before each test."""
+        reset_logging_state()
+
+    @patch("honeyhive.utils.logger.HoneyHiveLogger")
+    def test_get_logger_with_defaults(self, mock_logger_class: Mock) -> None:
+        """Test get_logger with default parameters."""
+        # Arrange
+        mock_logger_instance = Mock()
+        mock_logger_class.return_value = mock_logger_instance
+
+        # Act
+        result = get_logger("test.logger")
+
+        # Assert
+        assert result == mock_logger_instance
+        mock_logger_class.assert_called_once_with("test.logger", verbose=None)
+
+    @patch("honeyhive.utils.logger.HoneyHiveLogger")
+    def test_get_logger_with_explicit_verbose(self, mock_logger_class: Mock) -> None:
+        """Test get_logger with explicit verbose parameter."""
+        # Arrange
+        mock_logger_instance = Mock()
+        mock_logger_class.return_value = mock_logger_instance
+
+        # Act
+        result = get_logger("test.logger", verbose=True, level=logging.DEBUG)
+
+        # Assert
+        assert result == mock_logger_instance
+        mock_logger_class.assert_called_once_with(
+            "test.logger", verbose=True, level=logging.DEBUG
+        )
+
+    @patch("honeyhive.utils.logger.HoneyHiveLogger")
+    @patch("honeyhive.utils.logger._extract_verbose_from_tracer_dynamically")
+    def test_get_logger_with_tracer_instance(
+        self, mock_extract_verbose: Mock, mock_logger_class: Mock
+    ) -> None:
+        """Test get_logger with tracer instance."""
+        # Arrange
+        mock_logger_instance = Mock()
+        mock_logger_class.return_value = mock_logger_instance
+        mock_extract_verbose.return_value = True
+        mock_tracer = Mock()
+
+        # Act
+        result = get_logger("test.logger", tracer_instance=mock_tracer)
+
+        # Assert
+        assert result == mock_logger_instance
+        mock_extract_verbose.assert_called_once_with(mock_tracer)
+        mock_logger_class.assert_called_once_with("test.logger", verbose=True)
+
+    @patch("honeyhive.utils.logger.get_logger")
+    def test_get_tracer_logger_with_default_name(self, mock_get_logger: Mock) -> None:
+        """Test get_tracer_logger with default logger name generation."""
+        # Arrange
+        mock_logger = Mock()
+        mock_get_logger.return_value = mock_logger
+        mock_tracer = Mock()
+        mock_tracer.tracer_id = "test-tracer-123"
+
+        # Act
+        result = get_tracer_logger(mock_tracer)
+
+        # Assert
+        assert result == mock_logger
+        mock_get_logger.assert_called_once_with(
+            name="honeyhive.tracer.test-tracer-123", tracer_instance=mock_tracer
+        )
+
+    @patch("honeyhive.utils.logger.get_logger")
+    def test_get_tracer_logger_with_custom_name(self, mock_get_logger: Mock) -> None:
+        """Test get_tracer_logger with custom logger name."""
+        # Arrange
+        mock_logger = Mock()
+        mock_get_logger.return_value = mock_logger
+        mock_tracer = Mock()
+
+        # Act
+        result = get_tracer_logger(mock_tracer, "custom.logger")
+
+        # Assert
+        assert result == mock_logger
+        mock_get_logger.assert_called_once_with(
+            name="custom.logger", tracer_instance=mock_tracer
+        )
+
+    @patch("honeyhive.utils.logger.get_logger")
+    def test_get_tracer_logger_without_tracer_id(self, mock_get_logger: Mock) -> None:
+        """Test get_tracer_logger when tracer has no tracer_id attribute."""
+        # Arrange
+        mock_logger = Mock()
+        mock_get_logger.return_value = mock_logger
+        mock_tracer = Mock()
+        del mock_tracer.tracer_id  # Remove tracer_id attribute
+
+        # Act
+        result = get_tracer_logger(mock_tracer)
+
+        # Assert
+        assert result == mock_logger
+        # Should use id(mock_tracer) as fallback
+        expected_name = f"honeyhive.tracer.{id(mock_tracer)}"
+        mock_get_logger.assert_called_once_with(
+            name=expected_name, tracer_instance=mock_tracer
+        )
+
+    def test_extract_verbose_from_tracer_dynamically_with_none(self) -> None:
+        """Test _extract_verbose_from_tracer_dynamically with None tracer."""
+        # Act
+        result = _extract_verbose_from_tracer_dynamically(None)
+
+        # Assert
+        assert result is None
+
+    def test_extract_verbose_from_tracer_dynamically_with_verbose_attr(self) -> None:
+        """Test _extract_verbose_from_tracer_dynamically with verbose attribute."""
+        # Arrange
+        mock_tracer = Mock()
+        mock_tracer.verbose = True
+
+        # Act
+        result = _extract_verbose_from_tracer_dynamically(mock_tracer)
+
+        # Assert
+        assert result is True
+
+    def test_extract_verbose_from_tracer_dynamically_with_private_verbose(self) -> None:
+        """Test _extract_verbose_from_tracer_dynamically with _verbose attribute."""
+        # Arrange
+        mock_tracer = Mock()
+        del mock_tracer.verbose  # Remove verbose attribute
+        mock_tracer._verbose = False
+
+        # Act
+        result = _extract_verbose_from_tracer_dynamically(mock_tracer)
+
+        # Assert
+        assert result is False
+
+    def test_extract_verbose_from_tracer_dynamically_with_config_verbose(
+        self,
+    ) -> None:
+        """Test _extract_verbose_from_tracer_dynamically with config.verbose."""
+        # Arrange
+        mock_tracer = Mock()
+        del mock_tracer.verbose  # Remove verbose attribute
+        del mock_tracer._verbose  # Remove _verbose attribute
+        mock_config = Mock()
+        mock_config.verbose = True
+        mock_tracer.config = mock_config
+
+        # Act
+        result = _extract_verbose_from_tracer_dynamically(mock_tracer)
+
+        # Assert
+        assert result is True
+
+    def test_extract_verbose_from_tracer_dynamically_with_none_config(self) -> None:
+        """Test _extract_verbose_from_tracer_dynamically with None config."""
+        # Arrange
+        mock_tracer = Mock()
+        del mock_tracer.verbose  # Remove verbose attribute
+        del mock_tracer._verbose  # Remove _verbose attribute
+        mock_tracer.config = None
+
+        # Act
+        result = _extract_verbose_from_tracer_dynamically(mock_tracer)
+
+        # Assert
+        assert result is None
+
+    def test_extract_verbose_from_tracer_dynamically_with_attribute_error(self) -> None:
+        """Test _extract_verbose_from_tracer_dynamically with AttributeError."""
+        # Arrange
+        mock_tracer = Mock()
+        del mock_tracer.verbose  # Remove verbose attribute
+
+        # Act
+        result = _extract_verbose_from_tracer_dynamically(mock_tracer)
+
+        # Assert
+        assert result is None
+
+    def test_extract_verbose_from_tracer_dynamically_with_non_boolean(self) -> None:
+        """Test _extract_verbose_from_tracer_dynamically with non-boolean value."""
+        # Arrange
+        mock_tracer = Mock()
+        mock_tracer.verbose = "not_boolean"
+
+        # Act
+        result = _extract_verbose_from_tracer_dynamically(mock_tracer)
+
+        # Assert
+        assert result is None
+
+    def test_default_logger_exists(self) -> None:
+        """Test that default_logger is properly initialized."""
+        # Assert
+        assert default_logger is not None
+        assert hasattr(default_logger, "logger")
+
+
+class TestSafeLogFunction:
+    """Test suite for safe_log function and convenience functions."""
+
+    def setup_method(self) -> None:
+        """Reset shutdown state before each test."""
+        reset_logging_state()
+
+    @patch("honeyhive.utils.logger._detect_shutdown_conditions")
+    def test_safe_log_returns_early_on_shutdown(
+        self, mock_detect_shutdown: Mock
+    ) -> None:
+        """Test safe_log returns early when shutdown is detected."""
+        # Arrange
+        mock_detect_shutdown.return_value = True
+
+        # Act
+        safe_log(None, "info", "Test message")
+
+        # Assert
+        # safe_log should complete without raising exceptions
+        mock_detect_shutdown.assert_called_once()
+
+    @patch("honeyhive.utils.logger._detect_shutdown_conditions")
+    def test_safe_log_with_tracer_instance_logger(
+        self, mock_detect_shutdown: Mock
+    ) -> None:
+        """Test safe_log with tracer instance that has logger."""
+        # Arrange
+        mock_detect_shutdown.return_value = False
+        mock_tracer = Mock()
+        mock_logger = Mock()
+        # The safe_log function checks target_logger.logger.handlers
+        mock_logger.logger = Mock()
+        mock_logger.logger.handlers = [Mock()]  # Ensure handlers exist
+        mock_tracer.logger = mock_logger
+
+        # Act
+        safe_log(
+            mock_tracer,
+            "info",
+            "Test message %s",
+            "arg1",
+            honeyhive_data={"key": "value"},
+        )
+
+        # Assert - safe_log should return None and not raise exceptions
+        # safe_log should complete without raising exceptions
+        # The function should attempt to call the logger method
+        # Due to the complex fallback logic, we verify it doesn't crash
+
+    @patch("honeyhive.utils.logger._detect_shutdown_conditions")
+    def test_safe_log_with_tracer_instance_delegation(
+        self, mock_detect_shutdown: Mock
+    ) -> None:
+        """Test safe_log with API client pattern delegation."""
+        # Arrange
+        mock_detect_shutdown.return_value = False
+        mock_api_client = Mock()
+        mock_actual_tracer = Mock()
+        mock_logger = Mock()
+        mock_actual_tracer.logger = mock_logger
+        mock_api_client.tracer_instance = mock_actual_tracer
+        del mock_api_client.logger  # Remove logger from API client
+
+        with patch("honeyhive.utils.logger.safe_log") as mock_safe_log_recursive:
+            # Act
+            safe_log(mock_api_client, "warning", "Warning message")
+
+            # Assert
+            mock_safe_log_recursive.assert_called_once_with(
+                mock_actual_tracer, "warning", "Warning message", honeyhive_data=None
+            )
+
+    @patch("honeyhive.utils.logger._detect_shutdown_conditions")
+    @patch("honeyhive.utils.logger.get_logger")
+    def test_safe_log_with_partial_tracer_instance(
+        self, mock_get_logger: Mock, mock_detect_shutdown: Mock
+    ) -> None:
+        """Test safe_log with partially initialized tracer instance."""
+        # Arrange
+        mock_detect_shutdown.return_value = False
+        mock_tracer = Mock()
+        mock_tracer.verbose = True
+        del mock_tracer.logger  # Remove logger attribute
+        del mock_tracer.tracer_instance  # Remove tracer_instance attribute
+        mock_temp_logger = Mock()
+        mock_temp_logger.logger.handlers = [Mock()]  # Ensure handlers exist
+        mock_get_logger.return_value = mock_temp_logger
+
+        # Act
+        safe_log(mock_tracer, "debug", "Debug message")
+
+        # Assert - safe_log should return None and not raise exceptions
+        # safe_log should complete without raising exceptions
+        # Verify get_logger was called for fallback
+        mock_get_logger.assert_called_once_with("honeyhive.early_init", verbose=True)
+
+    @patch("honeyhive.utils.logger._detect_shutdown_conditions")
+    @patch("honeyhive.utils.logger.get_logger")
+    def test_safe_log_with_fallback_logger(
+        self, mock_get_logger: Mock, mock_detect_shutdown: Mock
+    ) -> None:
+        """Test safe_log with fallback logger for None tracer instance."""
+        # Arrange
+        mock_detect_shutdown.return_value = False
+        mock_fallback_logger = Mock()
+        mock_fallback_logger.logger.handlers = [Mock()]  # Ensure handlers exist
+        mock_get_logger.return_value = mock_fallback_logger
+
+        # Act
+        safe_log(None, "error", "Error message")
+
+        # Assert - safe_log should return None and not raise exceptions
+        # safe_log should complete without raising exceptions
+        # Verify get_logger was called for fallback
+        mock_get_logger.assert_called_once_with("honeyhive.fallback")
+
+    @patch("honeyhive.utils.logger._detect_shutdown_conditions")
+    def test_safe_log_with_missing_logger_handlers(
+        self, mock_detect_shutdown: Mock
+    ) -> None:
+        """Test safe_log when logger has no handlers."""
+        # Arrange
+        mock_detect_shutdown.return_value = False
+        mock_tracer = Mock()
+        mock_logger = Mock()
+        mock_logger.logger.handlers = []
+        mock_tracer.logger = mock_logger
+
+        # Act
+        safe_log(mock_tracer, "info", "Test message")
+
+        # Assert
+        # safe_log should complete without raising exceptions
+
+    @patch("honeyhive.utils.logger._detect_shutdown_conditions")
+    def test_safe_log_with_closed_stream_handler(
+        self, mock_detect_shutdown: Mock
+    ) -> None:
+        """Test safe_log when handler stream is closed."""
+        # Arrange
+        mock_detect_shutdown.return_value = False
+        mock_tracer = Mock()
+        mock_logger = Mock()
+        mock_handler = Mock()
+        mock_stream = Mock()
+        mock_stream.closed = True
+        mock_handler.stream = mock_stream
+        mock_logger.logger.handlers = [mock_handler]
+        mock_tracer.logger = mock_logger
+
+        # Act
+        safe_log(mock_tracer, "info", "Test message")
+
+        # Assert
+        # safe_log should complete without raising exceptions
+        assert _shutdown_detected.is_set() is True
+
+    @patch("honeyhive.utils.logger._detect_shutdown_conditions")
+    def test_safe_log_with_handler_without_stream(
+        self, mock_detect_shutdown: Mock
+    ) -> None:
+        """Test safe_log when handler has no stream attribute."""
+        # Arrange
+        mock_detect_shutdown.return_value = False
+        mock_tracer = Mock()
+        mock_logger = Mock()
+        mock_handler = Mock()
+        del mock_handler.stream  # Remove stream attribute
+        mock_logger.logger.handlers = [mock_handler]
+        mock_tracer.logger = mock_logger
+
+        # Act
+        safe_log(mock_tracer, "info", "Test message")
+
+        # Assert
+        mock_logger.info.assert_called_once_with("Test message")
+
+    @patch("honeyhive.utils.logger._detect_shutdown_conditions")
+    def test_safe_log_with_exception_in_logging(
+        self, mock_detect_shutdown: Mock
+    ) -> None:
+        """Test safe_log handles exceptions gracefully."""
+        # Arrange
+        mock_detect_shutdown.return_value = False
+        mock_tracer = Mock()
+        mock_logger = Mock()
+        mock_logger.info.side_effect = Exception("Logging error")
+        mock_tracer.logger = mock_logger
+
+        # Act
+        safe_log(mock_tracer, "info", "Test message")
+
+        # Assert
+        # safe_log should complete without raising exceptions  # Should fail silently
+
+    @patch("honeyhive.utils.logger._detect_shutdown_conditions")
+    def test_safe_log_without_honeyhive_data(self, mock_detect_shutdown: Mock) -> None:
+        """Test safe_log without honeyhive_data parameter."""
+        # Arrange
+        mock_detect_shutdown.return_value = False
+        mock_tracer = Mock()
+        mock_logger = Mock()
+        # The safe_log function checks target_logger.logger.handlers
+        mock_logger.logger = Mock()
+        mock_logger.logger.handlers = [Mock()]  # Ensure handlers exist
+        mock_tracer.logger = mock_logger
+
+        # Act
+        safe_log(mock_tracer, "critical", "Critical message", "arg1", extra="value")
+
+        # Assert - safe_log should return None and not raise exceptions
+        # safe_log should complete without raising exceptions
+        # The function should not crash with valid logger setup
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_safe_debug_convenience_function(self, mock_safe_log: Mock) -> None:
+        """Test safe_debug convenience function."""
+        # Arrange
+        mock_tracer = Mock()
+
+        # Act
+        safe_debug(mock_tracer, "Debug message", extra="value")
+
+        # Assert
+        mock_safe_log.assert_called_once_with(
+            mock_tracer, "debug", "Debug message", extra="value"
+        )
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_safe_info_convenience_function(self, mock_safe_log: Mock) -> None:
+        """Test safe_info convenience function."""
+        # Arrange
+        mock_tracer = Mock()
+
+        # Act
+        safe_info(mock_tracer, "Info message", extra="value")
+
+        # Assert
+        mock_safe_log.assert_called_once_with(
+            mock_tracer, "info", "Info message", extra="value"
+        )
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_safe_warning_convenience_function(self, mock_safe_log: Mock) -> None:
+        """Test safe_warning convenience function."""
+        # Arrange
+        mock_tracer = Mock()
+
+        # Act
+        safe_warning(mock_tracer, "Warning message", extra="value")
+
+        # Assert
+        mock_safe_log.assert_called_once_with(
+            mock_tracer, "warning", "Warning message", extra="value"
+        )
+
+    @patch("honeyhive.utils.logger.safe_log")
+    def test_safe_error_convenience_function(self, mock_safe_log: Mock) -> None:
+        """Test safe_error convenience function."""
+        # Arrange
+        mock_tracer = Mock()
+
+        # Act
+        safe_error(mock_tracer, "Error message", extra="value")
+
+        # Assert
+        mock_safe_log.assert_called_once_with(
+            mock_tracer, "error", "Error message", extra="value"
+        )
+
+
+class TestEdgeCasesAndErrorHandling:
+    """Test suite for edge cases and error handling scenarios."""
+
+    def setup_method(self) -> None:
+        """Reset shutdown state before each test."""
+        reset_logging_state()
+
+    @patch("honeyhive.utils.logger.logging.getLogger")
+    def test_honeyhive_logger_with_invalid_level_type(
+        self, mock_get_logger: Mock
+    ) -> None:
+        """Test HoneyHiveLogger with invalid level type."""
+        # Arrange
+        mock_logger = Mock()
+        mock_logger.handlers = []
+        mock_get_logger.return_value = mock_logger
+
+        # Act
+        _ = HoneyHiveLogger("test.logger", level=123.45)  # type: ignore[arg-type]
+
+        # Assert
+        # Should fall back to WARNING level
+        mock_logger.setLevel.assert_called_once_with(logging.WARNING)
+
+    def test_honeyhive_formatter_with_complex_honeyhive_data(self) -> None:
+        """Test HoneyHiveFormatter with complex nested HoneyHive data."""
+        # Arrange
+        formatter = HoneyHiveFormatter(include_timestamp=False, include_level=False)
+        record = logging.LogRecord(
+            name="test.logger",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=10,
+            msg="Complex data message",
+            args=(),
+            exc_info=None,
+        )
+        complex_data = {
+            "nested": {"key": "value", "number": 42},
+            "list": [1, 2, 3],
+            "boolean": True,
+            "null_value": None,
+        }
+        record.honeyhive_data = complex_data
+
+        # Act
+        result = formatter.format(record)
+
+        # Assert
+        parsed_result = json.loads(result)
+        assert parsed_result["nested"]["key"] == "value"
+        assert parsed_result["nested"]["number"] == 42
+        assert parsed_result["list"] == [1, 2, 3]
+        assert parsed_result["boolean"] is True
+        # null_value is removed by the formatter since it filters None values
+        assert "null_value" not in parsed_result
+
+    @patch("honeyhive.utils.logger._detect_shutdown_conditions")
+    def test_safe_log_with_missing_log_method(self, mock_detect_shutdown: Mock) -> None:
+        """Test safe_log when target logger doesn't have the requested log method."""
+        # Arrange
+        mock_detect_shutdown.return_value = False
+        mock_tracer = Mock()
+        mock_logger = Mock()
+        del mock_logger.nonexistent_level  # Ensure method doesn't exist
+        mock_tracer.logger = mock_logger
+
+        # Act
+        safe_log(mock_tracer, "nonexistent_level", "Test message")
+
+        # Assert
+        # safe_log should complete without raising exceptions  # Should fail silently
+
+    def test_extract_verbose_from_tracer_with_type_error(self) -> None:
+        """Test _extract_verbose_from_tracer_dynamically with TypeError."""
+        # Arrange
+        mock_tracer = Mock()
+        mock_tracer.verbose = Mock(side_effect=TypeError("Type error"))
+
+        # Act
+        result = _extract_verbose_from_tracer_dynamically(mock_tracer)
+
+        # Assert
+        assert result is None
+
+    @patch("honeyhive.utils.logger.datetime")
+    def test_honeyhive_formatter_with_datetime_error(self, mock_datetime: Mock) -> None:
+        """Test HoneyHiveFormatter when datetime raises an error."""
+        # Arrange
+        mock_datetime.now.side_effect = Exception("Datetime error")
+        formatter = HoneyHiveFormatter(include_timestamp=True, include_level=True)
+        record = logging.LogRecord(
+            name="test.logger",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=10,
+            msg="Test message",
+            args=(),
+            exc_info=None,
+        )
+
+        # Act & Assert
+        with pytest.raises(Exception, match="Datetime error"):
+            formatter.format(record)
+
+    @patch("honeyhive.utils.logger._detect_shutdown_conditions")
+    def test_safe_log_with_complex_args_and_kwargs(
+        self, mock_detect_shutdown: Mock
+    ) -> None:
+        """Test safe_log with complex arguments and keyword arguments."""
+        # Arrange
+        mock_detect_shutdown.return_value = False
+        mock_tracer = Mock()
+        mock_logger = Mock()
+        # The safe_log function checks target_logger.logger.handlers
+        mock_logger.logger = Mock()
+        mock_logger.logger.handlers = [Mock()]  # Ensure handlers exist
+        mock_tracer.logger = mock_logger
+
+        # Act
+        safe_log(
+            mock_tracer,
+            "info",
+            "Complex message %s %d",
+            "string_arg",
+            42,
+            honeyhive_data={"session": "test"},
+            extra_key="extra_value",
+            another_key=123,
+        )
+
+        # Assert - safe_log should return None and not raise exceptions
+        # safe_log should complete without raising exceptions
+        # The function should not crash with complex arguments
+
+    def test_honeyhive_logger_level_precedence(self) -> None:
+        """Test that explicit level takes precedence over verbose setting."""
+        # Arrange
+        with patch("honeyhive.utils.logger.logging.getLogger") as mock_get_logger:
+            mock_logger = Mock()
+            mock_logger.handlers = []
+            mock_get_logger.return_value = mock_logger
+
+            # Act
+            _ = HoneyHiveLogger("test.logger", level=logging.ERROR, verbose=True)
+
+            # Assert
+            # Explicit level should take precedence over verbose=True
+            mock_logger.setLevel.assert_called_once_with(logging.ERROR)

--- a/tests_v2/unit/test_utils_retry.py
+++ b/tests_v2/unit/test_utils_retry.py
@@ -1,0 +1,486 @@
+"""Unit tests for honeyhive.utils.retry.
+
+This module contains comprehensive unit tests for retry utilities including
+BackoffStrategy and RetryConfig classes with their methods.
+"""
+
+# pylint: disable=too-many-lines
+# Justification: Comprehensive unit test coverage requires extensive test cases
+
+# pylint: disable=redefined-outer-name
+# Justification: Pytest fixture pattern requires parameter shadowing
+
+# pylint: disable=protected-access
+# Justification: Unit tests need to verify private method behavior
+
+import random
+from unittest.mock import Mock, patch
+
+import httpx
+
+from honeyhive.utils.retry import BackoffStrategy, RetryConfig
+
+
+class TestBackoffStrategy:
+    """Test BackoffStrategy class functionality."""
+
+    def test_init_default_values(self) -> None:
+        """Test BackoffStrategy initialization with default values."""
+        strategy = BackoffStrategy()
+
+        assert strategy.initial_delay == 1.0
+        assert strategy.max_delay == 60.0
+        assert strategy.multiplier == 2.0
+        assert strategy.jitter == 0.1
+
+    def test_init_custom_values(self) -> None:
+        """Test BackoffStrategy initialization with custom values."""
+        strategy = BackoffStrategy(
+            initial_delay=2.0, max_delay=120.0, multiplier=3.0, jitter=0.2
+        )
+
+        assert strategy.initial_delay == 2.0
+        assert strategy.max_delay == 120.0
+        assert strategy.multiplier == 3.0
+        assert strategy.jitter == 0.2
+
+    def test_get_delay_attempt_zero(self) -> None:
+        """Test get_delay returns 0 for attempt 0."""
+        strategy = BackoffStrategy()
+
+        delay = strategy.get_delay(0)
+
+        assert delay == 0
+
+    def test_get_delay_exponential_backoff(self) -> None:
+        """Test get_delay calculates exponential backoff correctly."""
+        strategy = BackoffStrategy(
+            initial_delay=1.0,
+            multiplier=2.0,
+            jitter=0.0,  # No jitter for predictable testing
+        )
+
+        # Attempt 1: 1.0 * (2.0 ** 0) = 1.0
+        delay1 = strategy.get_delay(1)
+        assert delay1 == 1.0
+
+        # Attempt 2: 1.0 * (2.0 ** 1) = 2.0
+        delay2 = strategy.get_delay(2)
+        assert delay2 == 2.0
+
+        # Attempt 3: 1.0 * (2.0 ** 2) = 4.0
+        delay3 = strategy.get_delay(3)
+        assert delay3 == 4.0
+
+    def test_get_delay_max_delay_cap(self) -> None:
+        """Test get_delay respects max_delay cap."""
+        strategy = BackoffStrategy(
+            initial_delay=10.0,
+            max_delay=15.0,
+            multiplier=2.0,
+            jitter=0.0,  # No jitter for predictable testing
+        )
+
+        # Attempt 2: 10.0 * (2.0 ** 1) = 20.0, but capped at 15.0
+        delay = strategy.get_delay(2)
+        assert delay == 15.0
+
+    @patch.object(random, "uniform")
+    def test_get_delay_with_jitter(self, mock_uniform: Mock) -> None:
+        """Test get_delay applies jitter correctly."""
+        mock_uniform.return_value = 0.05  # 50% of jitter range
+
+        strategy = BackoffStrategy(initial_delay=1.0, multiplier=2.0, jitter=0.1)
+
+        # Base delay for attempt 1: 1.0
+        # Jitter amount: 1.0 * 0.1 = 0.1
+        # random.uniform(-0.1, 0.1) returns 0.05
+        # Final delay: 1.0 + 0.05 = 1.05
+        delay = strategy.get_delay(1)
+
+        assert delay == 1.05
+        mock_uniform.assert_called_once_with(-0.1, 0.1)
+
+    @patch.object(random, "uniform")
+    def test_get_delay_jitter_negative_result_capped_at_zero(
+        self, mock_uniform: Mock
+    ) -> None:
+        """Test get_delay ensures delay never goes below zero with jitter."""
+        mock_uniform.return_value = -0.2  # Large negative jitter
+
+        strategy = BackoffStrategy(
+            initial_delay=0.1, multiplier=1.0, jitter=0.5  # Large jitter
+        )
+
+        # Base delay: 0.1
+        # Jitter amount: 0.1 * 0.5 = 0.05
+        # random.uniform(-0.05, 0.05) returns -0.2 (mocked)
+        # Raw delay: 0.1 + (-0.2) = -0.1
+        # Capped at 0
+        delay = strategy.get_delay(1)
+
+        assert delay == 0
+
+    def test_get_delay_no_jitter_when_zero(self) -> None:
+        """Test get_delay skips jitter calculation when jitter is 0."""
+        strategy = BackoffStrategy(initial_delay=1.0, multiplier=2.0, jitter=0.0)
+
+        with patch.object(random, "uniform") as mock_uniform:
+            delay = strategy.get_delay(1)
+
+            assert delay == 1.0
+            mock_uniform.assert_not_called()
+
+
+class TestRetryConfig:
+    """Test RetryConfig class functionality."""
+
+    def test_init_default_values(self) -> None:
+        """Test RetryConfig initialization with default values."""
+        config = RetryConfig()
+
+        assert config.strategy == "exponential"
+        assert isinstance(config.backoff_strategy, BackoffStrategy)
+        assert config.max_retries == 3
+        assert config.retry_on_status_codes == {408, 429, 500, 502, 503, 504}
+
+    def test_init_custom_values(self) -> None:
+        """Test RetryConfig initialization with custom values."""
+        custom_backoff = BackoffStrategy(initial_delay=2.0)
+        custom_status_codes = {500, 502}
+
+        config = RetryConfig(
+            strategy="linear",
+            backoff_strategy=custom_backoff,
+            max_retries=5,
+            retry_on_status_codes=custom_status_codes,
+        )
+
+        assert config.strategy == "linear"
+        assert config.backoff_strategy is custom_backoff
+        assert config.max_retries == 5
+        assert config.retry_on_status_codes == custom_status_codes
+
+    def test_post_init_creates_default_backoff_strategy(self) -> None:
+        """Test __post_init__ creates default BackoffStrategy when None."""
+        config = RetryConfig(backoff_strategy=None)
+
+        assert isinstance(config.backoff_strategy, BackoffStrategy)
+        assert config.backoff_strategy.initial_delay == 1.0
+
+    def test_post_init_creates_default_status_codes(self) -> None:
+        """Test __post_init__ creates default status codes when None."""
+        config = RetryConfig(retry_on_status_codes=None)
+
+        assert config.retry_on_status_codes == {408, 429, 500, 502, 503, 504}
+
+    def test_post_init_preserves_existing_values(self) -> None:
+        """Test __post_init__ preserves existing non-None values."""
+        custom_backoff = BackoffStrategy(initial_delay=2.0)
+        custom_status_codes = {500}
+
+        config = RetryConfig(
+            backoff_strategy=custom_backoff, retry_on_status_codes=custom_status_codes
+        )
+
+        assert config.backoff_strategy is custom_backoff
+        assert config.retry_on_status_codes == custom_status_codes
+
+    def test_default_classmethod(self) -> None:
+        """Test default() classmethod creates default configuration."""
+        config = RetryConfig.default()
+
+        assert isinstance(config, RetryConfig)
+        assert config.strategy == "exponential"
+        assert isinstance(config.backoff_strategy, BackoffStrategy)
+        assert config.max_retries == 3
+        assert config.retry_on_status_codes == {408, 429, 500, 502, 503, 504}
+
+    def test_exponential_classmethod_default_values(self) -> None:
+        """Test exponential() classmethod with default values."""
+        config = RetryConfig.exponential()
+
+        assert config.strategy == "exponential"
+        assert config.backoff_strategy is not None
+        assert config.backoff_strategy.initial_delay == 1.0
+        assert config.backoff_strategy.max_delay == 60.0
+        assert config.backoff_strategy.multiplier == 2.0
+        assert config.max_retries == 3
+
+    def test_exponential_classmethod_custom_values(self) -> None:
+        """Test exponential() classmethod with custom values."""
+        config = RetryConfig.exponential(
+            initial_delay=2.0, max_delay=120.0, multiplier=3.0, max_retries=5
+        )
+
+        assert config.strategy == "exponential"
+        assert config.backoff_strategy is not None
+        assert config.backoff_strategy.initial_delay == 2.0
+        assert config.backoff_strategy.max_delay == 120.0
+        assert config.backoff_strategy.multiplier == 3.0
+        assert config.max_retries == 5
+
+    def test_linear_classmethod_default_values(self) -> None:
+        """Test linear() classmethod with default values."""
+        config = RetryConfig.linear()
+
+        assert config.strategy == "linear"
+        assert config.backoff_strategy is not None
+        assert config.backoff_strategy.initial_delay == 1.0
+        assert config.backoff_strategy.max_delay == 1.0
+        assert config.backoff_strategy.multiplier == 1.0
+        assert config.max_retries == 3
+
+    def test_linear_classmethod_custom_values(self) -> None:
+        """Test linear() classmethod with custom values."""
+        config = RetryConfig.linear(delay=2.5, max_retries=4)
+
+        assert config.strategy == "linear"
+        assert config.backoff_strategy is not None
+        assert config.backoff_strategy.initial_delay == 2.5
+        assert config.backoff_strategy.max_delay == 2.5
+        assert config.backoff_strategy.multiplier == 1.0
+        assert config.max_retries == 4
+
+    def test_constant_classmethod_default_values(self) -> None:
+        """Test constant() classmethod with default values."""
+        config = RetryConfig.constant()
+
+        assert config.strategy == "constant"
+        assert config.backoff_strategy is not None
+        assert config.backoff_strategy.initial_delay == 1.0
+        assert config.backoff_strategy.max_delay == 1.0
+        assert config.backoff_strategy.multiplier == 1.0
+        assert config.max_retries == 3
+
+    def test_constant_classmethod_custom_values(self) -> None:
+        """Test constant() classmethod with custom values."""
+        config = RetryConfig.constant(delay=3.0, max_retries=2)
+
+        assert config.strategy == "constant"
+        assert config.backoff_strategy is not None
+        assert config.backoff_strategy.initial_delay == 3.0
+        assert config.backoff_strategy.max_delay == 3.0
+        assert config.backoff_strategy.multiplier == 1.0
+        assert config.max_retries == 2
+
+    def test_should_retry_with_retryable_status_codes(self) -> None:
+        """Test should_retry returns True for retryable status codes."""
+        config = RetryConfig()
+
+        retryable_codes = [408, 429, 500, 502, 503, 504]
+
+        for status_code in retryable_codes:
+            mock_response = Mock(spec=httpx.Response)
+            mock_response.status_code = status_code
+
+            assert config.should_retry(mock_response) is True
+
+    def test_should_retry_with_non_retryable_status_codes(self) -> None:
+        """Test should_retry returns False for non-retryable status codes."""
+        config = RetryConfig()
+
+        non_retryable_codes = [200, 201, 400, 401, 403, 404]
+
+        for status_code in non_retryable_codes:
+            mock_response = Mock(spec=httpx.Response)
+            mock_response.status_code = status_code
+
+            assert config.should_retry(mock_response) is False
+
+    def test_should_retry_with_connection_error_status_code(self) -> None:
+        """Test should_retry returns True for connection error (status code 0)."""
+        config = RetryConfig()
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.status_code = 0
+
+        assert config.should_retry(mock_response) is True
+
+    def test_should_retry_with_custom_status_codes(self) -> None:
+        """Test should_retry respects custom retry_on_status_codes."""
+        config = RetryConfig(retry_on_status_codes={400, 401})
+
+        # Should retry on custom codes
+        mock_response_400 = Mock(spec=httpx.Response)
+        mock_response_400.status_code = 400
+        assert config.should_retry(mock_response_400) is True
+
+        mock_response_401 = Mock(spec=httpx.Response)
+        mock_response_401.status_code = 401
+        assert config.should_retry(mock_response_401) is True
+
+        # Should not retry on default codes that aren't in custom set
+        mock_response_500 = Mock(spec=httpx.Response)
+        mock_response_500.status_code = 500
+        assert config.should_retry(mock_response_500) is False
+
+    def test_should_retry_with_none_status_codes(self) -> None:
+        """Test should_retry handles None retry_on_status_codes gracefully."""
+        # Manually set to None to test edge case
+        config = RetryConfig()
+        config.retry_on_status_codes = None
+
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.status_code = 500
+
+        assert config.should_retry(mock_response) is False
+
+    def test_should_retry_exception_with_connection_errors(self) -> None:
+        """Test should_retry_exception returns True for connection errors."""
+        config = RetryConfig()
+
+        connection_exceptions = [
+            httpx.ConnectError("Connection failed"),
+            httpx.ConnectTimeout("Connection timeout"),
+            httpx.ReadTimeout("Read timeout"),
+            httpx.WriteTimeout("Write timeout"),
+            httpx.PoolTimeout("Pool timeout"),
+        ]
+
+        for exc in connection_exceptions:
+            assert config.should_retry_exception(exc) is True
+
+    def test_should_retry_exception_with_http_status_error_retryable(self) -> None:
+        """Test should_retry_exception with HTTPStatusError for retryable codes."""
+        config = RetryConfig()
+
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.status_code = 500
+
+        exc = httpx.HTTPStatusError(
+            "Server error", request=Mock(), response=mock_response
+        )
+
+        assert config.should_retry_exception(exc) is True
+
+    def test_should_retry_exception_with_http_status_error_non_retryable(
+        self,
+    ) -> None:
+        """Test should_retry_exception with HTTPStatusError for non-retryable codes."""
+        config = RetryConfig()
+
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.status_code = 404
+
+        exc = httpx.HTTPStatusError("Not found", request=Mock(), response=mock_response)
+
+        assert config.should_retry_exception(exc) is False
+
+    def test_should_retry_exception_with_http_status_error_none_status_codes(
+        self,
+    ) -> None:
+        """Test should_retry_exception with HTTPStatusError when codes is None."""
+        config = RetryConfig()
+        config.retry_on_status_codes = None
+
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.status_code = 500
+
+        exc = httpx.HTTPStatusError(
+            "Server error", request=Mock(), response=mock_response
+        )
+
+        assert config.should_retry_exception(exc) is False
+
+    def test_should_retry_exception_with_non_retryable_exceptions(self) -> None:
+        """Test should_retry_exception returns False for non-retryable exceptions."""
+        config = RetryConfig()
+
+        non_retryable_exceptions = [
+            ValueError("Invalid value"),
+            TypeError("Type error"),
+            KeyError("Key not found"),
+            AttributeError("Attribute error"),
+        ]
+
+        for exc in non_retryable_exceptions:
+            assert config.should_retry_exception(exc) is False
+
+    def test_should_retry_exception_with_generic_httpx_exception(self) -> None:
+        """Test should_retry_exception with generic httpx exceptions."""
+        config = RetryConfig()
+
+        # Test with a generic httpx exception that's not specifically handled
+        exc = httpx.RequestError("Generic request error")
+
+        assert config.should_retry_exception(exc) is False
+
+
+class TestRetryConfigIntegration:
+    """Test RetryConfig integration scenarios."""
+
+    def test_backoff_strategy_integration(self) -> None:
+        """Test RetryConfig works correctly with its BackoffStrategy."""
+        # Use custom BackoffStrategy with no jitter for deterministic testing
+        custom_backoff = BackoffStrategy(
+            initial_delay=0.5,
+            max_delay=10.0,
+            multiplier=2.0,
+            jitter=0.0,  # No jitter for predictable results
+        )
+        config = RetryConfig(
+            strategy="exponential", backoff_strategy=custom_backoff, max_retries=3
+        )
+
+        # Test that the backoff strategy is properly configured
+        assert config.backoff_strategy is not None
+        assert config.backoff_strategy.get_delay(0) == 0
+        assert config.backoff_strategy.get_delay(1) == 0.5
+        assert config.backoff_strategy.get_delay(2) == 1.0
+        assert config.backoff_strategy.get_delay(3) == 2.0
+
+    def test_retry_decision_with_backoff_timing(self) -> None:
+        """Test retry decision making combined with backoff timing."""
+        # Create custom backoff with no jitter for deterministic testing
+        custom_backoff = BackoffStrategy(
+            initial_delay=1.0,
+            max_delay=1.0,
+            multiplier=1.0,
+            jitter=0.0,  # No jitter for predictable results
+        )
+        config = RetryConfig(
+            strategy="linear", backoff_strategy=custom_backoff, max_retries=2
+        )
+
+        # Simulate a retryable response
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.status_code = 503
+
+        # Should retry
+        assert config.should_retry(mock_response) is True
+
+        # Get delays for retry attempts
+        assert config.backoff_strategy is not None
+        delay1 = config.backoff_strategy.get_delay(1)
+        delay2 = config.backoff_strategy.get_delay(2)
+
+        assert delay1 == 1.0
+        assert delay2 == 1.0  # Linear strategy maintains constant delay
+
+    def test_custom_configuration_end_to_end(self) -> None:
+        """Test custom configuration works end-to-end."""
+        custom_backoff = BackoffStrategy(
+            initial_delay=0.1, max_delay=5.0, multiplier=1.5, jitter=0.0
+        )
+
+        config = RetryConfig(
+            strategy="custom",
+            backoff_strategy=custom_backoff,
+            max_retries=4,
+            retry_on_status_codes={429, 503},
+        )
+
+        # Test retry decision
+        mock_response_429 = Mock(spec=httpx.Response)
+        mock_response_429.status_code = 429
+        assert config.should_retry(mock_response_429) is True
+
+        mock_response_500 = Mock(spec=httpx.Response)
+        mock_response_500.status_code = 500
+        assert config.should_retry(mock_response_500) is False
+
+        # Test backoff timing (use approximate comparison for floating point)
+        assert config.backoff_strategy is not None
+        assert config.backoff_strategy.get_delay(1) == 0.1
+        assert abs(config.backoff_strategy.get_delay(2) - 0.15) < 1e-10
+        assert abs(config.backoff_strategy.get_delay(3) - 0.225) < 1e-10

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py311, py312, py313, lint, format, docs, unit, integration, traceloop-integration, compatibility
+envlist = py311, py312, py313, lint, format, docs, unit, unit-v2, integration, traceloop-integration, compatibility
 isolated_build = True
 requires = tox>=4.0
 
@@ -199,6 +199,33 @@ setenv =
 passenv = 
     # Unit tests should be isolated - don't pass through real environment variables
     # Only pass through CI environment indicators for test reporting
+    CI
+    GITHUB_ACTIONS
+    GITLAB_CI
+    JENKINS_URL
+
+[testenv:unit-v2]
+description = run verified unit tests from tests_v2 (clean, passing tests only)
+deps = 
+    {[testenv]deps}
+    pytest-xdist>=3.0.0
+    coverage==7.10.7
+commands =
+    # Clean any existing coverage data
+    python -c "import os, glob; [os.remove(f) for f in glob.glob('.coverage*') if os.path.isfile(f)]"
+    # Run verified unit tests with coverage
+    pytest tests_v2/unit {posargs} --cov=src/honeyhive --cov-report=term-missing --cov-fail-under=40 -n auto --dist=worksteal
+setenv =
+    PYTHONPATH = {toxinidir}/src
+    PYTHONUNBUFFERED = 1
+    HH_API_KEY = test-api-key-12345
+    HH_API_URL = https://api.honeyhive.ai
+    HH_SOURCE = test
+    HH_TEST_MODE = true
+    HH_DISABLE_TRACING = false
+    HH_DISABLE_HTTP_TRACING = false
+    HH_OTLP_ENABLED = false
+passenv = 
     CI
     GITHUB_ACTIONS
     GITLAB_CI


### PR DESCRIPTION
## Summary

- Create `tests_v2/` folder structure for verified, passing tests
- Migrate 1324 unit tests that pass consistently
- Add `unit-v2` tox environment for running verified tests
- Add migration tracking document

## Why?

The existing test suite has 7 skipped test files with 128+ failures due to stale expectations after API client regeneration. Rather than trying to fix everything at once, this creates a clean foundation of working tests that we can build on incrementally.

## What's included

- 28 test files migrated to `tests_v2/unit/`
- All utility tests (`test_utils_*.py`)
- Config tests (`test_config_*.py`)
- Tracer lifecycle, utils, and processing tests
- Clean `conftest.py` fixtures

## Test plan

- [x] All 1324 tests pass: `pytest tests_v2/unit/`
- [x] tox environment works: `tox -e unit-v2`

## Next PRs (planned)

1. Fix `test_experiments_*.py` tests
2. Fix `test_tracer_core_*.py` tests
3. Fix `test_cli_main.py` tests
4. Migrate integration tests
5. Re-enable CI checks