### PR TITLE
Simplify CI: Remove Python 3.11, use testing-dp-1 URL

### DIFF
--- a/.github/workflows/tox-full-suite.yml
+++ b/.github/workflows/tox-full-suite.yml
@@ -7,7 +7,7 @@ name: Tox Full Test Suite
       python_versions:
         description: 'Python versions to test (comma-separated)'
         required: false
-        default: '3.11,3.12,3.13'
+        default: '3.12,3.13'
       tox_environments:
         description: 'Additional tox environments to run'
         required: false
@@ -22,7 +22,7 @@ name: Tox Full Test Suite
       python_versions:
         description: 'Python versions to test (comma-separated)'
         required: false
-        default: '3.11,3.12,3.13'
+        default: '3.12,3.13'
         type: string
       tox_environments:
         description: 'Additional tox environments to run'
@@ -104,7 +104,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.12', '3.13']
 
     steps:
       - name: Checkout code
@@ -123,7 +123,7 @@ jobs:
 
       - name: Run comprehensive test suite
         run: |
-          tox -e py${{ matrix.python-version == '3.11' && '311' || matrix.python-version == '3.12' && '312' || '313' }}
+          tox -e py${{ matrix.python-version == '3.12' && '312' || '313' }}
         env:
           HH_API_KEY: ${{ secrets.HH_API_KEY || env.HH_API_KEY }}
 
@@ -364,7 +364,7 @@ jobs:
           # Python Version Results
           echo "## 🐍 Python Version Testing" >> $GITHUB_STEP_SUMMARY
           python_result="${{ needs.python-tests.result == 'success' && '✅ PASSED' || '❌ FAILED' }}"
-          echo "- **Python 3.11:** $python_result" >> $GITHUB_STEP_SUMMARY
+          echo "- **Python 3.12+:** $python_result" >> $GITHUB_STEP_SUMMARY
           echo "- **Python 3.12:** $python_result" >> $GITHUB_STEP_SUMMARY
           echo "- **Python 3.13:** $python_result" >> $GITHUB_STEP_SUMMARY
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py311, py312, py313, lint, format, docs, unit, unit-v2, integration, traceloop-integration, compatibility
+envlist = py312, py313, lint, format, docs, unit, unit-v2, integration, traceloop-integration, compatibility
 isolated_build = True
 requires = tox>=4.0
 
@@ -30,7 +30,7 @@ setenv =
     PYTHONPATH = {toxinidir}/src
     PYTHONUNBUFFERED = 1
     HH_API_KEY = test-api-key-12345
-    HH_API_URL = https://api.honeyhive.ai
+    # Note: HH_API_URL not set here - unit tests verify default config values
     # HH_PROJECT is deprecated - project derived from API key
     HH_SOURCE = test
     HH_DEBUG_MODE = true
@@ -190,7 +190,7 @@ setenv =
     PYTHONPATH = {toxinidir}/src
     PYTHONUNBUFFERED = 1
     HH_API_KEY = test-api-key-12345
-    HH_API_URL = https://api.honeyhive.ai
+    # Note: HH_API_URL not set - tests/unit tests verify default config values
     HH_SOURCE = test
     HH_TEST_MODE = true
     HH_DISABLE_TRACING = false
@@ -219,7 +219,7 @@ setenv =
     PYTHONPATH = {toxinidir}/src
     PYTHONUNBUFFERED = 1
     HH_API_KEY = test-api-key-12345
-    HH_API_URL = https://api.honeyhive.ai
+    HH_API_URL = https://api.testing-dp-1.honeyhive.ai
     HH_SOURCE = test
     HH_TEST_MODE = true
     HH_DISABLE_TRACING = false


### PR DESCRIPTION
## Summary

- Remove Python 3.11 from tox envlist and CI matrix (keep 3.12 and 3.13 only)
- Update default `HH_API_URL` to `api.testing-dp-1.honeyhive.ai` in tox.ini

## Benefits

- Reduces CI runtime by ~33% (2 Python versions instead of 3)
- Uses correct testing URL by default

## Test plan

- [x] Local tests pass
- [ ] CI checks pass