### PR TITLE
fix: Events API fixes - ordering, project deprecation, enrich_span event_id

### DIFF
--- a/src/honeyhive/__init__.py
+++ b/src/honeyhive/__init__.py
@@ -3,7 +3,7 @@ HoneyHive Python SDK - LLM Observability and Evaluation Platform
 """
 
 # Version must be defined BEFORE imports to avoid circular import issues
-__version__ = "1.0.0rc14"
+__version__ = "1.0.0rc15"
 
 # Main API client
 from .api import HoneyHive

--- a/src/honeyhive/api/client.py
+++ b/src/honeyhive/api/client.py
@@ -16,9 +16,13 @@ Usage::
     configs = await client.configurations.list_async(project="my-project")
 """
 
+import time
+import warnings
 from typing import Any, Dict, List, Optional, Union
 
 import httpx
+
+from honeyhive.utils.retry import RetryConfig
 
 from honeyhive._generated.api_config import APIConfig
 from honeyhive.models import EventFilter, EventExportRequest, EventExportResponse
@@ -524,31 +528,42 @@ class EventsAPI(BaseAPI):
     def get_by_session_id(
         self,
         session_id: str,
-        project: str,
+        project: Optional[str] = None,
         *,
         limit: int = 1000,
     ) -> EventExportResponse:
         """Get events by session ID using the Data Plane export endpoint.
 
         This is a convenience wrapper around export() that filters by session_id.
+        Events are returned sorted by start_time in chronological order.
 
         Args:
             session_id: The session ID to fetch events for.
             project: Project name associated with the events.
+                .. deprecated:: 1.0
+                    The project parameter is deprecated and will be removed in v2.0.
+                    The backend now infers project from session_id.
             limit: Maximum number of events to return (default 1000).
 
         Returns:
-            EventExportResponse with events for the session.
+            EventExportResponse with events for the session, sorted by start_time.
 
         Example::
 
             response = client.events.get_by_session_id(
-                session_id="abc-123",
-                project="my-project"
+                session_id="abc-123"
             )
             for event in response.events:
                 print(event["event_name"])
         """
+        if project is not None:
+            warnings.warn(
+                "The 'project' parameter is deprecated and will be removed in v2.0. "
+                "The backend now infers project from session_id.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         return self.export(
             project=project,
             filters=[
@@ -560,6 +575,7 @@ class EventsAPI(BaseAPI):
                 )
             ],
             limit=limit,
+            _sort_by_time=True,  # Enable time-based sorting
         )
 
     def create(self, request: PostEventRequest) -> PostEventResponse:
@@ -581,13 +597,14 @@ class EventsAPI(BaseAPI):
 
     def export(
         self,
-        project: str,
+        project: Optional[str] = None,
         filters: Optional[List[Union[EventFilter, Dict[str, Any]]]] = None,
         *,
         date_range: Optional[Dict[str, str]] = None,
         projections: Optional[List[str]] = None,
         limit: int = 1000,
         page: int = 1,
+        _sort_by_time: bool = False,
     ) -> EventExportResponse:
         """Export events via POST /events/export (Data Plane).
 
@@ -596,7 +613,10 @@ class EventsAPI(BaseAPI):
         event_type, and other fields.
 
         Args:
-            project: Project name associated with the events (required).
+            project: Project name associated with the events.
+                .. deprecated:: 1.0
+                    The project parameter is deprecated and will be removed in v2.0.
+                    The backend now infers project from filters (e.g., session_id).
             filters: List of EventFilter objects or dicts with filter criteria.
                 Each filter should have: field, operator, value, type.
             date_range: Optional date range filter with '$gte' and '$lte' keys
@@ -604,6 +624,7 @@ class EventsAPI(BaseAPI):
             projections: Optional list of fields to include in the response.
             limit: Maximum number of results (default 1000, max 7500).
             page: Page number for pagination (default 1).
+            _sort_by_time: Internal flag to sort events by start_time (default False).
 
         Returns:
             EventExportResponse with events list and total_events count.
@@ -614,7 +635,6 @@ class EventsAPI(BaseAPI):
 
             # Export events for a session
             response = client.events.export(
-                project="my-project",
                 filters=[
                     EventFilter(
                         field="session_id",
@@ -631,7 +651,6 @@ class EventsAPI(BaseAPI):
 
             # Export with date range
             response = client.events.export(
-                project="my-project",
                 filters=[],
                 date_range={
                     "$gte": "2024-01-01T00:00:00Z",
@@ -639,6 +658,14 @@ class EventsAPI(BaseAPI):
                 }
             )
         """
+        if project is not None:
+            warnings.warn(
+                "The 'project' parameter is deprecated and will be removed in v2.0. "
+                "The backend now infers project from filters (e.g., session_id).",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         # Build filters array
         filters_data = []
         if filters:
@@ -650,11 +677,14 @@ class EventsAPI(BaseAPI):
 
         # Build request body
         request_body: Dict[str, Any] = {
-            "project": project,
             "filters": filters_data,
             "limit": limit,
             "page": page,
         }
+
+        # Only include project if provided (for backwards compatibility)
+        if project is not None:
+            request_body["project"] = project
 
         if date_range:
             request_body["dateRange"] = date_range
@@ -669,25 +699,102 @@ class EventsAPI(BaseAPI):
             "Authorization": f"Bearer {self._api_config.get_access_token()}",
         }
 
-        with httpx.Client(base_url=base_path, verify=self._api_config.verify) as client:
-            response = client.request(
-                "POST",
-                "/v1/events/export",
-                headers=headers,
-                json=request_body,
-            )
+        # Use retry logic for transient errors (502, 503, 504, etc.)
+        retry_config = RetryConfig.default()
+        last_exception: Optional[Exception] = None
+        last_response: Optional[httpx.Response] = None
 
-        if response.status_code != 200:
-            raise Exception(
-                f"export() failed with status code: {response.status_code}, "
-                f"response: {response.text}"
-            )
+        for attempt in range(retry_config.max_retries + 1):
+            try:
+                with httpx.Client(base_url=base_path, verify=self._api_config.verify) as client:
+                    response = client.request(
+                        "POST",
+                        "/v1/events/export",
+                        headers=headers,
+                        json=request_body,
+                    )
+
+                if response.status_code == 200:
+                    break  # Success, exit retry loop
+
+                # Check if we should retry this status code
+                if retry_config.should_retry(response):
+                    last_response = response
+                    if attempt < retry_config.max_retries:
+                        delay = retry_config.backoff_strategy.get_delay(attempt + 1)
+                        time.sleep(delay)
+                        continue
+
+                # Non-retryable error, raise immediately
+                raise Exception(
+                    f"export() failed with status code: {response.status_code}, "
+                    f"response: {response.text}"
+                )
+
+            except httpx.HTTPError as e:
+                if retry_config.should_retry_exception(e):
+                    last_exception = e
+                    if attempt < retry_config.max_retries:
+                        delay = retry_config.backoff_strategy.get_delay(attempt + 1)
+                        time.sleep(delay)
+                        continue
+                raise
+
+        else:
+            # All retries exhausted
+            if last_response is not None:
+                raise Exception(
+                    f"export() failed after {retry_config.max_retries + 1} attempts "
+                    f"with status code: {last_response.status_code}, "
+                    f"response: {last_response.text}"
+                )
+            if last_exception is not None:
+                raise last_exception
 
         data = response.json()
+        events = data.get("events", [])
+
+        # Sort events by start_time if requested (fixes jumbled order issue)
+        if _sort_by_time and events:
+            events = self._sort_events_by_time(events)
+
         return EventExportResponse(
-            events=data.get("events", []),
+            events=events,
             total_events=data.get("totalEvents", data.get("count", 0)),
         )
+
+    def _sort_events_by_time(self, events: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Sort events by start_time in chronological order.
+
+        Args:
+            events: List of event dictionaries.
+
+        Returns:
+            Sorted list of events by start_time.
+        """
+
+        def get_start_time(event: Dict[str, Any]) -> float:
+            """Extract start_time from event, handling various formats."""
+            # Try different possible field names for start time
+            start_time = event.get("start_time") or event.get("startTime") or event.get("created_at")
+            if start_time is None:
+                return 0.0
+            # Handle both numeric timestamps and ISO string formats
+            if isinstance(start_time, (int, float)):
+                return float(start_time)
+            if isinstance(start_time, str):
+                try:
+                    from datetime import datetime
+
+                    # Try ISO format parsing
+                    if "T" in start_time:
+                        dt = datetime.fromisoformat(start_time.replace("Z", "+00:00"))
+                        return dt.timestamp()
+                except (ValueError, TypeError):
+                    pass
+            return 0.0
+
+        return sorted(events, key=get_start_time)
 
     # Async methods
     async def list_async(
@@ -717,22 +824,34 @@ class EventsAPI(BaseAPI):
     async def get_by_session_id_async(
         self,
         session_id: str,
-        project: str,
+        project: Optional[str] = None,
         *,
         limit: int = 1000,
     ) -> EventExportResponse:
         """Get events by session ID asynchronously using the Data Plane export endpoint.
 
         Async version of get_by_session_id(). See get_by_session_id() for full documentation.
+        Events are returned sorted by start_time in chronological order.
 
         Args:
             session_id: The session ID to fetch events for.
             project: Project name associated with the events.
+                .. deprecated:: 1.0
+                    The project parameter is deprecated and will be removed in v2.0.
+                    The backend now infers project from session_id.
             limit: Maximum number of events to return (default 1000).
 
         Returns:
-            EventExportResponse with events for the session.
+            EventExportResponse with events for the session, sorted by start_time.
         """
+        if project is not None:
+            warnings.warn(
+                "The 'project' parameter is deprecated and will be removed in v2.0. "
+                "The backend now infers project from session_id.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         return await self.export_async(
             project=project,
             filters=[
@@ -744,6 +863,7 @@ class EventsAPI(BaseAPI):
                 )
             ],
             limit=limit,
+            _sort_by_time=True,  # Enable time-based sorting
         )
 
     async def create_async(self, request: PostEventRequest) -> PostEventResponse:
@@ -765,29 +885,42 @@ class EventsAPI(BaseAPI):
 
     async def export_async(
         self,
-        project: str,
+        project: Optional[str] = None,
         filters: Optional[List[Union[EventFilter, Dict[str, Any]]]] = None,
         *,
         date_range: Optional[Dict[str, str]] = None,
         projections: Optional[List[str]] = None,
         limit: int = 1000,
         page: int = 1,
+        _sort_by_time: bool = False,
     ) -> EventExportResponse:
         """Export events via POST /events/export asynchronously (Data Plane).
 
         Async version of export(). See export() for full documentation.
 
         Args:
-            project: Project name associated with the events (required).
+            project: Project name associated with the events.
+                .. deprecated:: 1.0
+                    The project parameter is deprecated and will be removed in v2.0.
+                    The backend now infers project from filters (e.g., session_id).
             filters: List of EventFilter objects or dicts with filter criteria.
             date_range: Optional date range filter.
             projections: Optional list of fields to include in the response.
             limit: Maximum number of results (default 1000, max 7500).
             page: Page number for pagination (default 1).
+            _sort_by_time: Internal flag to sort events by start_time (default False).
 
         Returns:
             EventExportResponse with events list and total_events count.
         """
+        if project is not None:
+            warnings.warn(
+                "The 'project' parameter is deprecated and will be removed in v2.0. "
+                "The backend now infers project from filters (e.g., session_id).",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         # Build filters array
         filters_data = []
         if filters:
@@ -799,11 +932,14 @@ class EventsAPI(BaseAPI):
 
         # Build request body
         request_body: Dict[str, Any] = {
-            "project": project,
             "filters": filters_data,
             "limit": limit,
             "page": page,
         }
+
+        # Only include project if provided (for backwards compatibility)
+        if project is not None:
+            request_body["project"] = project
 
         if date_range:
             request_body["dateRange"] = date_range
@@ -835,8 +971,14 @@ class EventsAPI(BaseAPI):
             )
 
         data = response.json()
+        events = data.get("events", [])
+
+        # Sort events by start_time if requested (fixes jumbled order issue)
+        if _sort_by_time and events:
+            events = self._sort_events_by_time(events)
+
         return EventExportResponse(
-            events=data.get("events", []),
+            events=events,
             total_events=data.get("totalEvents", data.get("count", 0)),
         )
 
@@ -851,7 +993,7 @@ class EventsAPI(BaseAPI):
 
     def list_events(
         self,
-        project: str,
+        project: Optional[str] = None,
         filters: Optional[List[Union[EventFilter, Dict[str, Any]]]] = None,
         *,
         date_range: Optional[Dict[str, str]] = None,
@@ -866,6 +1008,8 @@ class EventsAPI(BaseAPI):
 
         Args:
             project: Project name.
+                .. deprecated:: 1.0
+                    The project parameter is deprecated and will be removed in v2.0.
             filters: List of EventFilter objects or dicts.
             date_range: Optional date range filter.
             projections: Optional list of fields to include.
@@ -886,7 +1030,7 @@ class EventsAPI(BaseAPI):
 
     def get_events(
         self,
-        project: str,
+        project: Optional[str] = None,
         filters: Optional[List[Union[EventFilter, Dict[str, Any]]]] = None,
         *,
         date_range: Optional[Dict[str, str]] = None,
@@ -901,6 +1045,8 @@ class EventsAPI(BaseAPI):
 
         Args:
             project: Project name.
+                .. deprecated:: 1.0
+                    The project parameter is deprecated and will be removed in v2.0.
             filters: List of EventFilter objects or dicts.
             date_range: Optional date range filter.
             projections: Optional list of fields to include.
@@ -921,7 +1067,7 @@ class EventsAPI(BaseAPI):
 
     async def list_events_async(
         self,
-        project: str,
+        project: Optional[str] = None,
         filters: Optional[List[Union[EventFilter, Dict[str, Any]]]] = None,
         *,
         date_range: Optional[Dict[str, str]] = None,
@@ -929,7 +1075,13 @@ class EventsAPI(BaseAPI):
         limit: int = 1000,
         page: int = 1,
     ) -> EventExportResponse:
-        """List events asynchronously (backwards compatible alias for export_async)."""
+        """List events asynchronously (backwards compatible alias for export_async).
+
+        Args:
+            project: Project name.
+                .. deprecated:: 1.0
+                    The project parameter is deprecated and will be removed in v2.0.
+        """
         return await self.export_async(
             project=project,
             filters=filters,
@@ -941,7 +1093,7 @@ class EventsAPI(BaseAPI):
 
     async def get_events_async(
         self,
-        project: str,
+        project: Optional[str] = None,
         filters: Optional[List[Union[EventFilter, Dict[str, Any]]]] = None,
         *,
         date_range: Optional[Dict[str, str]] = None,
@@ -949,7 +1101,13 @@ class EventsAPI(BaseAPI):
         limit: int = 1000,
         page: int = 1,
     ) -> EventExportResponse:
-        """Get events asynchronously (backwards compatible alias for export_async)."""
+        """Get events asynchronously (backwards compatible alias for export_async).
+
+        Args:
+            project: Project name.
+                .. deprecated:: 1.0
+                    The project parameter is deprecated and will be removed in v2.0.
+        """
         return await self.export_async(
             project=project,
             filters=filters,

--- a/src/honeyhive/api/client.py
+++ b/src/honeyhive/api/client.py
@@ -539,10 +539,9 @@ class EventsAPI(BaseAPI):
 
         Args:
             session_id: The session ID to fetch events for.
-            project: Project name associated with the events.
-                .. deprecated:: 1.0
-                    The project parameter is deprecated and will be removed in v2.0.
-                    The backend now infers project from session_id.
+            project: Project name associated with the events. Deprecated in v1.0
+                and will be removed in v2.0. The backend now infers project from
+                session_id.
             limit: Maximum number of events to return (default 1000).
 
         Returns:
@@ -613,10 +612,9 @@ class EventsAPI(BaseAPI):
         event_type, and other fields.
 
         Args:
-            project: Project name associated with the events.
-                .. deprecated:: 1.0
-                    The project parameter is deprecated and will be removed in v2.0.
-                    The backend now infers project from filters (e.g., session_id).
+            project: Project name associated with the events. Deprecated in v1.0
+                and will be removed in v2.0. The backend now infers project from
+                filters (e.g., session_id).
             filters: List of EventFilter objects or dicts with filter criteria.
                 Each filter should have: field, operator, value, type.
             date_range: Optional date range filter with '$gte' and '$lte' keys
@@ -835,10 +833,9 @@ class EventsAPI(BaseAPI):
 
         Args:
             session_id: The session ID to fetch events for.
-            project: Project name associated with the events.
-                .. deprecated:: 1.0
-                    The project parameter is deprecated and will be removed in v2.0.
-                    The backend now infers project from session_id.
+            project: Project name associated with the events. Deprecated in v1.0
+                and will be removed in v2.0. The backend now infers project from
+                session_id.
             limit: Maximum number of events to return (default 1000).
 
         Returns:
@@ -899,10 +896,9 @@ class EventsAPI(BaseAPI):
         Async version of export(). See export() for full documentation.
 
         Args:
-            project: Project name associated with the events.
-                .. deprecated:: 1.0
-                    The project parameter is deprecated and will be removed in v2.0.
-                    The backend now infers project from filters (e.g., session_id).
+            project: Project name associated with the events. Deprecated in v1.0
+                and will be removed in v2.0. The backend now infers project from
+                filters (e.g., session_id).
             filters: List of EventFilter objects or dicts with filter criteria.
             date_range: Optional date range filter.
             projections: Optional list of fields to include in the response.
@@ -1007,9 +1003,7 @@ class EventsAPI(BaseAPI):
         POST /events/export endpoint.
 
         Args:
-            project: Project name.
-                .. deprecated:: 1.0
-                    The project parameter is deprecated and will be removed in v2.0.
+            project: Project name. Deprecated in v1.0 and will be removed in v2.0.
             filters: List of EventFilter objects or dicts.
             date_range: Optional date range filter.
             projections: Optional list of fields to include.
@@ -1044,9 +1038,7 @@ class EventsAPI(BaseAPI):
         POST /events/export endpoint.
 
         Args:
-            project: Project name.
-                .. deprecated:: 1.0
-                    The project parameter is deprecated and will be removed in v2.0.
+            project: Project name. Deprecated in v1.0 and will be removed in v2.0.
             filters: List of EventFilter objects or dicts.
             date_range: Optional date range filter.
             projections: Optional list of fields to include.
@@ -1078,9 +1070,7 @@ class EventsAPI(BaseAPI):
         """List events asynchronously (backwards compatible alias for export_async).
 
         Args:
-            project: Project name.
-                .. deprecated:: 1.0
-                    The project parameter is deprecated and will be removed in v2.0.
+            project: Project name. Deprecated in v1.0 and will be removed in v2.0.
         """
         return await self.export_async(
             project=project,
@@ -1104,9 +1094,7 @@ class EventsAPI(BaseAPI):
         """Get events asynchronously (backwards compatible alias for export_async).
 
         Args:
-            project: Project name.
-                .. deprecated:: 1.0
-                    The project parameter is deprecated and will be removed in v2.0.
+            project: Project name. Deprecated in v1.0 and will be removed in v2.0.
         """
         return await self.export_async(
             project=project,

--- a/src/honeyhive/tracer/core/context.py
+++ b/src/honeyhive/tracer/core/context.py
@@ -782,6 +782,7 @@ class TracerContextMixin(TracerContextInterface):
         user_properties: Optional[Dict[str, Any]] = None,
         error: Optional[str] = None,
         event_id: Optional[str] = None,
+        update_event_id: Optional[str] = None,
         **kwargs: Any,
     ) -> bool:
         """Enrich current span with dynamic attribute management.
@@ -807,7 +808,10 @@ class TracerContextMixin(TracerContextInterface):
             user_properties: User properties to add (automatically prefixed with
                 'honeyhive_user_properties.' for spans)
             error: Error message (stored as 'honeyhive_error')
-            event_id: Event ID (stored as 'honeyhive_event_id')
+            event_id: If provided, update an existing event with this ID
+                via PUT /events API instead of enriching the current span
+            update_event_id: Event ID to override the default event ID on the span
+                (stored as 'honeyhive_event_id' span attribute)
             **kwargs: Additional dynamic attributes (routed to metadata namespace)
 
         Returns:
@@ -852,35 +856,15 @@ class TracerContextMixin(TracerContextInterface):
             Instance method pattern introduced as primary API.
         """
         try:
-            # If event_id is provided, prioritize updating the existing event via API
-            # This allows users to enrich a specific event by ID rather than the current span
-            if event_id:
-                return self._enrich_existing_event(
-                    event_id=event_id,
-                    metadata=metadata,
-                    metrics=metrics,
-                    feedback=feedback,
-                    inputs=inputs,
-                    outputs=outputs,
-                    config=config,
-                    user_properties=user_properties,
-                    error=error,
-                    attributes=attributes,
-                    **kwargs,
-                )
-
-            # Get current span dynamically
-            current_span = self._get_current_span_dynamically()
-            if not current_span or not current_span.is_recording():
-                safe_log(self, "debug", "No active recording span for enrichment")
-                return False
-
             # Use the enrichment core logic which handles reserved parameters correctly
             # Import here to avoid circular dependency
             from ..instrumentation.enrichment import (  # pylint: disable=import-outside-toplevel
                 enrich_span_core,
             )
 
+            # enrich_span_core handles both:
+            # - update_event_id: Updates an existing event via PUT /events API
+            # - event_id: Overrides the default event ID on the span attribute
             result = enrich_span_core(
                 attributes=attributes,
                 metadata=metadata,
@@ -890,7 +874,8 @@ class TracerContextMixin(TracerContextInterface):
                 outputs=outputs,
                 config=config,
                 error=error,
-                event_id=None,  # Don't set event_id on span when enriching current span
+                event_id=event_id,
+                update_event_id=update_event_id,
                 tracer_instance=self,
                 verbose=False,
                 # Handle user_properties specially - for spans, it goes to a namespace

--- a/src/honeyhive/tracer/core/context.py
+++ b/src/honeyhive/tracer/core/context.py
@@ -852,6 +852,23 @@ class TracerContextMixin(TracerContextInterface):
             Instance method pattern introduced as primary API.
         """
         try:
+            # If event_id is provided, prioritize updating the existing event via API
+            # This allows users to enrich a specific event by ID rather than the current span
+            if event_id:
+                return self._enrich_existing_event(
+                    event_id=event_id,
+                    metadata=metadata,
+                    metrics=metrics,
+                    feedback=feedback,
+                    inputs=inputs,
+                    outputs=outputs,
+                    config=config,
+                    user_properties=user_properties,
+                    error=error,
+                    attributes=attributes,
+                    **kwargs,
+                )
+
             # Get current span dynamically
             current_span = self._get_current_span_dynamically()
             if not current_span or not current_span.is_recording():
@@ -873,7 +890,7 @@ class TracerContextMixin(TracerContextInterface):
                 outputs=outputs,
                 config=config,
                 error=error,
-                event_id=event_id,
+                event_id=None,  # Don't set event_id on span when enriching current span
                 tracer_instance=self,
                 verbose=False,
                 # Handle user_properties specially - for spans, it goes to a namespace
@@ -899,6 +916,116 @@ class TracerContextMixin(TracerContextInterface):
                 "error",
                 f"Failed to enrich span: {e}",
                 honeyhive_data={"error_type": type(e).__name__},
+            )
+            return False
+
+    def _enrich_existing_event(
+        self,
+        event_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+        metrics: Optional[Dict[str, Any]] = None,
+        feedback: Optional[Dict[str, Any]] = None,
+        inputs: Optional[Dict[str, Any]] = None,
+        outputs: Optional[Dict[str, Any]] = None,
+        config: Optional[Dict[str, Any]] = None,
+        user_properties: Optional[Dict[str, Any]] = None,
+        error: Optional[str] = None,
+        attributes: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> bool:
+        """Enrich an existing event by event_id via PUT /events API.
+
+        This method is called when enrich_span() is invoked with an event_id,
+        allowing users to update a specific existing event with new enrichment data.
+
+        Args:
+            event_id: The ID of the existing event to update.
+            metadata: Metadata to add/update on the event.
+            metrics: Metrics to add/update on the event.
+            feedback: Feedback to add/update on the event.
+            inputs: Inputs to add/update on the event.
+            outputs: Outputs to add/update on the event.
+            config: Config to add/update on the event.
+            user_properties: User properties to add/update on the event.
+            error: Error message to set on the event.
+            attributes: Additional attributes to merge into metadata.
+            **kwargs: Additional kwargs to merge into metadata.
+
+        Returns:
+            True if the event was successfully updated, False otherwise.
+        """
+        try:
+            # Check if we have a client available
+            if not hasattr(self, "client") or self.client is None:
+                safe_log(
+                    self,
+                    "warning",
+                    "No API client available to update event by event_id",
+                    honeyhive_data={"event_id": event_id},
+                )
+                return False
+
+            # Build update data for the event
+            update_data: Dict[str, Any] = {"event_id": event_id}
+
+            # Add enrichment fields if provided
+            if metadata:
+                update_data["metadata"] = metadata
+            if metrics:
+                update_data["metrics"] = metrics
+            if feedback:
+                update_data["feedback"] = feedback
+            if inputs:
+                update_data["inputs"] = inputs
+            if outputs:
+                update_data["outputs"] = outputs
+            if config:
+                update_data["config"] = config
+            if user_properties:
+                update_data["user_properties"] = user_properties
+            if error:
+                update_data["error"] = error
+
+            # Merge attributes and kwargs into metadata
+            extra_metadata: Dict[str, Any] = {}
+            if attributes:
+                extra_metadata.update(attributes)
+            if kwargs:
+                extra_metadata.update(kwargs)
+            if extra_metadata:
+                if "metadata" in update_data:
+                    update_data["metadata"].update(extra_metadata)
+                else:
+                    update_data["metadata"] = extra_metadata
+
+            # Call the Events API to update the event
+            if hasattr(self.client, "events") and hasattr(self.client.events, "update"):
+                self.client.events.update(data=update_data)
+                safe_log(
+                    self,
+                    "debug",
+                    "Successfully updated event via API",
+                    honeyhive_data={
+                        "event_id": event_id,
+                        "updated_fields": list(update_data.keys()),
+                    },
+                )
+                return True
+            else:
+                safe_log(
+                    self,
+                    "warning",
+                    "Events API update method not available",
+                    honeyhive_data={"event_id": event_id},
+                )
+                return False
+
+        except Exception as e:
+            safe_log(
+                self,
+                "error",
+                f"Failed to update event {event_id}: {e}",
+                honeyhive_data={"event_id": event_id, "error_type": type(e).__name__},
             )
             return False
 

--- a/src/honeyhive/tracer/instrumentation/enrichment.py
+++ b/src/honeyhive/tracer/instrumentation/enrichment.py
@@ -193,6 +193,7 @@ def enrich_span_core(  # pylint: disable=too-many-locals,too-many-statements
     user_properties: Optional[Dict[str, Any]] = None,
     error: Optional[str] = None,
     event_id: Optional[str] = None,
+    update_event_id: Optional[str] = None,
     tracer_instance: Optional[Any] = None,
     verbose: bool = False,
     **kwargs: Any,
@@ -237,8 +238,12 @@ def enrich_span_core(  # pylint: disable=too-many-locals,too-many-statements
     :type user_properties: Optional[Dict[str, Any]]
     :param error: Error string (honeyhive_error, non-namespaced)
     :type error: Optional[str]
-    :param event_id: Event ID (honeyhive_event_id, non-namespaced)
+    :param event_id: If provided, update an existing event with this ID
+        via PUT /events API instead of enriching the current span
     :type event_id: Optional[str]
+    :param update_event_id: Event ID to override the default event ID on the span
+        (stored as honeyhive_event_id span attribute)
+    :type update_event_id: Optional[str]
     :param tracer_instance: Optional tracer instance for logging
     :type tracer_instance: Optional[Any]
     :param verbose: Whether to log debug information
@@ -276,8 +281,8 @@ def enrich_span_core(  # pylint: disable=too-many-locals,too-many-statements
     propagation to access the current span automatically.
     """
     try:
-        # If event_id is provided, prioritize updating the existing event via API
-        # This allows users to enrich a specific event by ID rather than the current span
+        # If event_id is provided, update an existing event via PUT /events API
+        # This allows users to enrich a specific existing event by ID
         if event_id:
             return _enrich_existing_event_via_api(
                 event_id=event_id,
@@ -385,6 +390,7 @@ def enrich_span_core(  # pylint: disable=too-many-locals,too-many-statements
             "user_properties",
             "error",
             "event_id",
+            "update_event_id",
             "tracer_instance",
             "verbose",
         }
@@ -451,8 +457,10 @@ def enrich_span_core(  # pylint: disable=too-many-locals,too-many-statements
             current_span.set_attribute("honeyhive_error", error)
             attribute_count += 1
 
-        # Note: event_id is handled at the start of this function via API call
-        # It's no longer set as a span attribute since it represents an existing event
+        # update_event_id allows overriding the default event ID on the span
+        if update_event_id:
+            current_span.set_attribute("honeyhive_event_id", update_event_id)
+            attribute_count += 1
 
         # Log success if verbose mode is enabled
         if verbose:

--- a/src/honeyhive/tracer/instrumentation/enrichment.py
+++ b/src/honeyhive/tracer/instrumentation/enrichment.py
@@ -43,11 +43,146 @@ class NoOpSpan:
 # Using simple caller parameter approach instead
 
 
+def _enrich_existing_event_via_api(
+    event_id: str,
+    metadata: Optional[Dict[str, Any]] = None,
+    metrics: Optional[Dict[str, Any]] = None,
+    feedback: Optional[Dict[str, Any]] = None,
+    inputs: Optional[Dict[str, Any]] = None,
+    outputs: Optional[Dict[str, Any]] = None,
+    config: Optional[Dict[str, Any]] = None,
+    user_properties: Optional[Dict[str, Any]] = None,
+    error: Optional[str] = None,
+    attributes: Optional[Dict[str, Any]] = None,
+    tracer_instance: Optional[Any] = None,
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    """Enrich an existing event by event_id via PUT /events API.
+
+    This function is called when enrich_span() is invoked with an event_id,
+    allowing users to update a specific existing event with new enrichment data.
+
+    Args:
+        event_id: The ID of the existing event to update.
+        metadata: Metadata to add/update on the event.
+        metrics: Metrics to add/update on the event.
+        feedback: Feedback to add/update on the event.
+        inputs: Inputs to add/update on the event.
+        outputs: Outputs to add/update on the event.
+        config: Config to add/update on the event.
+        user_properties: User properties to add/update on the event.
+        error: Error message to set on the event.
+        attributes: Additional attributes to merge into metadata.
+        tracer_instance: Optional tracer instance with API client.
+        **kwargs: Additional kwargs to merge into metadata.
+
+    Returns:
+        Dict with success status and event_id.
+    """
+    try:
+        # Discover tracer if not provided
+        if tracer_instance is None:
+            try:
+                current_ctx = context.get_current()
+                tracer_instance = discover_tracer(explicit_tracer=None, ctx=current_ctx)
+            except Exception as e:
+                safe_log(
+                    None,
+                    "debug",
+                    f"Failed to discover tracer for event update: {e}",
+                    honeyhive_data={"error_type": type(e).__name__},
+                )
+
+        # Check if we have a client available
+        if tracer_instance is None or not hasattr(tracer_instance, "client"):
+            safe_log(
+                tracer_instance,
+                "warning",
+                "No API client available to update event by event_id",
+                honeyhive_data={"event_id": event_id},
+            )
+            return {"success": False, "error": "No API client available", "event_id": event_id}
+
+        client = getattr(tracer_instance, "client", None)
+        if client is None:
+            safe_log(
+                tracer_instance,
+                "warning",
+                "Tracer client is None, cannot update event",
+                honeyhive_data={"event_id": event_id},
+            )
+            return {"success": False, "error": "Tracer client is None", "event_id": event_id}
+
+        # Build update data for the event
+        update_data: Dict[str, Any] = {"event_id": event_id}
+
+        # Add enrichment fields if provided
+        if metadata:
+            update_data["metadata"] = metadata
+        if metrics:
+            update_data["metrics"] = metrics
+        if feedback:
+            update_data["feedback"] = feedback
+        if inputs:
+            update_data["inputs"] = inputs
+        if outputs:
+            update_data["outputs"] = outputs
+        if config:
+            update_data["config"] = config
+        if user_properties:
+            update_data["user_properties"] = user_properties
+        if error:
+            update_data["error"] = error
+
+        # Merge attributes and kwargs into metadata
+        extra_metadata: Dict[str, Any] = {}
+        if attributes:
+            extra_metadata.update(attributes)
+        if kwargs:
+            extra_metadata.update(kwargs)
+        if extra_metadata:
+            if "metadata" in update_data:
+                update_data["metadata"].update(extra_metadata)
+            else:
+                update_data["metadata"] = extra_metadata
+
+        # Call the Events API to update the event
+        if hasattr(client, "events") and hasattr(client.events, "update"):
+            client.events.update(data=update_data)
+            safe_log(
+                tracer_instance,
+                "debug",
+                "Successfully updated event via API",
+                honeyhive_data={
+                    "event_id": event_id,
+                    "updated_fields": list(update_data.keys()),
+                },
+            )
+            return {"success": True, "event_id": event_id, "span": NoOpSpan()}
+        else:
+            safe_log(
+                tracer_instance,
+                "warning",
+                "Events API update method not available",
+                honeyhive_data={"event_id": event_id},
+            )
+            return {"success": False, "error": "Events API not available", "event_id": event_id}
+
+    except Exception as e:
+        safe_log(
+            tracer_instance,
+            "error",
+            f"Failed to update event {event_id}: {e}",
+            honeyhive_data={"event_id": event_id, "error_type": type(e).__name__},
+        )
+        return {"success": False, "error": str(e), "event_id": event_id, "span": NoOpSpan()}
+
+
 # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-branches
 # Justification: Enrichment requires multiple optional parameters for comprehensive
 # span metadata (metadata, metrics, feedback, inputs, outputs, config, etc.).
 # Many branches are needed to handle reserved parameters correctly.
-def enrich_span_core(  # pylint: disable=too-many-locals
+def enrich_span_core(  # pylint: disable=too-many-locals,too-many-statements
     attributes: Optional[Dict[str, Any]] = None,
     metadata: Optional[Dict[str, Any]] = None,
     metrics: Optional[Dict[str, Any]] = None,
@@ -141,6 +276,24 @@ def enrich_span_core(  # pylint: disable=too-many-locals
     propagation to access the current span automatically.
     """
     try:
+        # If event_id is provided, prioritize updating the existing event via API
+        # This allows users to enrich a specific event by ID rather than the current span
+        if event_id:
+            return _enrich_existing_event_via_api(
+                event_id=event_id,
+                metadata=metadata,
+                metrics=metrics,
+                feedback=feedback,
+                inputs=inputs,
+                outputs=outputs,
+                config=config,
+                user_properties=user_properties,
+                error=error,
+                attributes=attributes,
+                tracer_instance=tracer_instance,
+                **kwargs,
+            )
+
         # Get current span from OpenTelemetry context
         current_span = trace.get_current_span()
 
@@ -298,9 +451,8 @@ def enrich_span_core(  # pylint: disable=too-many-locals
             current_span.set_attribute("honeyhive_error", error)
             attribute_count += 1
 
-        if event_id:
-            current_span.set_attribute("honeyhive_event_id", event_id)
-            attribute_count += 1
+        # Note: event_id is handled at the start of this function via API call
+        # It's no longer set as a span attribute since it represents an existing event
 
         # Log success if verbose mode is enabled
         if verbose:

--- a/tests/unit/test_api_events_fixes.py
+++ b/tests/unit/test_api_events_fixes.py
@@ -1,0 +1,531 @@
+"""Unit tests for events API fixes.
+
+This module tests the following fixes:
+1. Event ordering in get_by_session_id (sorted by start_time)
+2. Deprecation of project parameter in export and get_by_session_id
+3. Enrich span with event_id calls PUT /events API
+"""
+
+import warnings
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from honeyhive.api.client import EventsAPI, HoneyHive
+from honeyhive.models import EventExportResponse, EventFilter
+from honeyhive.tracer.instrumentation.enrichment import (
+    _enrich_existing_event_via_api,
+    enrich_span_core,
+)
+
+
+class TestEventOrderingFix:
+    """Tests for event ordering fix in get_by_session_id."""
+
+    def test_sort_events_by_time_with_numeric_timestamps(self) -> None:
+        """Test that events with numeric timestamps are sorted correctly."""
+        # Create EventsAPI instance with mock config
+        mock_config = MagicMock()
+        mock_config.base_path = "https://api.honeyhive.ai"
+        mock_config.get_access_token.return_value = "test-token"
+        mock_config.verify = True
+
+        events_api = EventsAPI(mock_config)
+
+        # Create unsorted events with numeric timestamps
+        unsorted_events: List[Dict[str, Any]] = [
+            {"event_name": "event3", "start_time": 3000.0},
+            {"event_name": "event1", "start_time": 1000.0},
+            {"event_name": "event2", "start_time": 2000.0},
+        ]
+
+        sorted_events = events_api._sort_events_by_time(unsorted_events)
+
+        assert len(sorted_events) == 3
+        assert sorted_events[0]["event_name"] == "event1"
+        assert sorted_events[1]["event_name"] == "event2"
+        assert sorted_events[2]["event_name"] == "event3"
+
+    def test_sort_events_by_time_with_iso_timestamps(self) -> None:
+        """Test that events with ISO string timestamps are sorted correctly."""
+        mock_config = MagicMock()
+        mock_config.base_path = "https://api.honeyhive.ai"
+        mock_config.get_access_token.return_value = "test-token"
+        mock_config.verify = True
+
+        events_api = EventsAPI(mock_config)
+
+        # Create unsorted events with ISO timestamps
+        unsorted_events: List[Dict[str, Any]] = [
+            {"event_name": "event3", "start_time": "2024-01-01T12:00:00Z"},
+            {"event_name": "event1", "start_time": "2024-01-01T10:00:00Z"},
+            {"event_name": "event2", "start_time": "2024-01-01T11:00:00Z"},
+        ]
+
+        sorted_events = events_api._sort_events_by_time(unsorted_events)
+
+        assert len(sorted_events) == 3
+        assert sorted_events[0]["event_name"] == "event1"
+        assert sorted_events[1]["event_name"] == "event2"
+        assert sorted_events[2]["event_name"] == "event3"
+
+    def test_sort_events_by_time_with_startTime_field(self) -> None:
+        """Test that events with startTime (camelCase) field are sorted correctly."""
+        mock_config = MagicMock()
+        mock_config.base_path = "https://api.honeyhive.ai"
+        mock_config.get_access_token.return_value = "test-token"
+        mock_config.verify = True
+
+        events_api = EventsAPI(mock_config)
+
+        # Create unsorted events with startTime (camelCase)
+        unsorted_events: List[Dict[str, Any]] = [
+            {"event_name": "event2", "startTime": 2000.0},
+            {"event_name": "event1", "startTime": 1000.0},
+        ]
+
+        sorted_events = events_api._sort_events_by_time(unsorted_events)
+
+        assert len(sorted_events) == 2
+        assert sorted_events[0]["event_name"] == "event1"
+        assert sorted_events[1]["event_name"] == "event2"
+
+    def test_sort_events_by_time_with_created_at_field(self) -> None:
+        """Test that events with created_at field are sorted correctly."""
+        mock_config = MagicMock()
+        mock_config.base_path = "https://api.honeyhive.ai"
+        mock_config.get_access_token.return_value = "test-token"
+        mock_config.verify = True
+
+        events_api = EventsAPI(mock_config)
+
+        # Create unsorted events with created_at
+        unsorted_events: List[Dict[str, Any]] = [
+            {"event_name": "event2", "created_at": 2000.0},
+            {"event_name": "event1", "created_at": 1000.0},
+        ]
+
+        sorted_events = events_api._sort_events_by_time(unsorted_events)
+
+        assert len(sorted_events) == 2
+        assert sorted_events[0]["event_name"] == "event1"
+        assert sorted_events[1]["event_name"] == "event2"
+
+    def test_sort_events_by_time_with_missing_timestamps(self) -> None:
+        """Test that events with missing timestamps are handled correctly."""
+        mock_config = MagicMock()
+        mock_config.base_path = "https://api.honeyhive.ai"
+        mock_config.get_access_token.return_value = "test-token"
+        mock_config.verify = True
+
+        events_api = EventsAPI(mock_config)
+
+        # Create events with some missing timestamps
+        unsorted_events: List[Dict[str, Any]] = [
+            {"event_name": "event3", "start_time": 3000.0},
+            {"event_name": "event1"},  # No timestamp
+            {"event_name": "event2", "start_time": 2000.0},
+        ]
+
+        sorted_events = events_api._sort_events_by_time(unsorted_events)
+
+        # Event without timestamp should come first (0.0 default)
+        assert len(sorted_events) == 3
+        assert sorted_events[0]["event_name"] == "event1"
+        assert sorted_events[1]["event_name"] == "event2"
+        assert sorted_events[2]["event_name"] == "event3"
+
+    def test_sort_events_by_time_empty_list(self) -> None:
+        """Test that empty event list returns empty list."""
+        mock_config = MagicMock()
+        mock_config.base_path = "https://api.honeyhive.ai"
+        mock_config.get_access_token.return_value = "test-token"
+        mock_config.verify = True
+
+        events_api = EventsAPI(mock_config)
+
+        sorted_events = events_api._sort_events_by_time([])
+
+        assert sorted_events == []
+
+
+class TestProjectDeprecationWarning:
+    """Tests for project parameter deprecation warnings."""
+
+    def test_export_with_project_shows_deprecation_warning(self) -> None:
+        """Test that export() with project parameter shows deprecation warning."""
+        mock_config = MagicMock()
+        mock_config.base_path = "https://api.honeyhive.ai"
+        mock_config.get_access_token.return_value = "test-token"
+        mock_config.verify = True
+
+        events_api = EventsAPI(mock_config)
+
+        with patch("httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"events": [], "totalEvents": 0}
+            mock_client.return_value.__enter__.return_value.request.return_value = (
+                mock_response
+            )
+
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                events_api.export(project="test-project", filters=[])
+
+                assert len(w) == 1
+                assert issubclass(w[0].category, DeprecationWarning)
+                assert "project" in str(w[0].message)
+                assert "deprecated" in str(w[0].message).lower()
+
+    def test_export_without_project_no_deprecation_warning(self) -> None:
+        """Test that export() without project parameter doesn't show warning."""
+        mock_config = MagicMock()
+        mock_config.base_path = "https://api.honeyhive.ai"
+        mock_config.get_access_token.return_value = "test-token"
+        mock_config.verify = True
+
+        events_api = EventsAPI(mock_config)
+
+        with patch("httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"events": [], "totalEvents": 0}
+            mock_client.return_value.__enter__.return_value.request.return_value = (
+                mock_response
+            )
+
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                events_api.export(filters=[])
+
+                # No deprecation warnings should be raised
+                deprecation_warnings = [
+                    warning
+                    for warning in w
+                    if issubclass(warning.category, DeprecationWarning)
+                ]
+                assert len(deprecation_warnings) == 0
+
+    def test_get_by_session_id_with_project_shows_deprecation_warning(self) -> None:
+        """Test that get_by_session_id() with project shows deprecation warning."""
+        mock_config = MagicMock()
+        mock_config.base_path = "https://api.honeyhive.ai"
+        mock_config.get_access_token.return_value = "test-token"
+        mock_config.verify = True
+
+        events_api = EventsAPI(mock_config)
+
+        with patch("httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"events": [], "totalEvents": 0}
+            mock_client.return_value.__enter__.return_value.request.return_value = (
+                mock_response
+            )
+
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                events_api.get_by_session_id(
+                    session_id="test-session-id", project="test-project"
+                )
+
+                assert len(w) >= 1
+                deprecation_warnings = [
+                    warning
+                    for warning in w
+                    if issubclass(warning.category, DeprecationWarning)
+                ]
+                assert len(deprecation_warnings) >= 1
+                assert any("project" in str(warning.message) for warning in deprecation_warnings)
+
+    def test_get_by_session_id_without_project_no_deprecation_warning(self) -> None:
+        """Test that get_by_session_id() without project doesn't show warning."""
+        mock_config = MagicMock()
+        mock_config.base_path = "https://api.honeyhive.ai"
+        mock_config.get_access_token.return_value = "test-token"
+        mock_config.verify = True
+
+        events_api = EventsAPI(mock_config)
+
+        with patch("httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"events": [], "totalEvents": 0}
+            mock_client.return_value.__enter__.return_value.request.return_value = (
+                mock_response
+            )
+
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                events_api.get_by_session_id(session_id="test-session-id")
+
+                # No deprecation warnings should be raised
+                deprecation_warnings = [
+                    warning
+                    for warning in w
+                    if issubclass(warning.category, DeprecationWarning)
+                ]
+                assert len(deprecation_warnings) == 0
+
+
+class TestExportRequestBody:
+    """Tests for export request body construction."""
+
+    def test_export_without_project_does_not_include_project_in_request(self) -> None:
+        """Test that export without project doesn't include project in request."""
+        mock_config = MagicMock()
+        mock_config.base_path = "https://api.honeyhive.ai"
+        mock_config.get_access_token.return_value = "test-token"
+        mock_config.verify = True
+
+        events_api = EventsAPI(mock_config)
+
+        with patch("httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"events": [], "totalEvents": 0}
+            mock_request = mock_client.return_value.__enter__.return_value.request
+            mock_request.return_value = mock_response
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                events_api.export(filters=[])
+
+                # Verify the request body
+                call_args = mock_request.call_args
+                request_body = call_args.kwargs.get("json", {})
+                assert "project" not in request_body
+
+    def test_export_with_project_includes_project_in_request(self) -> None:
+        """Test that export with project includes project in request."""
+        mock_config = MagicMock()
+        mock_config.base_path = "https://api.honeyhive.ai"
+        mock_config.get_access_token.return_value = "test-token"
+        mock_config.verify = True
+
+        events_api = EventsAPI(mock_config)
+
+        with patch("httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"events": [], "totalEvents": 0}
+            mock_request = mock_client.return_value.__enter__.return_value.request
+            mock_request.return_value = mock_response
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                events_api.export(project="test-project", filters=[])
+
+                # Verify the request body
+                call_args = mock_request.call_args
+                request_body = call_args.kwargs.get("json", {})
+                assert request_body.get("project") == "test-project"
+
+
+class TestGetBySessionIdSorting:
+    """Tests for get_by_session_id sorting behavior."""
+
+    def test_get_by_session_id_returns_sorted_events(self) -> None:
+        """Test that get_by_session_id returns events sorted by start_time."""
+        mock_config = MagicMock()
+        mock_config.base_path = "https://api.honeyhive.ai"
+        mock_config.get_access_token.return_value = "test-token"
+        mock_config.verify = True
+
+        events_api = EventsAPI(mock_config)
+
+        # Create unsorted events response
+        unsorted_events = [
+            {"event_name": "event3", "start_time": 3000.0},
+            {"event_name": "event1", "start_time": 1000.0},
+            {"event_name": "event2", "start_time": 2000.0},
+        ]
+
+        with patch("httpx.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "events": unsorted_events,
+                "totalEvents": 3,
+            }
+            mock_client.return_value.__enter__.return_value.request.return_value = (
+                mock_response
+            )
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                response = events_api.get_by_session_id(session_id="test-session-id")
+
+                # Verify events are sorted
+                assert len(response.events) == 3
+                assert response.events[0]["event_name"] == "event1"
+                assert response.events[1]["event_name"] == "event2"
+                assert response.events[2]["event_name"] == "event3"
+
+
+class TestEnrichSpanEventIdFix:
+    """Tests for enrich_span event_id prioritization fix.
+
+    When enrich_span is called with event_id, it should call PUT /events
+    to update the existing event instead of setting span attributes.
+    """
+
+    def test_enrich_existing_event_calls_api_update(self) -> None:
+        """Test that _enrich_existing_event_via_api calls the Events API update."""
+        # Create mock tracer with client
+        mock_client = MagicMock()
+        mock_events_api = MagicMock()
+        mock_client.events = mock_events_api
+
+        mock_tracer = MagicMock()
+        mock_tracer.client = mock_client
+
+        result = _enrich_existing_event_via_api(
+            event_id="test-event-123",
+            metadata={"key": "value"},
+            metrics={"score": 0.95},
+            tracer_instance=mock_tracer,
+        )
+
+        # Verify API was called
+        mock_events_api.update.assert_called_once()
+        call_args = mock_events_api.update.call_args
+        update_data = call_args.kwargs.get("data", {})
+
+        assert update_data["event_id"] == "test-event-123"
+        assert update_data["metadata"] == {"key": "value"}
+        assert update_data["metrics"] == {"score": 0.95}
+        assert result["success"] is True
+
+    def test_enrich_existing_event_with_all_fields(self) -> None:
+        """Test that all enrichment fields are passed to the API."""
+        mock_client = MagicMock()
+        mock_events_api = MagicMock()
+        mock_client.events = mock_events_api
+
+        mock_tracer = MagicMock()
+        mock_tracer.client = mock_client
+
+        result = _enrich_existing_event_via_api(
+            event_id="test-event-456",
+            metadata={"meta": "data"},
+            metrics={"latency": 100},
+            feedback={"rating": 5},
+            inputs={"input": "test"},
+            outputs={"output": "result"},
+            config={"model": "gpt-4"},
+            user_properties={"user_id": "user-123"},
+            error="test error",
+            tracer_instance=mock_tracer,
+        )
+
+        mock_events_api.update.assert_called_once()
+        call_args = mock_events_api.update.call_args
+        update_data = call_args.kwargs.get("data", {})
+
+        assert update_data["event_id"] == "test-event-456"
+        assert update_data["metadata"] == {"meta": "data"}
+        assert update_data["metrics"] == {"latency": 100}
+        assert update_data["feedback"] == {"rating": 5}
+        assert update_data["inputs"] == {"input": "test"}
+        assert update_data["outputs"] == {"output": "result"}
+        assert update_data["config"] == {"model": "gpt-4"}
+        assert update_data["user_properties"] == {"user_id": "user-123"}
+        assert update_data["error"] == "test error"
+        assert result["success"] is True
+
+    def test_enrich_existing_event_merges_attributes_to_metadata(self) -> None:
+        """Test that attributes and kwargs are merged into metadata."""
+        mock_client = MagicMock()
+        mock_events_api = MagicMock()
+        mock_client.events = mock_events_api
+
+        mock_tracer = MagicMock()
+        mock_tracer.client = mock_client
+
+        result = _enrich_existing_event_via_api(
+            event_id="test-event-789",
+            metadata={"existing": "value"},
+            attributes={"attr_key": "attr_value"},
+            tracer_instance=mock_tracer,
+            extra_kwarg="kwarg_value",
+        )
+
+        mock_events_api.update.assert_called_once()
+        call_args = mock_events_api.update.call_args
+        update_data = call_args.kwargs.get("data", {})
+
+        # Metadata should contain merged values
+        assert update_data["metadata"]["existing"] == "value"
+        assert update_data["metadata"]["attr_key"] == "attr_value"
+        assert update_data["metadata"]["extra_kwarg"] == "kwarg_value"
+        assert result["success"] is True
+
+    def test_enrich_existing_event_no_client_returns_failure(self) -> None:
+        """Test that missing client returns failure."""
+        mock_tracer = MagicMock()
+        mock_tracer.client = None
+
+        result = _enrich_existing_event_via_api(
+            event_id="test-event-abc",
+            metadata={"key": "value"},
+            tracer_instance=mock_tracer,
+        )
+
+        assert result["success"] is False
+        assert "event_id" in result
+
+    def test_enrich_existing_event_no_tracer_returns_failure(self) -> None:
+        """Test that missing tracer returns failure."""
+        with patch(
+            "honeyhive.tracer.instrumentation.enrichment.discover_tracer"
+        ) as mock_discover:
+            mock_discover.return_value = None
+
+            result = _enrich_existing_event_via_api(
+                event_id="test-event-xyz",
+                metadata={"key": "value"},
+                tracer_instance=None,
+            )
+
+            assert result["success"] is False
+
+    def test_enrich_span_core_with_event_id_calls_api(self) -> None:
+        """Test that enrich_span_core with event_id calls the API instead of setting span attrs."""
+        mock_client = MagicMock()
+        mock_events_api = MagicMock()
+        mock_client.events = mock_events_api
+
+        mock_tracer = MagicMock()
+        mock_tracer.client = mock_client
+
+        result = enrich_span_core(
+            event_id="existing-event-123",
+            metadata={"enriched": "data"},
+            tracer_instance=mock_tracer,
+        )
+
+        # Verify API was called
+        mock_events_api.update.assert_called_once()
+        assert result["success"] is True
+        assert result.get("event_id") == "existing-event-123"
+
+    def test_enrich_span_core_without_event_id_sets_span_attrs(self) -> None:
+        """Test that enrich_span_core without event_id sets span attributes normally."""
+        with patch("honeyhive.tracer.instrumentation.enrichment.trace") as mock_trace:
+            mock_span = MagicMock()
+            mock_span.set_attribute = MagicMock()
+            mock_trace.get_current_span.return_value = mock_span
+
+            result = enrich_span_core(
+                metadata={"key": "value"},
+                tracer_instance=None,
+            )
+
+            # Span attributes should be set
+            mock_span.set_attribute.assert_called()
+            assert result["success"] is True
+            assert "event_id" not in result

--- a/tests/unit/test_tracer_instrumentation_enrichment.py
+++ b/tests/unit/test_tracer_instrumentation_enrichment.py
@@ -908,29 +908,31 @@ class TestBackwardsCompatibility:
         mock_set_attrs.assert_any_call(mock_span, "honeyhive_config", config)
 
     @patch("honeyhive.tracer.instrumentation.enrichment.trace.get_current_span")
-    def test_error_and_event_id_attributes(
+    def test_error_and_update_event_id_attributes(
         self, mock_get_span: Any, honeyhive_tracer: Any
     ) -> None:
-        """Test error and event_id are set as non-namespaced attributes.
+        """Test error and update_event_id are set as non-namespaced attributes.
 
         These are special attributes that don't use namespace routing.
+        Note: update_event_id sets the honeyhive_event_id span attribute,
+        while event_id triggers an API call to update an existing event.
         """
         mock_span = Mock()
         mock_span.set_attribute = Mock()
         mock_get_span.return_value = mock_span
 
         error = "Something went wrong"
-        event_id = "evt_123"
+        update_event_id = "evt_123"
 
         result = enrich_span_core(
-            error=error, event_id=event_id, tracer_instance=honeyhive_tracer
+            error=error, update_event_id=update_event_id, tracer_instance=honeyhive_tracer
         )
 
         assert result["success"] is True
 
         # Verify direct attribute setting (no namespace)
         mock_span.set_attribute.assert_any_call("honeyhive_error", error)
-        mock_span.set_attribute.assert_any_call("honeyhive_event_id", event_id)
+        mock_span.set_attribute.assert_any_call("honeyhive_event_id", update_event_id)
 
 
 class TestNewFeatures:
@@ -1126,7 +1128,7 @@ class TestComplexDataHandling:
             outputs={"response": "hi"},
             config={"temp": 0.7},
             error="test error",
-            event_id="evt_123",
+            update_event_id="evt_123",  # Use update_event_id for span attribute
             tracer_instance=honeyhive_tracer,
         )
 

--- a/tests_v2/integrations/test_events_fixes_integration.py
+++ b/tests_v2/integrations/test_events_fixes_integration.py
@@ -1,0 +1,296 @@
+"""Integration tests for events API fixes.
+
+These tests require real API keys and make actual API calls.
+They are skipped by default unless the required environment variables are set.
+
+Tests:
+1. Event ordering in get_by_session_id (sorted by start_time)
+2. Deprecation of project parameter in export and get_by_session_id
+3. Enrich span with event_id calls PUT /events API
+"""
+
+import os
+import time
+import uuid
+import warnings
+from typing import Any, Dict, List
+
+import pytest
+
+from honeyhive import HoneyHiveTracer, trace
+from honeyhive.api import HoneyHive
+from honeyhive.models import EventFilter
+
+
+# Skip all tests if HH_API_KEY is not set
+pytestmark = pytest.mark.skipif(
+    not os.getenv("HH_API_KEY"),
+    reason="HH_API_KEY not set - skipping integration tests",
+)
+
+
+@pytest.fixture
+def api_client() -> HoneyHive:
+    """Create HoneyHive API client using HH_API_URL for both DP and CP."""
+    dp_url = os.getenv("HH_API_URL", "https://api.honeyhive.ai")
+    return HoneyHive(
+        api_key=os.getenv("HH_API_KEY"),
+        base_url=dp_url,
+        cp_base_url=dp_url,
+    )
+
+
+@pytest.fixture
+def project_name() -> str:
+    """Get project name from environment."""
+    return os.getenv("HH_PROJECT", "sdk-integration-tests")
+
+
+@pytest.fixture
+def tracer(project_name: str) -> HoneyHiveTracer:
+    """Create a HoneyHive tracer for testing."""
+    tracer = HoneyHiveTracer.init(
+        api_key=os.getenv("HH_API_KEY"),
+        project=project_name,
+        session_name=f"test-session-{uuid.uuid4().hex[:8]}",
+        server_url=os.getenv("HH_API_URL"),  # Use test environment URL
+    )
+    yield tracer
+    # Cleanup
+    if hasattr(tracer, "flush"):
+        tracer.flush()
+
+
+class TestEventOrderingIntegration:
+    """Integration tests for event ordering in get_by_session_id."""
+
+    def test_get_by_session_id_returns_chronological_order(
+        self, api_client: HoneyHive, tracer: HoneyHiveTracer, fetch_events, project_name: str
+    ) -> None:
+        """Test that events are returned in chronological order."""
+        session_id = tracer.session_id
+        assert session_id is not None
+
+        # Create multiple spans with known order
+        @trace(tracer=tracer, event_type="tool")
+        def first_operation() -> str:
+            time.sleep(0.1)  # Small delay to ensure distinct timestamps
+            return "first"
+
+        @trace(tracer=tracer, event_type="tool")
+        def second_operation() -> str:
+            time.sleep(0.1)
+            return "second"
+
+        @trace(tracer=tracer, event_type="tool")
+        def third_operation() -> str:
+            return "third"
+
+        # Execute in order
+        first_operation()
+        second_operation()
+        third_operation()
+
+        # Flush and wait for events to be processed
+        if hasattr(tracer, "flush"):
+            tracer.flush()
+
+        # Fetch events using helper with retry logic
+        events = fetch_events(
+            session_id=session_id,
+            project=project_name,
+            max_retries=10,
+            retry_delay=3.0,
+        )
+
+        # Verify we got events
+        assert len(events) >= 3, f"Expected at least 3 events, got {len(events)}"
+
+        # Filter to our operation events
+        operation_events = [
+            e
+            for e in events
+            if e.get("event_name", "").endswith("_operation")
+        ]
+
+        if len(operation_events) >= 3:
+            # Verify they are in chronological order (first should come before second, etc.)
+            event_names = [e.get("event_name", "") for e in operation_events]
+            # Check that events with earlier timestamps come first
+            for i in range(len(operation_events) - 1):
+                current_time = operation_events[i].get("start_time", 0)
+                next_time = operation_events[i + 1].get("start_time", 0)
+                if current_time and next_time:
+                    assert current_time <= next_time, (
+                        f"Events not in chronological order: {event_names}"
+                    )
+
+
+class TestProjectDeprecationIntegration:
+    """Integration tests for project parameter deprecation."""
+
+    def test_export_without_project_works(self, api_client: HoneyHive, tracer: HoneyHiveTracer) -> None:
+        """Test that export works without project parameter."""
+        session_id = tracer.session_id
+        assert session_id is not None
+
+        # Create a test event
+        @trace(tracer=tracer, event_type="tool")
+        def test_operation() -> str:
+            return "test"
+
+        test_operation()
+
+        if hasattr(tracer, "flush"):
+            tracer.flush()
+        time.sleep(2)
+
+        # Export without project - should work and not raise
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            response = api_client.events.export(
+                filters=[
+                    EventFilter(
+                        field="session_id",
+                        operator="is",
+                        value=session_id,
+                        type="string",
+                    )
+                ],
+                limit=10,
+            )
+
+            # No deprecation warnings should be raised
+            deprecation_warnings = [
+                warning
+                for warning in w
+                if issubclass(warning.category, DeprecationWarning)
+            ]
+            assert len(deprecation_warnings) == 0
+
+        # Should still get events
+        assert response is not None
+
+    def test_export_with_project_shows_warning(
+        self, api_client: HoneyHive, project_name: str, tracer: HoneyHiveTracer
+    ) -> None:
+        """Test that export with project shows deprecation warning."""
+        session_id = tracer.session_id
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            response = api_client.events.export(
+                project=project_name,
+                filters=[
+                    EventFilter(
+                        field="session_id",
+                        operator="is",
+                        value=session_id,
+                        type="string",
+                    )
+                ],
+                limit=10,
+            )
+
+            # Should have deprecation warning
+            deprecation_warnings = [
+                warning
+                for warning in w
+                if issubclass(warning.category, DeprecationWarning)
+            ]
+            assert len(deprecation_warnings) >= 1
+
+
+class TestEnrichSpanEventIdIntegration:
+    """Integration tests for enrich_span with event_id."""
+
+    def test_enrich_span_with_event_id_updates_event(
+        self, api_client: HoneyHive, tracer: HoneyHiveTracer
+    ) -> None:
+        """Test that enrich_span with event_id updates an existing event."""
+        session_id = tracer.session_id
+        assert session_id is not None
+
+        # Create a test event and get its ID
+        event_id = None
+
+        @trace(tracer=tracer, event_type="tool")
+        def operation_to_enrich() -> str:
+            return "initial result"
+
+        operation_to_enrich()
+
+        if hasattr(tracer, "flush"):
+            tracer.flush()
+        time.sleep(2)
+
+        # Get the event ID from the session
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            response = api_client.events.get_by_session_id(session_id=session_id)
+
+        # Find the event we created
+        for event in response.events:
+            if event.get("event_name") == "operation_to_enrich":
+                event_id = event.get("event_id") or event.get("_id")
+                break
+
+        if event_id:
+            # Now enrich that specific event using its ID
+            unique_value = f"enriched-{uuid.uuid4().hex[:8]}"
+            result = tracer.enrich_span(
+                event_id=event_id,
+                metadata={"enriched_key": unique_value},
+                metrics={"enrichment_score": 0.99},
+            )
+
+            assert result is True, "enrich_span with event_id should return True"
+
+            # Wait for the update to be processed
+            time.sleep(2)
+
+            # Fetch the event again and verify the enrichment
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                updated_response = api_client.events.get_by_session_id(
+                    session_id=session_id
+                )
+
+            # Find the enriched event
+            enriched_event = None
+            for event in updated_response.events:
+                if (event.get("event_id") or event.get("_id")) == event_id:
+                    enriched_event = event
+                    break
+
+            if enriched_event:
+                # Verify the enrichment was applied
+                metadata = enriched_event.get("metadata", {})
+                metrics = enriched_event.get("metrics", {})
+
+                # The enrichment should be present
+                assert (
+                    metadata.get("enriched_key") == unique_value
+                    or "enriched_key" in str(enriched_event)
+                ), f"Enrichment metadata not found in event: {enriched_event}"
+
+    def test_enrich_span_without_event_id_enriches_current_span(
+        self, tracer: HoneyHiveTracer
+    ) -> None:
+        """Test that enrich_span without event_id enriches the current span."""
+
+        @trace(tracer=tracer, event_type="tool")
+        def operation_with_enrichment() -> str:
+            # Enrich the current span (no event_id)
+            result = tracer.enrich_span(
+                metadata={"key": "value"},
+                metrics={"score": 0.95},
+            )
+            assert result is True, "enrich_span should succeed"
+            return "result"
+
+        output = operation_with_enrichment()
+        assert output == "result"
+
+        if hasattr(tracer, "flush"):
+            tracer.flush()


### PR DESCRIPTION
## Summary

- **Fix jumbled event ordering**: `get_by_session_id` now returns events sorted chronologically by `start_time`
- **Deprecate project parameter**: `export()` and `get_by_session_id()` now show `DeprecationWarning` when `project` is passed (backend infers from filters)
- **Fix enrich_span with event_id**: When `event_id` is provided, `enrich_span` now calls `PUT /events` API to update that specific event instead of enriching the current span
- **Add retry logic**: `export()` now retries on transient errors (502, 503, 504) with exponential backoff
- **Bumps version to 1.0.0rc15**

## Test plan

- [x] Unit tests: 20 tests covering sorting logic, deprecation warnings, request body construction, and enrich_span behavior
- [x] Integration tests: 5 tests verifying end-to-end functionality against live backend
- [ ] Manual verification of deprecation warnings in user code

## Files changed

- `src/honeyhive/__init__.py` - Version bump
- `src/honeyhive/api/client.py` - Event sorting, project deprecation, retry logic
- `src/honeyhive/tracer/core/context.py` - enrich_span event_id handling
- `src/honeyhive/tracer/instrumentation/enrichment.py` - API update logic for event_id
- `tests/unit/test_api_events_fixes.py` - New unit tests
- `tests_v2/integrations/test_events_fixes_integration.py` - New integration tests