### PR TITLE
ci: run verified tests_v2 in CI pipeline

### DIFF
--- a/.github/workflows/tox-full-suite.yml
+++ b/.github/workflows/tox-full-suite.yml
@@ -63,6 +63,7 @@ name: Tox Full Test Suite
     paths:
       - 'src/**'
       - 'tests/**'
+      - 'tests_v2/**'
       - 'tox.ini'
       - 'pyproject.toml'
       - 'openapi/**'
@@ -73,6 +74,7 @@ name: Tox Full Test Suite
     paths:
       - 'src/**'
       - 'tests/**'
+      - 'tests_v2/**'
       - 'tox.ini'
       - 'pyproject.toml'
       - 'openapi/**'
@@ -122,6 +124,12 @@ jobs:
       - name: Run comprehensive test suite
         run: |
           tox -e py${{ matrix.python-version == '3.11' && '311' || matrix.python-version == '3.12' && '312' || '313' }}
+        env:
+          HH_API_KEY: ${{ secrets.HH_API_KEY || env.HH_API_KEY }}
+
+      - name: Run verified tests (tests_v2)
+        run: |
+          tox -e unit-v2
         env:
           HH_API_KEY: ${{ secrets.HH_API_KEY || env.HH_API_KEY }}
 


### PR DESCRIPTION
## Summary

- Add `tests_v2/**` to workflow path triggers
- Run `unit-v2` tox environment after main test suite
- Ensures 1324 verified tests run on every PR

## Why?

The `tests_v2/` folder contains verified, passing tests migrated from PR #185. This PR ensures they run in CI to prevent regressions.

## Test plan

- [x] CI workflow triggers on tests_v2 changes
- [x] unit-v2 tox environment runs after main tests