### PR TITLE
Fix evaluate() with dataset_id parameter

### DIFF
--- a/src/honeyhive/experiments/core.py
+++ b/src/honeyhive/experiments/core.py
@@ -942,24 +942,32 @@ def evaluate(  # pylint: disable=too-many-locals,too-many-branches
             logger.info("DEBUG - Input dataset_id type: %s", type(dataset_id))
             logger.info("DEBUG - Is EXT- dataset: %s", dataset_id.startswith("EXT-"))
 
-        # Get dataset metadata
+        # Get dataset metadata — get_dataset returns GetDatasetsResponse (a list
+        # wrapper), so unwrap the first entry to get the actual Dataset object.
         ds_response = client.datasets.get_dataset(dataset_id, project=project)
+        ds = ds_response.testcases[0] if ds_response.testcases else None
         dataset_list = []
         datapoint_ids = []
 
-        # Dataset.datapoints is List[str] (IDs only), fetch each datapoint
-        if ds_response.datapoints:
-            for dp_id in ds_response.datapoints:
+        # Dataset.datapoints is List[str] (IDs only), fetch each datapoint.
+        # get_datapoint returns GetDatapointResponse (wrapper with .datapoint
+        # list), so we unwrap the first entry to get the actual Datapoint.
+        if ds and ds.datapoints:
+            for dp_id in ds.datapoints:
                 try:
-                    dp = client.datapoints.get_datapoint(dp_id)
+                    dp_response = client.datapoints.get_datapoint(dp_id)
+                    dp = dp_response.datapoint[0] if dp_response.datapoint else None
+                    if dp is None:
+                        logger.warning("Datapoint %s returned empty response", dp_id)
+                        continue
                     dataset_list.append(
                         {
                             "inputs": dp.inputs or {},
                             "ground_truth": dp.ground_truth,
-                            "id": dp.field_id or dp_id,
+                            "id": dp.id or dp_id,
                         }
                     )
-                    datapoint_ids.append(dp.field_id or dp_id)
+                    datapoint_ids.append(dp.id or dp_id)
                 except Exception as e:
                     logger.warning("Failed to fetch datapoint %s: %s", dp_id, str(e))
 

--- a/tests/unit/test_experiments_core.py
+++ b/tests/unit/test_experiments_core.py
@@ -648,23 +648,31 @@ class TestEvaluate:
 
         mock_client = Mock()
 
-        # Mock dataset response
+        # Mock dataset response — get_dataset returns GetDatasetsResponse
+        # with .testcases list; each entry is a Dataset with .datapoints
         mock_ds = Mock()
         mock_ds.datapoints = ["dp-1", "dp-2"]
-        mock_client.datasets.get_dataset.return_value = mock_ds
+        mock_ds_response = Mock()
+        mock_ds_response.testcases = [mock_ds]
+        mock_client.datasets.get_dataset.return_value = mock_ds_response
 
-        # Mock datapoint responses
+        # Mock datapoint responses — get_datapoint returns
+        # GetDatapointResponse with .datapoint list
         mock_dp1 = Mock()
         mock_dp1.inputs = {"x": 1}
         mock_dp1.ground_truth = {"y": 2}
-        mock_dp1.field_id = "dp-1"
+        mock_dp1.id = "dp-1"
+        mock_dp1_response = Mock()
+        mock_dp1_response.datapoint = [mock_dp1]
 
         mock_dp2 = Mock()
         mock_dp2.inputs = {"x": 3}
         mock_dp2.ground_truth = {"y": 4}
-        mock_dp2.field_id = "dp-2"
+        mock_dp2.id = "dp-2"
+        mock_dp2_response = Mock()
+        mock_dp2_response.datapoint = [mock_dp2]
 
-        mock_client.datapoints.get_datapoint.side_effect = [mock_dp1, mock_dp2]
+        mock_client.datapoints.get_datapoint.side_effect = [mock_dp1_response, mock_dp2_response]
 
         mock_run_response = Mock()
         mock_run_response.run_id = "run-789"
@@ -731,19 +739,23 @@ class TestEvaluate:
 
         mock_client = Mock()
 
-        # Mock dataset response
+        # Mock dataset response — wrapped in GetDatasetsResponse
         mock_ds = Mock()
         mock_ds.datapoints = ["dp-1", "dp-2"]
-        mock_client.datasets.get_dataset.return_value = mock_ds
+        mock_ds_response = Mock()
+        mock_ds_response.testcases = [mock_ds]
+        mock_client.datasets.get_dataset.return_value = mock_ds_response
 
-        # First datapoint succeeds, second fails
+        # First datapoint succeeds (wrapped), second fails
         mock_dp1 = Mock()
         mock_dp1.inputs = {"x": 1}
         mock_dp1.ground_truth = {"y": 2}
-        mock_dp1.field_id = "dp-1"
+        mock_dp1.id = "dp-1"
+        mock_dp1_response = Mock()
+        mock_dp1_response.datapoint = [mock_dp1]
 
         mock_client.datapoints.get_datapoint.side_effect = [
-            mock_dp1,
+            mock_dp1_response,
             Exception("Network error"),
         ]
 


### PR DESCRIPTION
## Summary
- `get_dataset()` was hardcoding `project=""` which the API rejects — now accepts and passes through `project`
- `evaluate()` now passes its `project` param to `get_dataset()`
- Fixed `evaluate()` accessing `.datapoints` directly on `GetDatasetsResponse` instead of unwrapping `.testcases[0]`
- Fixed `evaluate()` accessing `.inputs` directly on `GetDatapointResponse` instead of unwrapping `.datapoint[0]`
- Fixed `evaluate()` referencing `dp.field_id` which doesn't exist on `Datapoint` — corrected to `dp.id`

## Test plan
- [x] Run `evaluate()` with `dataset_id` pointing to an existing HoneyHive dataset
- [x] Verify datapoints are fetched and passed to the task function
- [x] Verify evaluator scores are computed and reported correctly

✨ Created with Claude Code