### PR TITLE
fix: remove duplicate traceloop.association.properties attributes [HHAI-3899]

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,28 +1,3 @@
 {
-  "mcpServers": {
-    "praxis-os": {
-      "command": "${workspaceFolder}/.praxis-os/venv/bin/python",
-      "args": [
-        "-m",
-        "ouroboros",
-        "--transport",
-        "dual",
-        "--log-level",
-        "INFO"
-      ],
-      "env": {
-        "PROJECT_ROOT": "${workspaceFolder}",
-        "PYTHONPATH": "${workspaceFolder}/.praxis-os",
-        "PYTHONUNBUFFERED": "1"
-      },
-      "autoApprove": [
-        "pos_search_project",
-        "pos_workflow",
-        "pos_browser",
-        "pos_filesystem",
-        "current_date",
-        "get_server_info"
-      ]
-    }
-  }
+  "mcpServers": {}
 }

--- a/src/honeyhive/tracer/processing/span_processor.py
+++ b/src/honeyhive/tracer/processing/span_processor.py
@@ -300,8 +300,6 @@ class HoneyHiveSpanProcessor(SpanProcessor):
 
         if session_id:
             attributes["honeyhive.session_id"] = session_id
-            # Backend compatibility: also set Traceloop-style attribute
-            attributes["traceloop.association.properties.session_id"] = session_id
 
         # Priority: baggage project (for distributed tracing), then tracer instance
         project = baggage.get_baggage("project", ctx)
@@ -313,8 +311,6 @@ class HoneyHiveSpanProcessor(SpanProcessor):
 
         if project:
             attributes["honeyhive.project"] = project
-            # Backend compatibility: also set Traceloop-style attribute
-            attributes["traceloop.association.properties.project"] = project
 
         # Priority: baggage source (for distributed tracing), then tracer instance
         source = baggage.get_baggage("source", ctx)
@@ -328,8 +324,6 @@ class HoneyHiveSpanProcessor(SpanProcessor):
 
         if source:
             attributes["honeyhive.source"] = source
-            # Backend compatibility: also set Traceloop-style attribute
-            attributes["traceloop.association.properties.source"] = source
 
         parent_id = baggage.get_baggage("parent_id", ctx)
         if parent_id:
@@ -380,66 +374,6 @@ class HoneyHiveSpanProcessor(SpanProcessor):
                 "Error adding experiment attributes",
                 honeyhive_data={"error_type": type(e).__name__},
             )
-
-        return attributes
-
-    def _process_association_properties(self, ctx: Context) -> dict:
-        """Process legacy association_properties from context.
-
-        :param ctx: OpenTelemetry context to extract association properties from
-        :type ctx: Context
-        :return: Dictionary of association properties attributes
-        :rtype: dict
-        """
-        attributes = {}
-
-        try:
-            # Check if context has association_properties (legacy support)
-            if hasattr(ctx, "get") and callable(getattr(ctx, "get", None)):
-                association_properties = ctx.get("association_properties")
-                if association_properties and isinstance(association_properties, dict):
-                    # Found association_properties
-                    for key, value in association_properties.items():
-                        if value is not None and not baggage.get_baggage(key, ctx):
-                            # Set traceloop.association.properties.* format
-                            # for backend compatibility
-                            attr_key = f"traceloop.association.properties.{key}"
-                            attributes[attr_key] = str(value)
-        except Exception as e:
-            # Graceful degradation following Agent OS standards - never crash host
-            self._safe_log(
-                "debug",
-                "Error checking association_properties",
-                honeyhive_data={"error_type": type(e).__name__},
-            )
-
-        return attributes
-
-    def _get_traceloop_compatibility_attributes(self, ctx: Context) -> dict:
-        """Get traceloop.association.properties.* attributes for backend compatibility.
-
-        :param ctx: OpenTelemetry context to extract baggage from
-        :type ctx: Context
-        :return: Dictionary of traceloop compatibility attributes
-        :rtype: dict
-        """
-        attributes = {}
-
-        session_id = baggage.get_baggage("session_id", ctx)
-        if session_id:
-            attributes["traceloop.association.properties.session_id"] = session_id
-
-        project = baggage.get_baggage("project", ctx)
-        if project:
-            attributes["traceloop.association.properties.project"] = project
-
-        source = baggage.get_baggage("source", ctx)
-        if source:
-            attributes["traceloop.association.properties.source"] = source
-
-        parent_id = baggage.get_baggage("parent_id", ctx)
-        if parent_id:
-            attributes["traceloop.association.properties.parent_id"] = parent_id
 
         return attributes
 
@@ -641,32 +575,17 @@ class HoneyHiveSpanProcessor(SpanProcessor):
             # Collect all attributes to set
             attributes_to_set = {}
 
-            # Always process association_properties for legacy support
-            attributes_to_set.update(self._process_association_properties(ctx))
-
             # Always add experiment attributes (they don't require session_id)
             attributes_to_set.update(self._get_experiment_attributes())
 
             if session_id:
-                # Set session_id attributes directly (multi-instance isolation)
+                # Set session_id directly (multi-instance isolation)
                 attributes_to_set["honeyhive.session_id"] = session_id
-                attributes_to_set["traceloop.association.properties.session_id"] = (
-                    session_id
-                )
 
                 # Get other baggage attributes (project, source, etc.)
                 other_baggage_attrs = self._get_basic_baggage_attributes(ctx)
-                # Remove session_id from baggage attrs since we're setting it directly
                 other_baggage_attrs.pop("honeyhive.session_id", None)
-                other_baggage_attrs.pop(
-                    "traceloop.association.properties.session_id", None
-                )
                 attributes_to_set.update(other_baggage_attrs)
-
-                # Add traceloop compatibility attributes for backend
-                attributes_to_set.update(
-                    self._get_traceloop_compatibility_attributes(ctx)
-                )
 
                 # Add evaluation metadata from baggage (run_id, dataset_id,
                 # datapoint_id)
@@ -738,9 +657,7 @@ class HoneyHiveSpanProcessor(SpanProcessor):
                 attributes = dict(span.attributes)
 
             # Get session information from span attributes (set in on_start)
-            session_id_raw = attributes.get("honeyhive.session_id") or attributes.get(
-                "traceloop.association.properties.session_id"
-            )
+            session_id_raw = attributes.get("honeyhive.session_id")
 
             if not session_id_raw:
                 # Span has no session_id, skipping HoneyHive export

--- a/tests/unit/test_tracer_processing_span_processor.py
+++ b/tests/unit/test_tracer_processing_span_processor.py
@@ -222,11 +222,8 @@ class TestHoneyHiveSpanProcessorBaggageHandling:
 
         expected = {
             "honeyhive.session_id": "session-123",
-            "traceloop.association.properties.session_id": "session-123",
             "honeyhive.project": "test-project",
-            "traceloop.association.properties.project": "test-project",
             "honeyhive.source": "test-source",
-            "traceloop.association.properties.source": "test-source",
             "honeyhive.parent_id": "parent-456",
         }
         assert result == expected
@@ -256,14 +253,11 @@ class TestHoneyHiveSpanProcessorBaggageHandling:
 
         result = processor._get_basic_baggage_attributes(mock_context)
 
-        # UPDATED: Baggage now takes priority for distributed tracing
+        # Baggage takes priority for distributed tracing
         expected = {
             "honeyhive.session_id": "baggage-session-123",
-            "traceloop.association.properties.session_id": "baggage-session-123",
             "honeyhive.project": "distributed-project",
-            "traceloop.association.properties.project": "distributed-project",
             "honeyhive.source": "distributed-source",
-            "traceloop.association.properties.source": "distributed-source",
         }
         assert result == expected
 
@@ -359,7 +353,6 @@ class TestHoneyHiveSpanProcessorBaggageHandling:
 
         expected = {
             "honeyhive.session_id": "session-789",
-            "traceloop.association.properties.session_id": "session-789",
         }
         assert result == expected
 
@@ -385,7 +378,6 @@ class TestHoneyHiveSpanProcessorBaggageHandling:
 
         expected = {
             "honeyhive.session_id": "baggage-session",
-            "traceloop.association.properties.session_id": "baggage-session",
         }
         assert result == expected
 
@@ -489,98 +481,6 @@ class TestHoneyHiveSpanProcessorExperimentAttributes:
 
         assert not result
         mock_safe_log.assert_called()
-
-
-class TestHoneyHiveSpanProcessorAssociationProperties:
-    """Test association properties handling with all conditional branches."""
-
-    def test_process_association_properties_with_context_get(self) -> None:
-        """Test association properties with context that has get method."""
-        processor = HoneyHiveSpanProcessor()
-        mock_context = Mock(spec=Context)
-        mock_context.get.return_value = {"key1": "value1", "key2": None}
-
-        result = processor._process_association_properties(mock_context)
-
-        # This method returns empty dict - it doesn't process association properties
-        assert not result
-
-    def test_process_association_properties_no_get_method(self) -> None:
-        """Test association properties with context that has no get method."""
-        processor = HoneyHiveSpanProcessor()
-        mock_context = Mock(spec=Context)
-        del mock_context.get  # Remove get method
-
-        result = processor._process_association_properties(mock_context)
-
-        assert not result
-
-    def test_process_association_properties_empty_properties(self) -> None:
-        """Test association properties with empty properties."""
-        processor = HoneyHiveSpanProcessor()
-        mock_context = Mock(spec=Context)
-        mock_context.get.return_value = {}
-
-        result = processor._process_association_properties(mock_context)
-
-        assert not result
-
-    def test_process_association_properties_non_dict(self) -> None:
-        """Test association properties with non-dict return value."""
-        processor = HoneyHiveSpanProcessor()
-        mock_context = Mock(spec=Context)
-        mock_context.get.return_value = "not a dict"
-
-        result = processor._process_association_properties(mock_context)
-
-        assert not result
-
-    @patch("honeyhive.tracer.processing.span_processor.baggage.get_baggage")
-    @patch("honeyhive.utils.logger.safe_log")
-    def test_process_association_properties_exception_handling(
-        self, mock_safe_log: Mock, mock_get_baggage: Mock
-    ) -> None:
-        """Test association properties with exception handling."""
-        processor = HoneyHiveSpanProcessor()
-        mock_context = Mock(spec=Context)
-        mock_context.get.side_effect = Exception("Context error")
-
-        result = processor._process_association_properties(mock_context)
-
-        assert not result
-        mock_safe_log.assert_called()
-
-
-class TestHoneyHiveSpanProcessorTraceloopCompatibility:
-    """Test Traceloop compatibility attributes."""
-
-    def test_get_traceloop_compatibility_attributes_with_session(self) -> None:
-        """Test Traceloop compatibility attributes with session ID."""
-        processor = HoneyHiveSpanProcessor()
-        mock_context = Mock(spec=Context)
-
-        with patch.object(processor, "_get_basic_baggage_attributes") as mock_baggage:
-            mock_baggage.return_value = {
-                "honeyhive.session_id": "session-123",
-                "honeyhive.project": "test-project",
-            }
-
-            result = processor._get_traceloop_compatibility_attributes(mock_context)
-
-        # This method returns empty dict - it doesn't process traceloop attributes
-        assert not result
-
-    def test_get_traceloop_compatibility_attributes_empty(self) -> None:
-        """Test Traceloop compatibility attributes with empty baggage."""
-        processor = HoneyHiveSpanProcessor()
-        mock_context = Mock(spec=Context)
-
-        with patch.object(processor, "_get_basic_baggage_attributes") as mock_baggage:
-            mock_baggage.return_value = {}
-
-            result = processor._get_traceloop_compatibility_attributes(mock_context)
-
-            assert not result
 
 
 class TestHoneyHiveSpanProcessorEventTypeDetection:

--- a/tests_v2/unit/test_tracer_processing_span_processor.py
+++ b/tests_v2/unit/test_tracer_processing_span_processor.py
@@ -220,11 +220,8 @@ class TestHoneyHiveSpanProcessorBaggageHandling:
 
         expected = {
             "honeyhive.session_id": "session-123",
-            "traceloop.association.properties.session_id": "session-123",
             "honeyhive.project": "test-project",
-            "traceloop.association.properties.project": "test-project",
             "honeyhive.source": "test-source",
-            "traceloop.association.properties.source": "test-source",
             "honeyhive.parent_id": "parent-456",
         }
         assert result == expected
@@ -257,11 +254,8 @@ class TestHoneyHiveSpanProcessorBaggageHandling:
         # UPDATED: Baggage now takes priority for distributed tracing
         expected = {
             "honeyhive.session_id": "baggage-session-123",
-            "traceloop.association.properties.session_id": "baggage-session-123",
             "honeyhive.project": "distributed-project",
-            "traceloop.association.properties.project": "distributed-project",
             "honeyhive.source": "distributed-source",
-            "traceloop.association.properties.source": "distributed-source",
         }
         assert result == expected
 
@@ -357,7 +351,6 @@ class TestHoneyHiveSpanProcessorBaggageHandling:
 
         expected = {
             "honeyhive.session_id": "session-789",
-            "traceloop.association.properties.session_id": "session-789",
         }
         assert result == expected
 
@@ -383,7 +376,6 @@ class TestHoneyHiveSpanProcessorBaggageHandling:
 
         expected = {
             "honeyhive.session_id": "baggage-session",
-            "traceloop.association.properties.session_id": "baggage-session",
         }
         assert result == expected
 
@@ -487,98 +479,6 @@ class TestHoneyHiveSpanProcessorExperimentAttributes:
 
         assert not result
         mock_safe_log.assert_called()
-
-
-class TestHoneyHiveSpanProcessorAssociationProperties:
-    """Test association properties handling with all conditional branches."""
-
-    def test_process_association_properties_with_context_get(self) -> None:
-        """Test association properties with context that has get method."""
-        processor = HoneyHiveSpanProcessor()
-        mock_context = Mock(spec=Context)
-        mock_context.get.return_value = {"key1": "value1", "key2": None}
-
-        result = processor._process_association_properties(mock_context)
-
-        # This method returns empty dict - it doesn't process association properties
-        assert not result
-
-    def test_process_association_properties_no_get_method(self) -> None:
-        """Test association properties with context that has no get method."""
-        processor = HoneyHiveSpanProcessor()
-        mock_context = Mock(spec=Context)
-        del mock_context.get  # Remove get method
-
-        result = processor._process_association_properties(mock_context)
-
-        assert not result
-
-    def test_process_association_properties_empty_properties(self) -> None:
-        """Test association properties with empty properties."""
-        processor = HoneyHiveSpanProcessor()
-        mock_context = Mock(spec=Context)
-        mock_context.get.return_value = {}
-
-        result = processor._process_association_properties(mock_context)
-
-        assert not result
-
-    def test_process_association_properties_non_dict(self) -> None:
-        """Test association properties with non-dict return value."""
-        processor = HoneyHiveSpanProcessor()
-        mock_context = Mock(spec=Context)
-        mock_context.get.return_value = "not a dict"
-
-        result = processor._process_association_properties(mock_context)
-
-        assert not result
-
-    @patch("honeyhive.tracer.processing.span_processor.baggage.get_baggage")
-    @patch("honeyhive.utils.logger.safe_log")
-    def test_process_association_properties_exception_handling(
-        self, mock_safe_log: Mock, mock_get_baggage: Mock
-    ) -> None:
-        """Test association properties with exception handling."""
-        processor = HoneyHiveSpanProcessor()
-        mock_context = Mock(spec=Context)
-        mock_context.get.side_effect = Exception("Context error")
-
-        result = processor._process_association_properties(mock_context)
-
-        assert not result
-        mock_safe_log.assert_called()
-
-
-class TestHoneyHiveSpanProcessorTraceloopCompatibility:
-    """Test Traceloop compatibility attributes."""
-
-    def test_get_traceloop_compatibility_attributes_with_session(self) -> None:
-        """Test Traceloop compatibility attributes with session ID."""
-        processor = HoneyHiveSpanProcessor()
-        mock_context = Mock(spec=Context)
-
-        with patch.object(processor, "_get_basic_baggage_attributes") as mock_baggage:
-            mock_baggage.return_value = {
-                "honeyhive.session_id": "session-123",
-                "honeyhive.project": "test-project",
-            }
-
-            result = processor._get_traceloop_compatibility_attributes(mock_context)
-
-        # This method returns empty dict - it doesn't process traceloop attributes
-        assert not result
-
-    def test_get_traceloop_compatibility_attributes_empty(self) -> None:
-        """Test Traceloop compatibility attributes with empty baggage."""
-        processor = HoneyHiveSpanProcessor()
-        mock_context = Mock(spec=Context)
-
-        with patch.object(processor, "_get_basic_baggage_attributes") as mock_baggage:
-            mock_baggage.return_value = {}
-
-            result = processor._get_traceloop_compatibility_attributes(mock_context)
-
-            assert not result
 
 
 class TestHoneyHiveSpanProcessorEventTypeDetection:


### PR DESCRIPTION
## Summary

- Removes duplicate `traceloop.association.properties.*` span attributes for session_id, project, and source that were leaking into the Config bucket in the UI
- Deletes two dead methods: `_process_association_properties()` (structurally unreachable due to OTel Context key type mismatch) and `_get_traceloop_compatibility_attributes()` (redundant with `honeyhive.*` attributes)
- Removes traceloop fallback read in `on_end()`

Net: -213 lines, 61 unit tests passing.

## Context

The backend `extractContextFields()` in `context.go` uses `honeyhive.*` as priority 1 in an if/else chain — the `traceloop.*` else-branch is never taken when both are present. The duplicates flow through to the strategy routing layer and land in Config as noise.

Backend PR [#2315](https://github.com/honeyhiveai/hive-kube/pull/2315) adds belt-and-suspenders cleanup for older SDK versions, but this SDK change is independent of it.

Linear: [HHAI-3899](https://linear.app/honeyhive/issue/HHAI-3899)

## Test plan

- [x] All 61 span processor unit tests pass
- [ ] Verify spans no longer contain `traceloop.association.properties.*` in Config bucket