### PR TITLE
fix: make mermaid architecture diagram visible on light backgrounds

### DIFF
--- a/docs/reference/api/tracer-architecture.rst
+++ b/docs/reference/api/tracer-architecture.rst
@@ -27,7 +27,7 @@ The new architecture is built on four key principles:
 
 .. mermaid::
 
-   %%{init: {'theme':'base', 'themeVariables': {'primaryColor': '#4F81BD', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ffffff', 'lineColor': '#ffffff', 'mainBkg': 'transparent', 'secondBkg': 'transparent', 'tertiaryColor': 'transparent', 'clusterBkg': 'transparent', 'clusterBorder': '#ffffff', 'edgeLabelBackground': 'transparent', 'background': 'transparent'}, 'flowchart': {'linkColor': '#ffffff', 'linkWidth': 2}}}%%
+   %%{init: {'theme':'neutral'}}%%
    graph TB
        subgraph "HoneyHiveTracer Composition"
            HT[HoneyHiveTracer]


### PR DESCRIPTION
## Summary

- The Mermaid diagram on the [Tracer Architecture Overview](https://honeyhiveai.github.io/python-sdk/reference/api/tracer-architecture.html) page was invisible because the custom `base` theme used all-white colors (`#ffffff`) for text, borders, and lines with transparent backgrounds -- designed for a dark background that doesn't exist on the RTD light theme.
- Switched to Mermaid's built-in `neutral` theme, which is purpose-built for light-background documents. No custom `themeVariables` needed.

## Before
The diagram renders as a blank white space on the page:
<img width="769" height="770" alt="Screenshot 2026-02-16 at 4 44 40 PM" src="https://github.com/user-attachments/assets/77859e87-05c9-407e-88c8-80eb88f541e3" />

## After

The diagram is now fully readable inline on the page:
<img width="764" height="473" alt="Screenshot 2026-02-16 at 4 57 37 PM" src="https://github.com/user-attachments/assets/01f33ea0-000b-4ebd-bb2c-fb7cd867e74b" />


## Test plan

- [x] Built docs locally with `make html`
- [x] Verified diagram renders correctly on light background
- [x] Verified node text, subgraph labels, arrows, and borders are all visible