### PR TITLE
fix: resolve convenience extras for uv dependency resolution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ openinference-anthropic = [
 
 # Google Generative AI (openinference-google-generativeai)
 openinference-google-ai = [
-    "openinference-instrumentation-google-generativeai>=0.1.0",
+    "openinference-instrumentation-google-genai>=0.1.0",
     "google-generativeai>=0.3.0",
 ]
 
@@ -159,40 +159,57 @@ traceloop-mcp = [
 # Convenience Groups (OpenInference Instrumentors)
 # All Available OpenInference Integrations (documented only)
 all-openinference = [
-    "openinference-openai",
-    "openinference-anthropic",
-    "openinference-google-ai",
-    "openinference-google-adk",
-    "openinference-aws-bedrock",
-    "openinference-azure-openai",
-    "openinference-mcp",
+    "openinference-instrumentation-openai>=0.1.0",
+    "openinference-instrumentation-anthropic>=0.1.0",
+    "openinference-instrumentation-google-genai>=0.1.0",
+    "openinference-instrumentation-google-adk>=0.1.0",
+    "openinference-instrumentation-bedrock>=0.1.0",
+    "openinference-instrumentation-mcp>=1.3.0",
+    "openai>=1.0.0",
+    "anthropic>=0.18.0",
+    "google-generativeai>=0.3.0",
+    "google-adk>=0.1.0",
+    "boto3>=1.26.0",
+    "azure-identity>=1.12.0",
 ]
 
 # Common LLM Providers (OpenInference Ecosystem)
 openinference-llm-providers = [
-    "openinference-openai",
-    "openinference-anthropic",
-    "openinference-google-ai",
-    "openinference-aws-bedrock",
+    "openinference-instrumentation-openai>=0.1.0",
+    "openinference-instrumentation-anthropic>=0.1.0",
+    "openinference-instrumentation-google-genai>=0.1.0",
+    "openinference-instrumentation-bedrock>=0.1.0",
+    "openai>=1.0.0",
+    "anthropic>=0.18.0",
+    "google-generativeai>=0.3.0",
+    "boto3>=1.26.0",
 ]
 
 # OpenLLMetry (Traceloop) Convenience Groups
 # All Available Traceloop Integrations (documented only)
 all-traceloop = [
-    "traceloop-openai",
-    "traceloop-anthropic",
-    "traceloop-google-ai",
-    "traceloop-aws-bedrock",
-    "traceloop-azure-openai",
-    "traceloop-mcp",
+    "opentelemetry-instrumentation-openai>=0.46.0,<1.0.0",
+    "opentelemetry-instrumentation-anthropic>=0.46.0,<1.0.0",
+    "opentelemetry-instrumentation-google-generativeai>=0.46.0,<1.0.0",
+    "opentelemetry-instrumentation-bedrock>=0.46.0,<1.0.0",
+    "opentelemetry-instrumentation-mcp>=0.46.0,<1.0.0",
+    "openai>=1.0.0",
+    "anthropic>=0.17.0",
+    "google-generativeai>=0.3.0",
+    "boto3>=1.26.0",
+    "azure-identity>=1.12.0",
 ]
 
 # Common LLM Providers (Traceloop Ecosystem)
 traceloop-llm-providers = [
-    "traceloop-openai",
-    "traceloop-anthropic",
-    "traceloop-google-ai",
-    "traceloop-aws-bedrock",
+    "opentelemetry-instrumentation-openai>=0.46.0,<1.0.0",
+    "opentelemetry-instrumentation-anthropic>=0.46.0,<1.0.0",
+    "opentelemetry-instrumentation-google-generativeai>=0.46.0,<1.0.0",
+    "opentelemetry-instrumentation-bedrock>=0.46.0,<1.0.0",
+    "openai>=1.0.0",
+    "anthropic>=0.17.0",
+    "google-generativeai>=0.3.0",
+    "boto3>=1.26.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,10 +83,10 @@ openinference-anthropic = [
     "anthropic>=0.18.0",
 ]
 
-# Google Generative AI (openinference-google-generativeai)
+# Google GenAI SDK (openinference-google-ai)
 openinference-google-ai = [
     "openinference-instrumentation-google-genai>=0.1.0",
-    "google-generativeai>=0.3.0",
+    "google-genai>=0.3.0",
 ]
 
 # Google Agent Development Kit (openinference-google-adk)
@@ -167,7 +167,7 @@ all-openinference = [
     "openinference-instrumentation-mcp>=1.3.0",
     "openai>=1.0.0",
     "anthropic>=0.18.0",
-    "google-generativeai>=0.3.0",
+    "google-genai>=0.3.0",
     "google-adk>=0.1.0",
     "boto3>=1.26.0",
     "azure-identity>=1.12.0",
@@ -181,7 +181,7 @@ openinference-llm-providers = [
     "openinference-instrumentation-bedrock>=0.1.0",
     "openai>=1.0.0",
     "anthropic>=0.18.0",
-    "google-generativeai>=0.3.0",
+    "google-genai>=0.3.0",
     "boto3>=1.26.0",
 ]
 


### PR DESCRIPTION
## Summary
- Replace convenience extra groups in `pyproject.toml` with concrete package requirements so `uv` does not interpret extra names as package names.
- Fix the OpenInference Google package name from `openinference-instrumentation-google-generativeai` to the published package `openinference-instrumentation-google-genai`.
- Unblock `uv run` for integration examples so dependency resolution succeeds before runtime env checks.

## Test plan
- [x] Run `uv run python -c \"import honeyhive; print('ok')\"` from `python-sdk`.
- [x] Run `uv run --no-sync python examples/integrations/langgraph_integration.py` and verify it reaches runtime env var checks.
- [x] Confirm previous resolver error about `openinference-anthropic` no longer appears.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Packaging-only change, but it modifies optional dependency groups and provider SDK pins, which can impact install/resolution behavior across environments.
> 
> **Overview**
> Fixes optional dependency definitions in `pyproject.toml` so convenience extras (e.g. `all-openinference`, `openinference-llm-providers`, `all-traceloop`, `traceloop-llm-providers`) expand to **explicit package requirements** instead of referencing other extras, which `uv` misinterprets during dependency resolution.
> 
> Also corrects the OpenInference Google integration to the published packages (`openinference-instrumentation-google-genai` + `google-genai`) in place of the older `google-generativeai` naming, unblocking `uv run` for integration examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f5ea93677d4c43e542a806abedd64bc835839ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->