### PR TITLE
chore: gitignore .envrc and .worktrees

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,8 +1,0 @@
-# Automatically load the Nix flake development environment
-use flake
-
-# Load local .env file if it exists (for API keys, etc.)
-dotenv_if_exists .env
-
-# Load integration test environment if it exists
-dotenv_if_exists .env.integration

--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,8 @@
+# Automatically load the Nix flake development environment
+use flake
+
+# Load local .env file if it exists (for API keys, etc.)
+dotenv_if_exists .env
+
+# Load integration test environment if it exists
+dotenv_if_exists .env.integration

--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,5 @@ var/
 venv.bak/
 venv/
 wheels/
+.envrc
+.worktrees


### PR DESCRIPTION
## Summary
- Stop tracking `.envrc` (local direnv config with dev-specific env profile paths) and add it to `.gitignore`
- Add `.worktrees` to `.gitignore`

Each developer has their own direnv setup for API keys and env profiles — this shouldn't be in version control.