### PR TITLE
chore: update makefile python venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .PHONY: help install install-dev test test-all test-unit test-integration check-integration lint format check check-format check-lint typecheck check-docs check-docs-compliance check-feature-sync check-tracer-patterns check-no-mocks docs docs-serve docs-clean generate generate-sdk compare-sdk clean clean-all build build-bundled publish publish-bundled
 
+# Use the venv python so make recipes get venv site-packages
+PYTHON := .venv/bin/python
+
 # Default target
 help:
 	@echo "HoneyHive Python SDK - Available Commands"
@@ -105,10 +108,10 @@ check: check-format check-lint test-unit check-no-mocks check-integration check-
 	@echo "✅ All checks passed!"
 
 check-docs-compliance:
-	python scripts/check-documentation-compliance.py
+	$(PYTHON) scripts/check-documentation-compliance.py
 
 check-feature-sync:
-	python scripts/check-feature-sync.py
+	$(PYTHON) scripts/check-feature-sync.py
 
 check-tracer-patterns:
 	scripts/validate-tracer-patterns.sh
@@ -125,7 +128,7 @@ docs:
 	cd docs && $(MAKE) html
 
 docs-serve:
-	cd docs && python serve.py
+	cd docs && ../$(PYTHON) serve.py
 
 docs-clean:
 	cd docs && $(MAKE) clean
@@ -133,42 +136,42 @@ docs-clean:
 # SDK Generation
 # Generate client from OpenAPI spec
 generate:
-	python scripts/generate_client.py
+	$(PYTHON) scripts/generate_client.py
 	$(MAKE) format
 
 # Generate full SDK to comparison_output/ (for analysis)
 generate-sdk:
-	python scripts/generate_models_and_client.py
+	$(PYTHON) scripts/generate_models_and_client.py
 
 compare-sdk:
 	@if [ ! -d "comparison_output/full_sdk" ]; then \
 		echo "❌ No generated SDK found. Run 'make generate-sdk' first."; \
 		exit 1; \
 	fi
-	python comparison_output/full_sdk/compare_with_current.py
+	$(PYTHON) comparison_output/full_sdk/compare_with_current.py
 
 # Build & Publish
 build:
-	python -m build
+	$(PYTHON) -m build
 
 build-bundled:
 	@echo "Building honeyhive-bundled package..."
 	cp pyproject.toml pyproject.toml.backup
 	cp pyproject.bundled.toml pyproject.toml
-	python -m build
+	$(PYTHON) -m build
 	mv pyproject.toml.backup pyproject.toml
 	@echo "✅ Built honeyhive-bundled package in dist/"
 
 publish:
 	@echo "Publishing honeyhive to PyPI..."
-	python -m twine upload dist/*
+	$(PYTHON) -m twine upload dist/*
 
 publish-bundled:
 	@echo "Publishing honeyhive-bundled to PyPI..."
 	cp pyproject.toml pyproject.toml.backup
 	cp pyproject.bundled.toml pyproject.toml
-	python -m build
-	python -m twine upload dist/*
+	$(PYTHON) -m build
+	$(PYTHON) -m twine upload dist/*
 	mv pyproject.toml.backup pyproject.toml
 	@echo "✅ Published honeyhive-bundled to PyPI"
 

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,6 @@
             buildInputs = [
             # Python environment
             pythonEnv
-            pkgs.yq
           ];
 
           shellHook = ''
@@ -50,9 +49,6 @@
             # Activate virtual environment
             source .venv/bin/activate
 
-            # Ensure venv site-packages and src are in PYTHONPATH
-            export PYTHONPATH="src:.venv/lib/python3.12/site-packages:.:$PYTHONPATH"
-
             # Upgrade pip (silent)
             pip install --upgrade pip > /dev/null 2>&1
 
@@ -69,7 +65,6 @@
           '';
 
           # Environment variables
-          # Note: PYTHONPATH is set in shellHook after venv activation
 
           # Prevent Python from writing bytecode
           PYTHONDONTWRITEBYTECODE = "1";


### PR DESCRIPTION
# Summary

Fix `make build` failures caused by Nix Python 3.13 dependencies conflicting with the venv's Python 3.12. Remove yq from flake.nix and ensure Makefile recipes use the venv python directly.

# Details

- Remove `yq` from flake.nix buildInputs — it injected Python 3.13 site-packages into PYTHONPATH, conflicting with the venv's Python 3.12
- Remove stale PYTHONPATH export from flake.nix that was redundant and harmful to hatchling's isolated build
- Add `PYTHON := .venv/bin/python` variable to Makefile to ensure all recipes run with venv python
- Replace all bare `python` calls with `$(PYTHON)` in Makefile for consistency (10 occurrences)
- Fixes "No module named build" errors without requiring manual PYTHONPATH management

