### PR TITLE
docs: Restructure API reference navigation

### DIFF
--- a/src/honeyhive/experiments/core.py
+++ b/src/honeyhive/experiments/core.py
@@ -170,11 +170,14 @@ def run_experiment(
         List of execution results (one per datapoint)
 
     Examples:
-        >>> def my_function(inputs, ground_truth):
+        >>> def my_function(datapoint):
+        ...     inputs = datapoint.get("inputs", {})
+        ...     ground_truth = datapoint.get("ground_truth", {})
         ...     return {"output": "test"}
         >>>
         >>> # Async functions are also supported
-        >>> async def my_async_function(inputs, ground_truth):
+        >>> async def my_async_function(datapoint):
+        ...     inputs = datapoint.get("inputs", {})
         ...     result = await some_async_call()
         ...     return {"output": result}
         >>>
@@ -844,12 +847,15 @@ def evaluate(  # pylint: disable=too-many-locals,too-many-branches
         >>> from honeyhive.experiments import evaluate
         >>>
         >>> # Define function to test (sync)
-        >>> def my_function(inputs, ground_truth):
+        >>> def my_function(datapoint):
+        ...     inputs = datapoint.get("inputs", {})
+        ...     ground_truth = datapoint.get("ground_truth", {})
         ...     # Your LLM call or function logic
         ...     return {"output": "result"}
         >>>
         >>> # Async functions are also supported
-        >>> async def my_async_function(inputs, ground_truth):
+        >>> async def my_async_function(datapoint):
+        ...     inputs = datapoint.get("inputs", {})
         ...     result = await some_async_llm_call()
         ...     return {"output": result}
         >>>


### PR DESCRIPTION
## Summary

Restructures the Sphinx API reference documentation for better navigation and discoverability.

**Before:** Everything nested under "Core API" with Platform APIs (Datasets, Datapoints, etc.) hidden on a single page.

**After:** Clear product-aligned sections:
- **Overview** - Decision table for choosing SDK components
- **Tracing** - HoneyHiveTracer, Decorators, Enrichment
- **Platform Client** - Individual pages for each API (Datasets, Datapoints, Projects, etc.)
- **Experiments** - evaluate(), evaluators, results
- **Configuration** - Environment variables, authentication

## Changes

- Add Overview page with "I want to..." decision table
- Split `api/client-apis.rst` into individual API pages under `client/`
- Create `tracing/` section with tracer, decorators, enrichment pages
- Create `experiments/` and `configuration/` index pages
- Simplify reference pages to pure autodoc (examples belong in tutorials)
- Delete orphaned duplicate files

## Test plan

- [x] `make html` builds successfully
- [ ] Review navigation in browser
- [ ] Verify all pages render correctly

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/honeyhiveai/python-sdk/pull/197">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
