### PR TITLE
chore: add automated Claude code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,131 @@
+# Triggered by:
+#   1. Commenting "@claude review" on a PR — runs code review
+#   2. Automatically when a PR is opened (excludes dependabot PRs) — runs code review
+name: Claude Code Review
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [opened]
+
+jobs:
+  review:
+    if: >
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@claude review') &&
+       !contains(github.event.comment.body, '@claude approve')) ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.user.login != 'dependabot[bot]')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      issues: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Resolve PR info
+        id: pr-info
+        uses: actions/github-script@v8
+        with:
+          script: |
+            let prNumber, headRef;
+
+            if (context.eventName === 'issue_comment') {
+              prNumber = context.issue.number;
+              const pr = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+              headRef = pr.data.head.ref;
+            } else {
+              prNumber = context.payload.pull_request.number;
+              headRef = context.payload.pull_request.head.ref;
+            }
+
+            core.setOutput('pr_number', prNumber);
+            core.setOutput('head_ref', headRef);
+
+      - name: Check if workflow file is modified
+        id: check-workflow
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const files = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: Number(${{ steps.pr-info.outputs.pr_number }})
+            });
+            const workflowModified = files.data.some(
+              f => f.filename === '.github/workflows/claude-code-review.yml'
+            );
+            core.setOutput('skip', workflowModified ? 'true' : 'false');
+            if (workflowModified) {
+              core.info('Skipping Claude review — workflow file itself is modified in this PR');
+            }
+
+      - name: Checkout repository
+        if: steps.check-workflow.outputs.skip != 'true'
+        uses: actions/checkout@v6
+        with:
+          ref: federated-sdk-release-candidate
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        if: steps.check-workflow.outputs.skip != 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          trigger_phrase: "@claude review"
+          track_progress: true
+          allowed_bots: "devin-ai-integration"
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ steps.pr-info.outputs.pr_number }}
+
+            You are reviewing a Python SDK published to PyPI. Review the PR changes with
+            meticulous attention to detail. Focus on:
+
+            - **Backwards compatibility**: This is a published SDK. Flag any breaking changes
+              to public APIs (function signatures, class interfaces, default values).
+            - **Type safety**: All functions must have type hints. Flag any missing annotations.
+            - **Graceful degradation**: The SDK must never crash the host application. Flag any
+              unhandled exceptions that could propagate to user code.
+            - **Python best practices**: Black formatting (line length 88), isort import ordering,
+              no code in `__init__.py` files (only imports).
+            - **Security**: Check for leaked secrets, unsafe deserialization, or injection risks.
+            - **Generated code**: Files under `src/honeyhive/models/` and `src/honeyhive/api/`
+              are auto-generated via `make generate`. Don't nitpick style in those files — only
+              flag functional issues.
+            - **Documentation impact**: If the PR changes public APIs, adds new features, modifies
+              behavior, or changes configuration options, flag whether `docs/` (Sphinx docs under
+              `docs/how-to/`, `docs/tutorials/`, `docs/reference/`, `docs/explanation/`) or
+              `examples/` need corresponding updates. Include a "Documentation" section in the
+              top-level PR comment listing any suggested doc updates.
+
+            NOTE: the default branch of this repository is `federated-sdk-release-candidate`.
+
+            ## How to post feedback
+
+            Use inline comments for specific code feedback (bugs, suggestions, nits, etc):
+              - Use `mcp__github_inline_comment__create_inline_comment` to leave feedback on specific lines of code.
+
+            Use a single top-level comment for high-level observations about the PR as a whole:
+              - Use `gh pr comment` for this.
+              - This comment should cover things like overall design, architecture, what looks good, and any general concerns.
+              - Do NOT repeat or summarize individual code-level feedback here. That feedback already exists as inline comments and duplicating it adds noise.
+
+            Only post GitHub comments - don't submit review text as messages.
+          claude_args: |
+            --model claude-opus-4-6 --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),WebFetch,WebSearch"
+
+      - name: Upload review execution output
+        if: always() && steps.check-workflow.outputs.skip != 'true'
+        uses: actions/upload-artifact@v6
+        with:
+          name: claude-review-output
+          path: /home/runner/work/_temp/claude-execution-output.json
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow (`.github/workflows/claude-code-review.yml`) that runs automated Claude code review on PRs
- Triggers on PR open (excludes dependabot) and on `@claude review` comments
- Review focuses on backwards compatibility, type safety, graceful degradation, security, and documentation impact
- Mirrors the review system already running in hive-kube, tailored for the Python SDK

## Pre-requisite

`ANTHROPIC_API_KEY` must be set as a GitHub Actions secret on this repo.

## Test plan

- [ ] Verify `ANTHROPIC_API_KEY` secret exists on the repo
- [ ] Merge and open a test PR to confirm the workflow triggers and posts review comments