### PR TITLE
fix: Fix import errors and AttributeError in RC9 (events.py, context.py)

### DIFF
--- a/src/honeyhive/__init__.py
+++ b/src/honeyhive/__init__.py
@@ -3,7 +3,7 @@ HoneyHive Python SDK - LLM Observability and Evaluation Platform
 """
 
 # Version must be defined BEFORE imports to avoid circular import issues
-__version__ = "1.0.0rc9.post1"
+__version__ = "1.0.0rc9.post2"
 
 # Main API client
 from .api import HoneyHive

--- a/src/honeyhive/api/datapoints.py
+++ b/src/honeyhive/api/datapoints.py
@@ -1,9 +1,10 @@
 """Datapoints API module for HoneyHive."""
 
-from typing import List, Optional
+from typing import Any, List, Optional
 
-from ..models import CreateDatapointRequest, Datapoint, UpdateDatapointRequest
-from .base import BaseAPI
+from ..models import CreateDatapointRequest, UpdateDatapointRequest
+from .._generated.models import GetDatapointResponse as Datapoint
+from ._base import BaseAPI
 
 
 class DatapointsAPI(BaseAPI):

--- a/src/honeyhive/api/events.py
+++ b/src/honeyhive/api/events.py
@@ -2,8 +2,13 @@
 
 from typing import Any, Dict, List, Optional, Union
 
-from ..models import CreateEventRequest, Event, EventFilter
-from .base import BaseAPI
+from ..models import Event
+from .._generated.models import PostEventRequest, SingleFilter
+from ._base import BaseAPI
+
+# Type aliases for backwards compatibility
+CreateEventRequest = PostEventRequest
+EventFilter = SingleFilter
 
 
 class CreateEventResponse:  # pylint: disable=too-few-public-methods

--- a/src/honeyhive/api/metrics.py
+++ b/src/honeyhive/api/metrics.py
@@ -1,10 +1,11 @@
 """Metrics API module for HoneyHive."""
 
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
-from ..models import Metric, MetricEdit
+from .._generated.models import CreateMetricRequest as Metric
+from .._generated.models import UpdateMetricRequest as MetricEdit
 from ..utils.error_handler import AuthenticationError, ErrorResponse
-from .base import BaseAPI
+from ._base import BaseAPI
 
 
 class MetricsAPI(BaseAPI):

--- a/src/honeyhive/tracer/core/context.py
+++ b/src/honeyhive/tracer/core/context.py
@@ -407,7 +407,7 @@ class TracerContextMixin(TracerContextInterface):
                 return session_id
 
             # Create session via API
-            if not self.session_api:
+            if not (hasattr(self, 'client') and self.client and hasattr(self.client, 'sessions')):
                 safe_log(
                     self, "warning", "No session API available for session creation"
                 )
@@ -435,7 +435,7 @@ class TracerContextMixin(TracerContextInterface):
                 session_params["user_properties"] = user_properties
 
             # Create session via API
-            response = self.session_api.create_session_from_dict(session_params)
+            response = self.client.sessions.start(data=session_params)
             new_session_id = response.session_id
 
             # Set session_id in baggage (ContextVar-based, request-scoped)
@@ -542,7 +542,7 @@ class TracerContextMixin(TracerContextInterface):
                 return session_id
 
             # Create session via API
-            if not self.session_api:
+            if not (hasattr(self, 'client') and self.client and hasattr(self.client, 'sessions')):
                 safe_log(
                     self, "warning", "No session API available for session creation"
                 )
@@ -570,9 +570,7 @@ class TracerContextMixin(TracerContextInterface):
                 session_params["user_properties"] = user_properties
 
             # Create session via async API
-            response = await self.session_api.create_session_from_dict_async(
-                session_params
-            )
+            response = await self.client.sessions.start_async(data=session_params)
             new_session_id = response.session_id
 
             # Set session_id in baggage (ContextVar-based, request-scoped)


### PR DESCRIPTION
## Summary

Fixes critical import and runtime errors preventing tracer and experiments from working in the current RC9 release.

### Issues Fixed

#### 1. API Module Import Errors
- **events.py**: Fixed `.base` → `._base` import path
- **events.py**: Added correct model imports (`PostEventRequest`, `SingleFilter`) 
- **events.py**: Added backwards compatibility aliases (`CreateEventRequest`, `EventFilter`)
- **datapoints.py**: Fixed `.base` → `._base` import path
- **metrics.py**: Fixed `.base` → `._base` import path

#### 2. Context Module Runtime Error
- **context.py line 410**: Fixed `AttributeError: Object has no attribute 'session_api'`
- Replaced `self.session_api` (non-existent attribute) with proper `client.sessions` API
- Added safe hasattr checks: `hasattr(self, 'client') and self.client and hasattr(self.client, 'sessions')`
- Updated session creation calls:
  - Sync: `client.sessions.start(data=...)`
  - Async: `client.sessions.start_async(data=...)`

### Changes
- `src/honeyhive/__init__.py`: Version bump to `1.0.0rc9.post2`
- `src/honeyhive/api/events.py`: Import fixes + backwards compatibility
- `src/honeyhive/api/datapoints.py`: Import fix
- `src/honeyhive/api/metrics.py`: Import fix  
- `src/honeyhive/tracer/core/context.py`: session_api → client.sessions fix

### Test Results
All tests passing:
- ✓ Import validation for all fixed modules
- ✓ Tracer initialization 
- ✓ Session API checks (no AttributeError)
- ✓ Trace creation
- ✓ Session enrichment
- ✓ EventsAPI direct usage
- ✓ Backwards compatibility aliases

### Root Cause
Customer reported these issues when trying to run experiments on RC9:
1. `events.py` had bad references to `.base` when it's actually `._base.py`
2. `events.py` referenced non-existent `CreateEventRequest` and `EventFilter` models
3. `context.py` line 410 conditional didn't safely evaluate, causing `AttributeError`

Resolves: Customer-reported issues with running tracer & experiments on current RC