### PR TITLE
feat: add retry logic to `export_async()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,11 @@
   - Added examples covering common agent patterns for each framework
   - Rewrote LangGraph example with canonical tool-calling loop and routing workflow
 
-### Fixed
-
 - **API Client: Async export now retries on transient errors** (#264)
   - `export_async()` now retries on transient HTTP errors (502, 503, 504, etc.), matching `export()` behavior
   - Export errors now raise `APIError` with status code and response body instead of generic `Exception`
+
+### Fixed
 
 - **API Client: List query params serialization with single item** (#251)
   - Fixed 400 errors when passing a single-element list to API query params (e.g. `ids=["abc"]`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ### Fixed
 
+- **API Client: Async export now retries on transient errors** (#264)
+  - `export_async()` now retries on transient HTTP errors (502, 503, 504, etc.), matching `export()` behavior
+  - Export errors now raise `APIError` with status code and response body instead of generic `Exception`
+
 - **API Client: List query params serialization with single item** (#251)
   - Fixed 400 errors when passing a single-element list to API query params (e.g. `ids=["abc"]`)
   - List params now serialize with bracket notation (`ids[]=a&ids[]=b`) as required by the backend

--- a/src/honeyhive/api/client.py
+++ b/src/honeyhive/api/client.py
@@ -16,7 +16,6 @@ Usage::
     configs = await client.configurations.list_async(project="my-project")
 """
 
-import time
 import warnings
 from typing import Any, Dict, List, Optional, Union
 
@@ -679,59 +678,20 @@ class EventsAPI(BaseAPI):
             "Authorization": f"Bearer {self._api_config.get_access_token()}",
         }
 
-        # Use retry logic for transient errors (502, 503, 504, etc.)
+        # Execute with retry logic for transient errors (502, 503, 504, etc.)
         retry_config = RetryConfig.default()
-        last_exception: Optional[Exception] = None
-        last_response: Optional[httpx.Response] = None
-
-        for attempt in range(retry_config.max_retries + 1):
-            try:
-                with httpx.Client(
-                    base_url=base_path, verify=self._api_config.verify
-                ) as client:
-                    response = client.request(
-                        "POST",
-                        "/v1/events/export",
-                        headers=headers,
-                        json=request_body,
-                    )
-
-                if response.status_code == 200:
-                    break  # Success, exit retry loop
-
-                # Check if we should retry this status code
-                if retry_config.should_retry(response):
-                    last_response = response
-                    if attempt < retry_config.max_retries:
-                        delay = retry_config.backoff_strategy.get_delay(attempt + 1)
-                        time.sleep(delay)
-                        continue
-
-                # Non-retryable error, raise immediately
-                raise Exception(
-                    f"export() failed with status code: {response.status_code}, "
-                    f"response: {response.text}"
-                )
-
-            except httpx.HTTPError as e:
-                if retry_config.should_retry_exception(e):
-                    last_exception = e
-                    if attempt < retry_config.max_retries:
-                        delay = retry_config.backoff_strategy.get_delay(attempt + 1)
-                        time.sleep(delay)
-                        continue
-                raise
-
-        else:
-            # All retries exhausted
-            if last_response is not None:
-                raise Exception(
-                    f"export() failed after {retry_config.max_retries + 1} attempts "
-                    f"with status code: {last_response.status_code}, "
-                    f"response: {last_response.text}"
-                )
-            if last_exception is not None:
-                raise last_exception
+        with httpx.Client(
+            base_url=base_path, verify=self._api_config.verify
+        ) as client:
+            response = retry_config.execute(
+                lambda: client.request(
+                    "POST",
+                    "/v1/events/export",
+                    headers=headers,
+                    json=request_body,
+                ),
+                operation="export()",
+            )
 
         data = response.json()
         events = data.get("events", [])
@@ -940,20 +900,19 @@ class EventsAPI(BaseAPI):
             "Authorization": f"Bearer {self._api_config.get_access_token()}",
         }
 
+        # Execute with retry logic for transient errors (502, 503, 504, etc.)
+        retry_config = RetryConfig.default()
         async with httpx.AsyncClient(
             base_url=base_path, verify=self._api_config.verify
         ) as client:
-            response = await client.request(
-                "POST",
-                "/v1/events/export",
-                headers=headers,
-                json=request_body,
-            )
-
-        if response.status_code != 200:
-            raise Exception(
-                f"export_async() failed with status code: {response.status_code}, "
-                f"response: {response.text}"
+            response = await retry_config.execute_async(
+                lambda: client.request(
+                    "POST",
+                    "/v1/events/export",
+                    headers=headers,
+                    json=request_body,
+                ),
+                operation="export_async()",
             )
 
         data = response.json()

--- a/src/honeyhive/api/client.py
+++ b/src/honeyhive/api/client.py
@@ -680,9 +680,7 @@ class EventsAPI(BaseAPI):
 
         # Execute with retry logic for transient errors (502, 503, 504, etc.)
         retry_config = RetryConfig.default()
-        with httpx.Client(
-            base_url=base_path, verify=self._api_config.verify
-        ) as client:
+        with httpx.Client(base_url=base_path, verify=self._api_config.verify) as client:
             response = retry_config.execute(
                 lambda: client.request(
                     "POST",

--- a/src/honeyhive/utils/retry.py
+++ b/src/honeyhive/utils/retry.py
@@ -241,6 +241,8 @@ class RetryConfig:
                         delay = self.backoff_strategy.get_delay(attempt + 1)
                         time.sleep(delay)
                         continue
+                    # Last attempt exhausted — break to _raise_for_failure
+                    break
 
                 # Non-retryable error — raise immediately
                 self._raise_non_retryable(operation, response)
@@ -252,6 +254,8 @@ class RetryConfig:
                         delay = self.backoff_strategy.get_delay(attempt + 1)
                         time.sleep(delay)
                         continue
+                    # Last attempt exhausted — break to _raise_for_failure
+                    break
                 raise
 
         # All retries exhausted (loop finished without return/raise)
@@ -295,6 +299,8 @@ class RetryConfig:
                         delay = self.backoff_strategy.get_delay(attempt + 1)
                         await asyncio.sleep(delay)
                         continue
+                    # Last attempt exhausted — break to _raise_for_failure
+                    break
 
                 # Non-retryable error — raise immediately
                 self._raise_non_retryable(operation, response)
@@ -306,6 +312,8 @@ class RetryConfig:
                         delay = self.backoff_strategy.get_delay(attempt + 1)
                         await asyncio.sleep(delay)
                         continue
+                    # Last attempt exhausted — break to _raise_for_failure
+                    break
                 raise
 
         # All retries exhausted (loop finished without return/raise)

--- a/src/honeyhive/utils/retry.py
+++ b/src/honeyhive/utils/retry.py
@@ -2,11 +2,15 @@
 
 # pylint: disable=duplicate-code  # HTTP error types are standard across modules
 
+import asyncio
 import random
+import time
 from dataclasses import dataclass
-from typing import Optional
+from typing import Callable, NoReturn, Optional
 
 import httpx
+
+from honeyhive.utils.error_handler import APIError, ErrorResponse
 
 
 @dataclass
@@ -152,3 +156,157 @@ class RetryConfig:
             )
 
         return False
+
+    def _raise_for_failure(
+        self,
+        operation: str,
+        last_response: Optional[httpx.Response],
+        last_exception: Optional[Exception],
+    ) -> NoReturn:
+        """Raise an appropriate error after all retries are exhausted.
+
+        Args:
+            operation: Name of the operation that failed (for error messages).
+            last_response: The last HTTP response received (if any).
+            last_exception: The last exception caught (if any).
+        """
+        if last_response is not None:
+            raise APIError(
+                f"{operation} failed after {self.max_retries + 1} attempts "
+                f"with status code: {last_response.status_code}, "
+                f"response: {last_response.text}",
+                error_response=ErrorResponse(
+                    error_type="APIError",
+                    error_message=last_response.text,
+                    status_code=last_response.status_code,
+                ),
+            )
+        if last_exception is not None:
+            raise last_exception
+        # Should never happen — guard against unbound response after the loop.
+        raise RuntimeError(f"{operation} retry loop exited unexpectedly")
+
+    @staticmethod
+    def _raise_non_retryable(
+        operation: str, response: httpx.Response
+    ) -> NoReturn:
+        """Raise an APIError for a non-retryable HTTP error.
+
+        Args:
+            operation: Name of the operation that failed.
+            response: The failed HTTP response.
+        """
+        raise APIError(
+            f"{operation} failed with status code: {response.status_code}, "
+            f"response: {response.text}",
+            error_response=ErrorResponse(
+                error_type="APIError",
+                error_message=response.text,
+                status_code=response.status_code,
+            ),
+        )
+
+    def execute(
+        self,
+        request_fn: Callable[[], httpx.Response],
+        operation: str = "request",
+    ) -> httpx.Response:
+        """Execute a sync HTTP request with retries.
+
+        Args:
+            request_fn: A callable that performs the HTTP request and returns
+                an httpx.Response.
+            operation: Name of the operation (used in error messages).
+
+        Returns:
+            The successful httpx.Response.
+
+        Raises:
+            APIError: On non-retryable errors or after all retries exhausted.
+        """
+        last_exception: Optional[Exception] = None
+        last_response: Optional[httpx.Response] = None
+
+        for attempt in range(self.max_retries + 1):
+            try:
+                response = request_fn()
+
+                if response.status_code == 200:
+                    return response
+
+                # Check if we should retry this status code
+                if self.should_retry(response):
+                    last_response = response
+                    if attempt < self.max_retries:
+                        delay = self.backoff_strategy.get_delay(attempt + 1)
+                        time.sleep(delay)
+                        continue
+
+                # Non-retryable error — raise immediately
+                self._raise_non_retryable(operation, response)
+
+            except httpx.HTTPError as e:
+                if self.should_retry_exception(e):
+                    last_exception = e
+                    if attempt < self.max_retries:
+                        delay = self.backoff_strategy.get_delay(attempt + 1)
+                        time.sleep(delay)
+                        continue
+                raise
+
+        # All retries exhausted (loop finished without return/raise)
+        self._raise_for_failure(operation, last_response, last_exception)
+
+    async def execute_async(
+        self,
+        request_fn: Callable[[], httpx.Response],
+        operation: str = "request",
+    ) -> httpx.Response:
+        """Execute an async HTTP request with retries.
+
+        Same contract as execute(), but awaits the request_fn and uses
+        asyncio.sleep for backoff delays.
+
+        Args:
+            request_fn: An async callable that performs the HTTP request and
+                returns an httpx.Response.
+            operation: Name of the operation (used in error messages).
+
+        Returns:
+            The successful httpx.Response.
+
+        Raises:
+            APIError: On non-retryable errors or after all retries exhausted.
+        """
+        last_exception: Optional[Exception] = None
+        last_response: Optional[httpx.Response] = None
+
+        for attempt in range(self.max_retries + 1):
+            try:
+                response = await request_fn()
+
+                if response.status_code == 200:
+                    return response
+
+                # Check if we should retry this status code
+                if self.should_retry(response):
+                    last_response = response
+                    if attempt < self.max_retries:
+                        delay = self.backoff_strategy.get_delay(attempt + 1)
+                        await asyncio.sleep(delay)
+                        continue
+
+                # Non-retryable error — raise immediately
+                self._raise_non_retryable(operation, response)
+
+            except httpx.HTTPError as e:
+                if self.should_retry_exception(e):
+                    last_exception = e
+                    if attempt < self.max_retries:
+                        delay = self.backoff_strategy.get_delay(attempt + 1)
+                        await asyncio.sleep(delay)
+                        continue
+                raise
+
+        # All retries exhausted (loop finished without return/raise)
+        self._raise_for_failure(operation, last_response, last_exception)

--- a/src/honeyhive/utils/retry.py
+++ b/src/honeyhive/utils/retry.py
@@ -6,7 +6,7 @@ import asyncio
 import random
 import time
 from dataclasses import dataclass
-from typing import Callable, NoReturn, Optional
+from typing import Awaitable, Callable, NoReturn, Optional
 
 import httpx
 
@@ -263,7 +263,7 @@ class RetryConfig:
 
     async def execute_async(
         self,
-        request_fn: Callable[[], httpx.Response],
+        request_fn: Callable[[], Awaitable[httpx.Response]],
         operation: str = "request",
     ) -> httpx.Response:
         """Execute an async HTTP request with retries.

--- a/src/honeyhive/utils/retry.py
+++ b/src/honeyhive/utils/retry.py
@@ -187,9 +187,7 @@ class RetryConfig:
         raise RuntimeError(f"{operation} retry loop exited unexpectedly")
 
     @staticmethod
-    def _raise_non_retryable(
-        operation: str, response: httpx.Response
-    ) -> NoReturn:
+    def _raise_non_retryable(operation: str, response: httpx.Response) -> NoReturn:
         """Raise an APIError for a non-retryable HTTP error.
 
         Args:


### PR DESCRIPTION
## Summary
The async `export_async()` method was missing retry logic that the sync `export()` already had. Rather than duplicating the retry loop, this PR extracts it into shared helpers on `RetryConfig` and brings both methods to full parity.

- Extracts duplicated retry loop from `export()` and `export_async()` into shared `RetryConfig.execute()` / `execute_async()` methods
- Hoists httpx client creation outside the retry loop so connection pools are reused across attempts
- Replaces bare `Exception` with `APIError` carrying structured `ErrorResponse` (status code, response text)
- Adds `RuntimeError` guard against unexpected retry loop exit

## Test plan
- [x] `tox -e unit` passes
- [x] `tox -e lint` passes (no new warnings)
- [ ] Manual verification of retry behavior on transient 502/503/504 errors

✨ Created with Claude Code