### PR TITLE
fix: port uv convenience extras resolution to federated branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ openinference-anthropic = [
 
 # Google Generative AI (openinference-google-generativeai)
 openinference-google-ai = [
-    "openinference-instrumentation-google-generativeai>=0.1.0",
+    "openinference-instrumentation-google-genai>=0.1.0",
     "google-generativeai>=0.3.0",
 ]
 
@@ -159,40 +159,57 @@ traceloop-mcp = [
 # Convenience Groups (OpenInference Instrumentors)
 # All Available OpenInference Integrations (documented only)
 all-openinference = [
-    "openinference-openai",
-    "openinference-anthropic",
-    "openinference-google-ai",
-    "openinference-google-adk",
-    "openinference-aws-bedrock",
-    "openinference-azure-openai",
-    "openinference-mcp",
+    "openinference-instrumentation-openai>=0.1.0",
+    "openinference-instrumentation-anthropic>=0.1.0",
+    "openinference-instrumentation-google-genai>=0.1.0",
+    "openinference-instrumentation-google-adk>=0.1.0",
+    "openinference-instrumentation-bedrock>=0.1.0",
+    "openinference-instrumentation-mcp>=1.3.0",
+    "openai>=1.0.0",
+    "anthropic>=0.18.0",
+    "google-generativeai>=0.3.0",
+    "google-adk>=0.1.0",
+    "boto3>=1.26.0",
+    "azure-identity>=1.12.0",
 ]
 
 # Common LLM Providers (OpenInference Ecosystem)
 openinference-llm-providers = [
-    "openinference-openai",
-    "openinference-anthropic",
-    "openinference-google-ai",
-    "openinference-aws-bedrock",
+    "openinference-instrumentation-openai>=0.1.0",
+    "openinference-instrumentation-anthropic>=0.1.0",
+    "openinference-instrumentation-google-genai>=0.1.0",
+    "openinference-instrumentation-bedrock>=0.1.0",
+    "openai>=1.0.0",
+    "anthropic>=0.18.0",
+    "google-generativeai>=0.3.0",
+    "boto3>=1.26.0",
 ]
 
 # OpenLLMetry (Traceloop) Convenience Groups
 # All Available Traceloop Integrations (documented only)
 all-traceloop = [
-    "traceloop-openai",
-    "traceloop-anthropic",
-    "traceloop-google-ai",
-    "traceloop-aws-bedrock",
-    "traceloop-azure-openai",
-    "traceloop-mcp",
+    "opentelemetry-instrumentation-openai>=0.46.0,<1.0.0",
+    "opentelemetry-instrumentation-anthropic>=0.46.0,<1.0.0",
+    "opentelemetry-instrumentation-google-generativeai>=0.46.0,<1.0.0",
+    "opentelemetry-instrumentation-bedrock>=0.46.0,<1.0.0",
+    "opentelemetry-instrumentation-mcp>=0.46.0,<1.0.0",
+    "openai>=1.0.0",
+    "anthropic>=0.17.0",
+    "google-generativeai>=0.3.0",
+    "boto3>=1.26.0",
+    "azure-identity>=1.12.0",
 ]
 
 # Common LLM Providers (Traceloop Ecosystem)
 traceloop-llm-providers = [
-    "traceloop-openai",
-    "traceloop-anthropic",
-    "traceloop-google-ai",
-    "traceloop-aws-bedrock",
+    "opentelemetry-instrumentation-openai>=0.46.0,<1.0.0",
+    "opentelemetry-instrumentation-anthropic>=0.46.0,<1.0.0",
+    "opentelemetry-instrumentation-google-generativeai>=0.46.0,<1.0.0",
+    "opentelemetry-instrumentation-bedrock>=0.46.0,<1.0.0",
+    "openai>=1.0.0",
+    "anthropic>=0.17.0",
+    "google-generativeai>=0.3.0",
+    "boto3>=1.26.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,10 +83,10 @@ openinference-anthropic = [
     "anthropic>=0.18.0",
 ]
 
-# Google Generative AI (openinference-google-generativeai)
+# Google GenAI SDK (openinference-google-ai)
 openinference-google-ai = [
     "openinference-instrumentation-google-genai>=0.1.0",
-    "google-generativeai>=0.3.0",
+    "google-genai>=0.3.0",
 ]
 
 # Google Agent Development Kit (openinference-google-adk)
@@ -167,7 +167,7 @@ all-openinference = [
     "openinference-instrumentation-mcp>=1.3.0",
     "openai>=1.0.0",
     "anthropic>=0.18.0",
-    "google-generativeai>=0.3.0",
+    "google-genai>=0.3.0",
     "google-adk>=0.1.0",
     "boto3>=1.26.0",
     "azure-identity>=1.12.0",
@@ -181,7 +181,7 @@ openinference-llm-providers = [
     "openinference-instrumentation-bedrock>=0.1.0",
     "openai>=1.0.0",
     "anthropic>=0.18.0",
-    "google-generativeai>=0.3.0",
+    "google-genai>=0.3.0",
     "boto3>=1.26.0",
 ]
 


### PR DESCRIPTION
## Summary
- Port the uv convenience-extras dependency resolution fix onto `federated-sdk-release-candidate`.
- Expand convenience extras to concrete package requirements so `uv` resolves dependencies correctly.
- Align OpenInference Google extras with `google-genai` package naming.

## Validation
- [x] `uv run python -c "import honeyhive; print('ok')"`
- [x] `uv sync` completes successfully on this branch.
- [x] `uv run --no-sync python examples/integrations/strands_agents_integration.py` runs successfully with configured env and reaches model/tool execution.

These checks validate that dependency resolution is working and examples can run with resolved deps.