### PR TITLE
fix: correct Sphinx docs for tracer initialization patterns

### DIFF
--- a/docs/how-to/deployment/tracer-initialization-patterns.rst
+++ b/docs/how-to/deployment/tracer-initialization-patterns.rst
@@ -697,10 +697,10 @@ Best Practices
       def my_function():
           tracer.enrich_span(...)
 
-      # ❌ AVOID - Implicit tracer discovery (deprecated in v2.0)
+      # ❌ AVOID - Implicit tracer discovery (harder to debug)
       @trace(event_type="tool")
       def my_function():
-          enrich_span(...)  # Global function - will be deprecated
+          enrich_span(...)  # Relies on baggage-based discovery
 
 3. **Create Sessions for Isolation**
 
@@ -728,14 +728,19 @@ Best Practices
 
    .. code-block:: python
 
-      from opentelemetry import propagate
+      from opentelemetry import propagate, context
 
-      # Service A: Inject context
+      # Service A: Inject context into outgoing request
       propagate.inject(outgoing_request.headers)
       
-      # Service B: Extract context
+      # Service B: Extract and attach context from incoming request
       ctx = propagate.extract(incoming_request.headers)
-      tracer.create_session(..., link_carrier=ctx)
+      token = context.attach(ctx)
+      try:
+          tracer.create_session(session_name="downstream-request")
+          # All spans created here are linked to the upstream trace
+      finally:
+          context.detach(token)
 
 Troubleshooting
 ---------------


### PR DESCRIPTION
## Summary

- **Fixed incorrect `link_carrier=ctx` on `create_session()`**: The "Best Practices" section showed `tracer.create_session(..., link_carrier=ctx)` but `link_carrier` is a parameter of `HoneyHiveTracer.__init__()`, not `create_session()`. Replaced with the correct `context.attach(ctx)` + `create_session()` pattern, consistent with the distributed tracing example already shown in Pattern 4 of the same page.

- **Removed false "deprecated in v2.0" claim on implicit tracer discovery**: The docs stated implicit tracer discovery via `@trace(event_type="tool")` without explicit tracer was "deprecated in v2.0" and that `enrich_span()` "will be deprecated". There are no deprecation markers in the codebase for `discover_tracer()`, `get_tracer_from_baggage()`, or global `enrich_span()`. Reframed as a best practice recommendation ("harder to debug" / "relies on baggage-based discovery").

## Test plan

- [ ] Verify the corrected distributed tracing code example matches the `context.attach()` pattern used in Pattern 4 (lines 502-528 of same file)
- [ ] Rebuild Sphinx docs locally to confirm no RST rendering issues