### PR TITLE
docs-fixes

### DIFF
--- a/docs/reference/api/tracer-architecture.rst
+++ b/docs/reference/api/tracer-architecture.rst
@@ -428,7 +428,6 @@ Optimization Features
 - **Lazy Loading**: Modules loaded only when needed
 - **Efficient Composition**: Mixin composition has minimal overhead
 - **Connection Pooling**: Shared HTTP connection pools across modules
-- **Batch Processing**: Optimized span batching and export
 
 Benchmarks
 ----------


### PR DESCRIPTION
## Summary
- Remove inaccurate "Batch Processing" claim from tracer architecture docs — the SDK exports spans individually via OTLP on span completion, not in batches.

This PR will collect additional docs accuracy fixes as they come up.

## Test plan
- [ ] Verify docs build cleanly