### PR TITLE
Add id field and name filter to Dataset API

### DIFF
--- a/src/honeyhive/_generated/models/Dataset.py
+++ b/src/honeyhive/_generated/models/Dataset.py
@@ -10,6 +10,8 @@ class Dataset(BaseModel):
 
     model_config = {"populate_by_name": True, "validate_assignment": True}
 
+    id: Optional[str] = Field(validation_alias="id", default=None)
+
     project: Optional[str] = Field(validation_alias="project", default=None)
 
     name: Optional[str] = Field(validation_alias="name", default=None)

--- a/src/honeyhive/_generated/services/Datasets_service.py
+++ b/src/honeyhive/_generated/services/Datasets_service.py
@@ -10,6 +10,7 @@ def getDatasets(
     project: str,
     type: Optional[str] = None,
     dataset_id: Optional[str] = None,
+    name: Optional[str] = None,
 ) -> GetDatasetsResponse:
     api_config = api_config_override if api_config_override else APIConfig()
 
@@ -23,6 +24,7 @@ def getDatasets(
         "project": project,
         "type": type,
         "dataset_id": dataset_id,
+        "name": name,
     }
 
     query_params = {

--- a/src/honeyhive/_generated/services/async_Datasets_service.py
+++ b/src/honeyhive/_generated/services/async_Datasets_service.py
@@ -10,6 +10,7 @@ async def getDatasets(
     project: str,
     type: Optional[str] = None,
     dataset_id: Optional[str] = None,
+    name: Optional[str] = None,
 ) -> GetDatasetsResponse:
     api_config = api_config_override if api_config_override else APIConfig()
 
@@ -23,6 +24,7 @@ async def getDatasets(
         "project": project,
         "type": type,
         "dataset_id": dataset_id,
+        "name": name,
     }
 
     query_params = {

--- a/src/honeyhive/api/client.py
+++ b/src/honeyhive/api/client.py
@@ -284,6 +284,7 @@ class DatasetsAPI(BaseAPI):
         project: str,
         type: Optional[str] = None,
         dataset_id: Optional[str] = None,
+        name: Optional[str] = None,
     ) -> GetDatasetsResponse:
         """List datasets.
 
@@ -291,9 +292,10 @@ class DatasetsAPI(BaseAPI):
             project: Project name (required by NWD API).
             type: Optional dataset type filter.
             dataset_id: Optional dataset ID to fetch.
+            name: Optional dataset name filter.
         """
         return datasets_svc.getDatasets(
-            self._api_config, project=project, type=type, dataset_id=dataset_id
+            self._api_config, project=project, type=type, dataset_id=dataset_id, name=name
         )
 
     def create(self, request: CreateDatasetRequest) -> CreateDatasetResponse:
@@ -326,10 +328,11 @@ class DatasetsAPI(BaseAPI):
         project: str,
         type: Optional[str] = None,
         dataset_id: Optional[str] = None,
+        name: Optional[str] = None,
     ) -> GetDatasetsResponse:
         """List datasets asynchronously."""
         return await datasets_svc_async.getDatasets(
-            self._api_config, project=project, type=type, dataset_id=dataset_id
+            self._api_config, project=project, type=type, dataset_id=dataset_id, name=name
         )
 
     async def create_async(


### PR DESCRIPTION
## Summary
- Add `id` field to the `Dataset` model — previously Pydantic silently dropped it from API responses, making it impossible to get a dataset's ID from `datasets.list()` or `datasets.get()`
- Add `name` query parameter to `datasets.list()` — allows `client.datasets.list(project, name="my-dataset")` instead of fetching all datasets and filtering client-side

## Test plan
- [x] Verified `dataset.id` returns the correct value from `datasets.list()` responses against nationwide deployment
- [x] Confirmed the dataset sync test script uses `datasets.list(project, name=...)` + `ds.id` to find existing datasets
- [ ] Verify `name` filter works end-to-end once backend support is deployed