### PR TITLE
fix: query params serialization for List query params with one item

### DIFF
--- a/scripts/generate_client.py
+++ b/scripts/generate_client.py
@@ -52,6 +52,9 @@ def run_generator(spec_path: Path, temp_dir: Path) -> bool:
 
     Returns True if successful, False otherwise.
     """
+    # Custom templates live alongside this script
+    templates_dir = Path(__file__).parent / "templates"
+
     cmd = [
         "openapi-python-generator",
         str(spec_path),
@@ -62,6 +65,8 @@ def run_generator(spec_path: Path, temp_dir: Path) -> bool:
         "v2",
         "--formatter",
         "black",
+        "--custom-template-path",
+        str(templates_dir),
     ]
 
     print(f"Running: {' '.join(cmd)}")
@@ -123,7 +128,7 @@ def patch_api_config(output_dir: Path) -> bool:
 
     # Our custom api_config.py content with all extensions
     custom_content = '''import os
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from pydantic import BaseModel, Field
 
@@ -196,6 +201,29 @@ class HTTPException(Exception):
 
     def __str__(self):
         return f"{self.status_code} {self.message}"
+
+
+def _serialize_query_params(
+    params: dict,
+) -> list[tuple[str, Any]]:
+    """Serialize query params, expanding lists with bracket notation.
+
+    httpx passes a plain List value as a repeated bare key, e.g.
+    ``ids=a&ids=b``.  The server-side Zod schema rejects a single-value
+    list as "expected array, received string" because one bare key looks
+    like a plain string to the parser.
+
+    Bracket notation (``ids[]=a&ids[]=b``) always produces an array
+    regardless of how many values are present, which is what Zod expects.
+    """
+    result: list[tuple[str, Any]] = []
+    for key, value in params.items():
+        if isinstance(value, list):
+            for item in value:
+                result.append((f"{key}[]", item))
+        else:
+            result.append((key, value))
+    return result
 '''
 
     api_config_file.write_text(custom_content)
@@ -221,21 +249,8 @@ def post_process(output_dir: Path) -> bool:
         init_file.write_text('"""Auto-generated HoneyHive API client."""\n')
         print("  ✓ Created __init__.py")
 
-    # Fix serialization to exclude None values
-    # The API rejects null values, so we must use model_dump(exclude_none=True)
-    services_dir = output_dir / "services"
-    if services_dir.exists():
-        fixed_count = 0
-        for service_file in services_dir.glob("*.py"):
-            content = service_file.read_text()
-            if "data.dict()" in content:
-                content = content.replace(
-                    "data.dict()", "data.model_dump(exclude_none=True)"
-                )
-                service_file.write_text(content)
-                fixed_count += 1
-        if fixed_count > 0:
-            print(f"  ✓ Fixed serialization in {fixed_count} service files")
+    # Note: data.model_dump(exclude_none=True) and _serialize_query_params are
+    # handled directly in scripts/templates/httpx.jinja2 and service.jinja2.
 
     print("  ✓ Post-processing complete")
     return True

--- a/scripts/generate_client.py
+++ b/scripts/generate_client.py
@@ -205,7 +205,7 @@ class HTTPException(Exception):
 
 def _serialize_query_params(
     params: dict,
-) -> list[tuple[str, Any]]:
+    params: dict[str, Any],
     """Serialize query params, expanding lists with bracket notation.
 
     httpx passes a plain List value as a repeated bare key, e.g.

--- a/scripts/generate_client.py
+++ b/scripts/generate_client.py
@@ -109,128 +109,6 @@ def move_generated_code(temp_dir: Path, output_dir: Path) -> bool:
     return True
 
 
-def patch_api_config(output_dir: Path) -> bool:
-    """
-    Patch the generated api_config.py to add our custom HoneyHive extensions.
-
-    The generator creates a basic api_config.py, but we need:
-    - DEFAULT_BASE_URL and DEFAULT_CP_BASE_URL constants
-    - cp_base_path field for Control Plane API
-    - from_env() class method for environment-based initialization
-    - get_cp_base_path() method for Control Plane base path
-
-    Returns True if successful, False otherwise.
-    """
-    api_config_file = output_dir / "api_config.py"
-    if not api_config_file.exists():
-        print("  ⚠ api_config.py not found, skipping patch")
-        return True
-
-    # Our custom api_config.py content with all extensions
-    custom_content = '''import os
-from typing import Any, Optional, Union
-
-from pydantic import BaseModel, Field
-
-
-# Default production URLs
-DEFAULT_BASE_URL = "https://api.honeyhive.ai"
-DEFAULT_CP_BASE_URL = "https://api.honeyhive.ai"
-
-
-class APIConfig(BaseModel):
-    model_config = {"validate_assignment": True}
-
-    base_path: str = DEFAULT_BASE_URL
-    cp_base_path: Optional[str] = DEFAULT_CP_BASE_URL
-    verify: Union[bool, str] = True
-    access_token: Optional[str] = None
-
-    @classmethod
-    def from_env(
-        cls,
-        api_key: Optional[str] = None,
-        base_url: Optional[str] = None,
-        cp_base_url: Optional[str] = None,
-    ) -> "APIConfig":
-        """Create APIConfig from environment variables with overrides.
-
-        Environment variables:
-            HH_API_KEY: API key for authentication
-            HH_API_URL: Base URL for Data Plane API
-            HH_CP_API_URL: Base URL for Control Plane API (defaults to HH_API_URL)
-
-        Args:
-            api_key: Override for HH_API_KEY
-            base_url: Override for HH_API_URL
-            cp_base_url: Override for HH_CP_API_URL
-        """
-        resolved_api_key = api_key or os.environ.get("HH_API_KEY")
-        resolved_base_url = (
-            base_url or os.environ.get("HH_API_URL") or DEFAULT_BASE_URL
-        )
-        resolved_cp_base_url = (
-            cp_base_url
-            or os.environ.get("HH_CP_API_URL")
-            or os.environ.get("HH_API_URL")
-            or DEFAULT_CP_BASE_URL
-        )
-
-        return cls(
-            base_path=resolved_base_url,
-            cp_base_path=resolved_cp_base_url,
-            access_token=resolved_api_key,
-        )
-
-    def get_access_token(self) -> Optional[str]:
-        return self.access_token
-
-    def set_access_token(self, value: str):
-        self.access_token = value
-
-    def get_cp_base_path(self) -> str:
-        """Get Control Plane base path, defaults to base_path if not set."""
-        return self.cp_base_path or self.base_path
-
-
-class HTTPException(Exception):
-    def __init__(self, status_code: int, message: str):
-        self.status_code = status_code
-        self.message = message
-        super().__init__(f"{status_code} {message}")
-
-    def __str__(self):
-        return f"{self.status_code} {self.message}"
-
-
-def _serialize_query_params(
-    params: dict,
-    params: dict[str, Any],
-    """Serialize query params, expanding lists with bracket notation.
-
-    httpx passes a plain List value as a repeated bare key, e.g.
-    ``ids=a&ids=b``.  The server-side Zod schema rejects a single-value
-    list as "expected array, received string" because one bare key looks
-    like a plain string to the parser.
-
-    Bracket notation (``ids[]=a&ids[]=b``) always produces an array
-    regardless of how many values are present, which is what Zod expects.
-    """
-    result: list[tuple[str, Any]] = []
-    for key, value in params.items():
-        if isinstance(value, list):
-            for item in value:
-                result.append((f"{key}[]", item))
-        else:
-            result.append((key, value))
-    return result
-'''
-
-    api_config_file.write_text(custom_content)
-    print("  ✓ Patched api_config.py with HoneyHive extensions")
-    return True
-
-
 def post_process(output_dir: Path) -> bool:
     """
     Apply any post-processing customizations to the generated code.
@@ -238,10 +116,6 @@ def post_process(output_dir: Path) -> bool:
     Returns True if successful, False otherwise.
     """
     print("🔧 Applying post-processing customizations...")
-
-    # Patch api_config.py with our custom extensions
-    if not patch_api_config(output_dir):
-        return False
 
     # Ensure __init__.py exists at the package root
     init_file = output_dir / "__init__.py"

--- a/scripts/templates/apiconfig_pydantic_2.jinja2
+++ b/scripts/templates/apiconfig_pydantic_2.jinja2
@@ -1,0 +1,114 @@
+{#
+  Forked from openapi-python-generator's default template:
+  https://github.com/MarcoMuellner/openapi-python-generator/blob/main/src/openapi_python_generator/language_converters/python/templates/apiconfig_pydantic_2.jinja2
+
+  Changes from upstream:
+  - Always import os and add Any to typing imports (upstream conditionally imports os
+    only when env_token_name is set)
+  - Added DEFAULT_BASE_URL and DEFAULT_CP_BASE_URL constants
+  - Added cp_base_path field to APIConfig
+  - Added from_env() classmethod for environment-based initialization
+  - Added get_cp_base_path() method
+  - Removed env_token_name conditional branches (hardcoded to the non-env-token path)
+  - Added _serialize_query_params() helper so List-typed query params are sent as
+    bracket notation (ids[]=a&ids[]=b) instead of bare repeated keys (ids=a&ids=b)
+#}
+import os
+from typing import Any, Optional, Union
+
+from pydantic import BaseModel, Field
+
+
+# Default production URLs
+DEFAULT_BASE_URL = "https://api.honeyhive.ai"
+DEFAULT_CP_BASE_URL = "https://api.honeyhive.ai"
+
+
+class APIConfig(BaseModel):
+    model_config = {
+        "validate_assignment": True
+    }
+
+    base_path: str = DEFAULT_BASE_URL
+    cp_base_path: Optional[str] = DEFAULT_CP_BASE_URL
+    verify: Union[bool, str] = True
+    access_token: Optional[str] = None
+
+    @classmethod
+    def from_env(
+        cls,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        cp_base_url: Optional[str] = None,
+    ) -> "APIConfig":
+        """Create APIConfig from environment variables with overrides.
+
+        Environment variables:
+            HH_API_KEY: API key for authentication
+            HH_API_URL: Base URL for Data Plane API
+            HH_CP_API_URL: Base URL for Control Plane API (defaults to HH_API_URL)
+
+        Args:
+            api_key: Override for HH_API_KEY
+            base_url: Override for HH_API_URL
+            cp_base_url: Override for HH_CP_API_URL
+        """
+        resolved_api_key = api_key or os.environ.get("HH_API_KEY")
+        resolved_base_url = (
+            base_url or os.environ.get("HH_API_URL") or DEFAULT_BASE_URL
+        )
+        resolved_cp_base_url = (
+            cp_base_url
+            or os.environ.get("HH_CP_API_URL")
+            or os.environ.get("HH_API_URL")
+            or DEFAULT_CP_BASE_URL
+        )
+
+        return cls(
+            base_path=resolved_base_url,
+            cp_base_path=resolved_cp_base_url,
+            access_token=resolved_api_key,
+        )
+
+    def get_access_token(self) -> Optional[str]:
+        return self.access_token
+
+    def set_access_token(self, value: str):
+        self.access_token = value
+
+    def get_cp_base_path(self) -> str:
+        """Get Control Plane base path, defaults to base_path if not set."""
+        return self.cp_base_path or self.base_path
+
+
+class HTTPException(Exception):
+    def __init__(self, status_code: int, message: str):
+        self.status_code = status_code
+        self.message = message
+        super().__init__(f"{status_code} {message}")
+
+    def __str__(self):
+        return f"{self.status_code} {self.message}"
+
+
+def _serialize_query_params(
+    params: dict[str, Any],
+) -> list[tuple[str, Any]]:
+    """Serialize query params, expanding lists with bracket notation.
+
+    httpx passes a plain List value as a repeated bare key, e.g.
+    ``ids=a&ids=b``.  The server-side Zod schema rejects a single-value
+    list as "expected array, received string" because one bare key looks
+    like a plain string to the parser.
+
+    Bracket notation (``ids[]=a&ids[]=b``) always produces an array
+    regardless of how many values are present, which is what Zod expects.
+    """
+    result: list[tuple[str, Any]] = []
+    for key, value in params.items():
+        if isinstance(value, list):
+            for item in value:
+                result.append((f"{key}[]", item))
+        else:
+            result.append((key, value))
+    return result

--- a/scripts/templates/httpx.jinja2
+++ b/scripts/templates/httpx.jinja2
@@ -1,0 +1,67 @@
+{#
+  Forked from openapi-python-generator's default template.
+
+  Changes from upstream:
+  - params=query_params replaced with params=_serialize_query_params(query_params)
+    so List-typed query params are sent as bracket notation (ids[]=a&ids[]=b) rather
+    than bare repeated keys (ids=a&ids=b). The server-side Zod schema requires bracket
+    notation to recognise a single-value list as an array rather than a string.
+  - data.dict() replaced with data.model_dump(exclude_none=True) for Pydantic v2
+    compatibility and to avoid sending null fields to the API.
+#}
+{%  if async_client %}async {% endif %}def {{ operation_id }}(api_config_override : Optional[APIConfig] = None{% if params.strip() %}, *, {{ params.rstrip(', ') }}{% endif %}) -> {% if return_type.type is none or return_type.type.converted_type is none %}None{% else %}{{ return_type.type.converted_type}}{% endif %}:
+    api_config = api_config_override if api_config_override else APIConfig()
+
+    base_path = api_config.base_path
+    path = f'{{ path_name }}'
+    headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+        'Authorization': f'Bearer { api_config.get_access_token() }',
+        {{ header_params | join(',\n') | safe }}
+    }
+    query_params : Dict[str,Any] = {
+    {% if query_params|length > 0 %}
+        {{ query_params | join(',\n') | safe }}
+    {% endif %}
+    }
+
+    query_params = {key:value for (key,value) in query_params.items() if value is not None}
+
+    {% if async_client %}
+async with httpx.AsyncClient(base_url=base_path, verify=api_config.verify) as client:
+        response = await client.request(
+    {% else %}
+with httpx.Client(base_url=base_path, verify=api_config.verify) as client:
+        response = client.request(
+    {% endif %}
+        '{{ method }}',
+        httpx.URL(path),
+        headers=headers,
+        params=_serialize_query_params(query_params),
+        {% if body_param %}
+        {% if use_orjson %}
+        content=orjson.dumps({{ body_param | replace("data.dict()", "data.model_dump(exclude_none=True)") }})
+        {% else %}
+        json = {{ body_param | replace("data.dict()", "data.model_dump(exclude_none=True)") }}
+        {% endif %}
+        {% endif %}
+    )
+
+    if response.status_code != {{ return_type.status_code }}:
+        raise HTTPException(response.status_code, f'{{ operation_id }} failed with status code: {response.status_code}')
+    else:
+        {# Conditional body parsing: avoid calling .json() for 204 #}
+        body = None if {{ return_type.status_code }} == 204 else response.json()
+
+{% if return_type.type is none or return_type.type.converted_type is none %}
+    return None
+{% elif return_type.complex_type %}
+    {%- if return_type.list_type is none %}
+    return {{ return_type.type.converted_type }}(**body) if body is not None else {{ return_type.type.converted_type }}()
+    {%- else %}
+    return [{{ return_type.list_type }}(**item) for item in body]
+    {%- endif %}
+{% else %}
+    return body
+{% endif %}

--- a/scripts/templates/service.jinja2
+++ b/scripts/templates/service.jinja2
@@ -1,0 +1,20 @@
+{#
+  Forked from openapi-python-generator's default template.
+
+  Changes from upstream:
+  - Added _serialize_query_params to the api_config import so service functions
+    can use bracket-notation query param serialization (fixes Zod "expected array,
+    received string" errors when List params are passed to GET endpoints).
+#}
+from typing import *
+import {{ library_import }}
+
+{% if use_orjson %}
+import orjson
+from uuid import UUID
+{% endif %}
+
+from ..models import *
+from ..api_config import APIConfig, HTTPException, _serialize_query_params
+
+{{ content | safe}}

--- a/src/honeyhive/_generated/api_config.py
+++ b/src/honeyhive/_generated/api_config.py
@@ -1,5 +1,5 @@
 import os
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from pydantic import BaseModel, Field
 
@@ -69,3 +69,26 @@ class HTTPException(Exception):
 
     def __str__(self):
         return f"{self.status_code} {self.message}"
+
+
+def _serialize_query_params(
+    params: dict,
+) -> list[tuple[str, Any]]:
+    """Serialize query params, expanding lists with bracket notation.
+
+    httpx passes a plain List value as a repeated bare key, e.g.
+    ``ids=a&ids=b``.  The server-side Zod schema rejects a single-value
+    list as "expected array, received string" because one bare key looks
+    like a plain string to the parser.
+
+    Bracket notation (``ids[]=a&ids[]=b``) always produces an array
+    regardless of how many values are present, which is what Zod expects.
+    """
+    result: list[tuple[str, Any]] = []
+    for key, value in params.items():
+        if isinstance(value, list):
+            for item in value:
+                result.append((f"{key}[]", item))
+        else:
+            result.append((key, value))
+    return result

--- a/src/honeyhive/_generated/api_config.py
+++ b/src/honeyhive/_generated/api_config.py
@@ -72,7 +72,7 @@ class HTTPException(Exception):
 
 
 def _serialize_query_params(
-    params: dict,
+    params: dict[str, Any],
 ) -> list[tuple[str, Any]]:
     """Serialize query params, expanding lists with bracket notation.
 

--- a/src/honeyhive/_generated/services/Configurations_service.py
+++ b/src/honeyhive/_generated/services/Configurations_service.py
@@ -2,7 +2,7 @@ from typing import *
 
 import httpx
 
-from ..api_config import APIConfig, HTTPException
+from ..api_config import APIConfig, HTTPException, _serialize_query_params
 from ..models import *
 
 
@@ -33,7 +33,7 @@ def getConfigurations(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -70,7 +70,7 @@ def createConfiguration(
             "post",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -115,7 +115,7 @@ def updateConfiguration(
             "put",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -157,7 +157,7 @@ def deleteConfiguration(
             "delete",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:

--- a/src/honeyhive/_generated/services/Datapoints_service.py
+++ b/src/honeyhive/_generated/services/Datapoints_service.py
@@ -2,7 +2,7 @@ from typing import *
 
 import httpx
 
-from ..api_config import APIConfig, HTTPException
+from ..api_config import APIConfig, HTTPException, _serialize_query_params
 from ..models import *
 
 
@@ -35,7 +35,7 @@ def getDatapoints(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -74,7 +74,7 @@ def createDatapoint(
             "post",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -118,7 +118,7 @@ def batchCreateDatapoints(
             "post",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -160,7 +160,7 @@ def getDatapoint(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -200,7 +200,7 @@ def updateDatapoint(
             "put",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -242,7 +242,7 @@ def deleteDatapoint(
             "delete",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:

--- a/src/honeyhive/_generated/services/Datasets_service.py
+++ b/src/honeyhive/_generated/services/Datasets_service.py
@@ -2,7 +2,7 @@ from typing import *
 
 import httpx
 
-from ..api_config import APIConfig, HTTPException
+from ..api_config import APIConfig, HTTPException, _serialize_query_params
 from ..models import *
 
 
@@ -32,7 +32,7 @@ def getDatasets(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -69,7 +69,7 @@ def createDataset(
             "post",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -109,7 +109,7 @@ def updateDataset(
             "put",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -149,7 +149,7 @@ def deleteDataset(
             "delete",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -191,7 +191,7 @@ def addDatapoints(
             "post",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -234,7 +234,7 @@ def removeDatapoint(
             "delete",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:

--- a/src/honeyhive/_generated/services/Events_service.py
+++ b/src/honeyhive/_generated/services/Events_service.py
@@ -2,7 +2,7 @@ from typing import *
 
 import httpx
 
-from ..api_config import APIConfig, HTTPException
+from ..api_config import APIConfig, HTTPException, _serialize_query_params
 from ..models import *
 
 
@@ -45,7 +45,7 @@ def getEvents(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -79,7 +79,11 @@ def createEvent(
 
     with httpx.Client(base_url=base_path, verify=api_config.verify) as client:
         response = client.request(
-            "post", httpx.URL(path), headers=headers, params=query_params, json=data
+            "post",
+            httpx.URL(path),
+            headers=headers,
+            params=_serialize_query_params(query_params),
+            json=data,
         )
 
     if response.status_code != 200:
@@ -113,7 +117,11 @@ def updateEvent(
 
     with httpx.Client(base_url=base_path, verify=api_config.verify) as client:
         response = client.request(
-            "put", httpx.URL(path), headers=headers, params=query_params, json=data
+            "put",
+            httpx.URL(path),
+            headers=headers,
+            params=_serialize_query_params(query_params),
+            json=data,
         )
 
     if response.status_code != 200:
@@ -168,7 +176,7 @@ def getEventsChart(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -207,7 +215,7 @@ def getEventsBySessionId(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -248,7 +256,7 @@ def deleteEvent(
             "delete",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -285,7 +293,7 @@ def exportEvents(
             "post",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -327,7 +335,7 @@ def createModelEvent(
             "post",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -365,7 +373,7 @@ def createEventBatch(
             "post",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -405,7 +413,7 @@ def createModelEventBatch(
             "post",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 

--- a/src/honeyhive/_generated/services/Experiments_service.py
+++ b/src/honeyhive/_generated/services/Experiments_service.py
@@ -2,7 +2,7 @@ from typing import *
 
 import httpx
 
-from ..api_config import APIConfig, HTTPException
+from ..api_config import APIConfig, HTTPException, _serialize_query_params
 from ..models import *
 
 
@@ -35,7 +35,7 @@ def getExperimentRunsSchema(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -96,7 +96,7 @@ def getRuns(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -137,7 +137,7 @@ def createRun(
             "post",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -179,7 +179,7 @@ def getRun(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -223,7 +223,7 @@ def updateRun(
             "put",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -265,7 +265,7 @@ def deleteRun(
             "delete",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -310,7 +310,7 @@ def getExperimentRunMetrics(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -354,7 +354,7 @@ def getExperimentResult(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -403,7 +403,7 @@ def getExperimentComparison(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -460,7 +460,7 @@ def getExperimentCompareEvents(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:

--- a/src/honeyhive/_generated/services/Metrics_service.py
+++ b/src/honeyhive/_generated/services/Metrics_service.py
@@ -2,7 +2,7 @@ from typing import *
 
 import httpx
 
-from ..api_config import APIConfig, HTTPException
+from ..api_config import APIConfig, HTTPException, _serialize_query_params
 from ..models import *
 
 
@@ -32,7 +32,7 @@ def getMetrics(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -69,7 +69,7 @@ def createMetric(
             "post",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -107,7 +107,7 @@ def updateMetric(
             "put",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -145,7 +145,7 @@ def deleteMetric(
             "delete",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -182,7 +182,7 @@ def runMetric(
             "post",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 

--- a/src/honeyhive/_generated/services/Projects_service.py
+++ b/src/honeyhive/_generated/services/Projects_service.py
@@ -2,7 +2,7 @@ from typing import *
 
 import httpx
 
-from ..api_config import APIConfig, HTTPException
+from ..api_config import APIConfig, HTTPException, _serialize_query_params
 from ..models import *
 
 
@@ -29,7 +29,7 @@ def getProjects(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -66,7 +66,7 @@ def createProject(
             "post",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -104,7 +104,7 @@ def updateProject(
             "put",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -142,7 +142,7 @@ def deleteProject(
             "delete",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:

--- a/src/honeyhive/_generated/services/Session_service.py
+++ b/src/honeyhive/_generated/services/Session_service.py
@@ -2,7 +2,7 @@ from typing import *
 
 import httpx
 
-from ..api_config import APIConfig, HTTPException
+from ..api_config import APIConfig, HTTPException, _serialize_query_params
 from ..models import *
 
 
@@ -26,7 +26,11 @@ def startSession(
 
     with httpx.Client(base_url=base_path, verify=api_config.verify) as client:
         response = client.request(
-            "post", httpx.URL(path), headers=headers, params=query_params, json=data
+            "post",
+            httpx.URL(path),
+            headers=headers,
+            params=_serialize_query_params(query_params),
+            json=data,
         )
 
     if response.status_code != 200:

--- a/src/honeyhive/_generated/services/Sessions_service.py
+++ b/src/honeyhive/_generated/services/Sessions_service.py
@@ -2,7 +2,7 @@ from typing import *
 
 import httpx
 
-from ..api_config import APIConfig, HTTPException
+from ..api_config import APIConfig, HTTPException, _serialize_query_params
 from ..models import *
 
 
@@ -29,7 +29,7 @@ def getSession(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -66,7 +66,7 @@ def deleteSession(
             "delete",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:

--- a/src/honeyhive/_generated/services/async_Configurations_service.py
+++ b/src/honeyhive/_generated/services/async_Configurations_service.py
@@ -2,7 +2,7 @@ from typing import *
 
 import httpx
 
-from ..api_config import APIConfig, HTTPException
+from ..api_config import APIConfig, HTTPException, _serialize_query_params
 from ..models import *
 
 
@@ -35,7 +35,7 @@ async def getConfigurations(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -74,7 +74,7 @@ async def createConfiguration(
             "post",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -121,7 +121,7 @@ async def updateConfiguration(
             "put",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -165,7 +165,7 @@ async def deleteConfiguration(
             "delete",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:

--- a/src/honeyhive/_generated/services/async_Datapoints_service.py
+++ b/src/honeyhive/_generated/services/async_Datapoints_service.py
@@ -2,7 +2,7 @@ from typing import *
 
 import httpx
 
-from ..api_config import APIConfig, HTTPException
+from ..api_config import APIConfig, HTTPException, _serialize_query_params
 from ..models import *
 
 
@@ -37,7 +37,7 @@ async def getDatapoints(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -78,7 +78,7 @@ async def createDatapoint(
             "post",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -124,7 +124,7 @@ async def batchCreateDatapoints(
             "post",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -168,7 +168,7 @@ async def getDatapoint(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -210,7 +210,7 @@ async def updateDatapoint(
             "put",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -254,7 +254,7 @@ async def deleteDatapoint(
             "delete",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:

--- a/src/honeyhive/_generated/services/async_Datasets_service.py
+++ b/src/honeyhive/_generated/services/async_Datasets_service.py
@@ -2,7 +2,7 @@ from typing import *
 
 import httpx
 
-from ..api_config import APIConfig, HTTPException
+from ..api_config import APIConfig, HTTPException, _serialize_query_params
 from ..models import *
 
 
@@ -34,7 +34,7 @@ async def getDatasets(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -73,7 +73,7 @@ async def createDataset(
             "post",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -115,7 +115,7 @@ async def updateDataset(
             "put",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -157,7 +157,7 @@ async def deleteDataset(
             "delete",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -201,7 +201,7 @@ async def addDatapoints(
             "post",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -246,7 +246,7 @@ async def removeDatapoint(
             "delete",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:

--- a/src/honeyhive/_generated/services/async_Events_service.py
+++ b/src/honeyhive/_generated/services/async_Events_service.py
@@ -2,7 +2,7 @@ from typing import *
 
 import httpx
 
-from ..api_config import APIConfig, HTTPException
+from ..api_config import APIConfig, HTTPException, _serialize_query_params
 from ..models import *
 
 
@@ -47,7 +47,7 @@ async def getEvents(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -83,7 +83,11 @@ async def createEvent(
         base_url=base_path, verify=api_config.verify
     ) as client:
         response = await client.request(
-            "post", httpx.URL(path), headers=headers, params=query_params, json=data
+            "post",
+            httpx.URL(path),
+            headers=headers,
+            params=_serialize_query_params(query_params),
+            json=data,
         )
 
     if response.status_code != 200:
@@ -119,7 +123,11 @@ async def updateEvent(
         base_url=base_path, verify=api_config.verify
     ) as client:
         response = await client.request(
-            "put", httpx.URL(path), headers=headers, params=query_params, json=data
+            "put",
+            httpx.URL(path),
+            headers=headers,
+            params=_serialize_query_params(query_params),
+            json=data,
         )
 
     if response.status_code != 200:
@@ -176,7 +184,7 @@ async def getEventsChart(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -217,7 +225,7 @@ async def getEventsBySessionId(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -260,7 +268,7 @@ async def deleteEvent(
             "delete",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -299,7 +307,7 @@ async def exportEvents(
             "post",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -343,7 +351,7 @@ async def createModelEvent(
             "post",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -383,7 +391,7 @@ async def createEventBatch(
             "post",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -425,7 +433,7 @@ async def createModelEventBatch(
             "post",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 

--- a/src/honeyhive/_generated/services/async_Experiments_service.py
+++ b/src/honeyhive/_generated/services/async_Experiments_service.py
@@ -2,7 +2,7 @@ from typing import *
 
 import httpx
 
-from ..api_config import APIConfig, HTTPException
+from ..api_config import APIConfig, HTTPException, _serialize_query_params
 from ..models import *
 
 
@@ -37,7 +37,7 @@ async def getExperimentRunsSchema(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -100,7 +100,7 @@ async def getRuns(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -143,7 +143,7 @@ async def createRun(
             "post",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -187,7 +187,7 @@ async def getRun(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -233,7 +233,7 @@ async def updateRun(
             "put",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -277,7 +277,7 @@ async def deleteRun(
             "delete",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -324,7 +324,7 @@ async def getExperimentRunMetrics(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -370,7 +370,7 @@ async def getExperimentResult(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -421,7 +421,7 @@ async def getExperimentComparison(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -480,7 +480,7 @@ async def getExperimentCompareEvents(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:

--- a/src/honeyhive/_generated/services/async_Metrics_service.py
+++ b/src/honeyhive/_generated/services/async_Metrics_service.py
@@ -2,7 +2,7 @@ from typing import *
 
 import httpx
 
-from ..api_config import APIConfig, HTTPException
+from ..api_config import APIConfig, HTTPException, _serialize_query_params
 from ..models import *
 
 
@@ -34,7 +34,7 @@ async def getMetrics(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -73,7 +73,7 @@ async def createMetric(
             "post",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -113,7 +113,7 @@ async def updateMetric(
             "put",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -153,7 +153,7 @@ async def deleteMetric(
             "delete",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -192,7 +192,7 @@ async def runMetric(
             "post",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 

--- a/src/honeyhive/_generated/services/async_Projects_service.py
+++ b/src/honeyhive/_generated/services/async_Projects_service.py
@@ -2,7 +2,7 @@ from typing import *
 
 import httpx
 
-from ..api_config import APIConfig, HTTPException
+from ..api_config import APIConfig, HTTPException, _serialize_query_params
 from ..models import *
 
 
@@ -31,7 +31,7 @@ async def getProjects(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -70,7 +70,7 @@ async def createProject(
             "post",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -110,7 +110,7 @@ async def updateProject(
             "put",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
             json=data.model_dump(exclude_none=True),
         )
 
@@ -150,7 +150,7 @@ async def deleteProject(
             "delete",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:

--- a/src/honeyhive/_generated/services/async_Session_service.py
+++ b/src/honeyhive/_generated/services/async_Session_service.py
@@ -2,7 +2,7 @@ from typing import *
 
 import httpx
 
-from ..api_config import APIConfig, HTTPException
+from ..api_config import APIConfig, HTTPException, _serialize_query_params
 from ..models import *
 
 
@@ -28,7 +28,11 @@ async def startSession(
         base_url=base_path, verify=api_config.verify
     ) as client:
         response = await client.request(
-            "post", httpx.URL(path), headers=headers, params=query_params, json=data
+            "post",
+            httpx.URL(path),
+            headers=headers,
+            params=_serialize_query_params(query_params),
+            json=data,
         )
 
     if response.status_code != 200:

--- a/src/honeyhive/_generated/services/async_Sessions_service.py
+++ b/src/honeyhive/_generated/services/async_Sessions_service.py
@@ -2,7 +2,7 @@ from typing import *
 
 import httpx
 
-from ..api_config import APIConfig, HTTPException
+from ..api_config import APIConfig, HTTPException, _serialize_query_params
 from ..models import *
 
 
@@ -31,7 +31,7 @@ async def getSession(
             "get",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:
@@ -70,7 +70,7 @@ async def deleteSession(
             "delete",
             httpx.URL(path),
             headers=headers,
-            params=query_params,
+            params=_serialize_query_params(query_params),
         )
 
     if response.status_code != 200:


### PR DESCRIPTION
Add `scripts/templates/httpx.jinja2` and `service.jinja2` forked from the upstream `openapi-python-generator` defaults, with two targeted changes:

- Replace `params=query_params` with `params=_serialize_query_params(query_params)` in the httpx template so List-typed params are sent as bracket notation (`ids[]=a&ids[]=b`) rather than bare repeated keys (`ids=a&ids=b`). The server-side Zod schema requires bracket notation to parse a list correctly; bare keys for a single value are treated as a string, causing 400 errors.

- Replace `data.dict()` with `data.model_dump(exclude_none=True)` for Pydantic v2 compatibility and to avoid sending null fields to the API.

Also wires `--custom-template-path` into `generate_client.py` and removes the equivalent post-processing steps that were previously patching generated files.

Fixes: HHAI-3902
