### PR TITLE
ci: use python venv in ci

### DIFF
--- a/.github/workflows/tox-full-suite.yml
+++ b/.github/workflows/tox-full-suite.yml
@@ -177,7 +177,7 @@ jobs:
       - name: Regenerate and format code
         run: |
           echo "🔄 Regenerating and formatting code..."
-          make generate
+          source .venv/bin/activate && make generate
 
       - name: Check for uncommitted changes
         run: |

--- a/.github/workflows/tox-full-suite.yml
+++ b/.github/workflows/tox-full-suite.yml
@@ -170,8 +170,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          python -m venv .venv
+          .venv/bin/pip install --upgrade pip
+          .venv/bin/pip install -e ".[dev]"
 
       - name: Regenerate and format code
         run: |


### PR DESCRIPTION
fixes this error in CI:

```
Run echo "🔄 Regenerating and formatting code..."
🔄 Regenerating and formatting code...
.venv/bin/python scripts/generate_client.py
make: .venv/bin/python: No such file or directory
make: *** [Makefile:137: generate] Error 127
Error: Process completed with exit code 2.
```