### PR TITLE
feat: batch query string array params to avoid URL length limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+### Fixed
+
+- **API Client: Large query string arrays no longer fail with 414/431 errors**
+  - Methods that pass arrays in query strings (`datapoints.list(datapoint_ids=...)`, `experiments.list_runs(run_ids=...)`) now automatically batch requests when the list exceeds 100 items and merge the results transparently
+  - No changes to the public API — existing code works as before, just without silent truncation or HTTP errors on large lists
+
 ## [1.0.0rc17] - 2026-02-25
 
 ### Added

--- a/src/honeyhive/api/client.py
+++ b/src/honeyhive/api/client.py
@@ -16,9 +16,10 @@ Usage::
     configs = await client.configurations.list_async(project="my-project")
 """
 
+import asyncio
 import logging
 import warnings
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, TypeVar, Union
 
 import httpx
 
@@ -53,6 +54,7 @@ from honeyhive._generated.models import (
     GetExperimentRunsResponse,
     GetExperimentRunsSchemaResponse,
     GetMetricsResponse,
+    Pagination,
     GetSessionResponse,
     PostEventRequest,
     PostEventResponse,
@@ -111,7 +113,9 @@ logger = logging.getLogger(__name__)
 QUERY_BATCH_SIZE = 100
 
 
-def _chunk_list(items: List[str], size: int) -> List[List[str]]:
+T = TypeVar("T")
+
+def _chunk_list(items: List[T], size: int) -> List[List[T]]:
     """Split a list into chunks of the given size."""
     return [items[i : i + size] for i in range(0, len(items), size)]
 
@@ -222,10 +226,19 @@ class DatapointsAPI(BaseAPI):
         # Batch if the list is large enough to risk exceeding URL length limits.
         if datapoint_ids and len(datapoint_ids) > QUERY_BATCH_SIZE:
             all_datapoints: List[Any] = []
-            for batch in _chunk_list(datapoint_ids, QUERY_BATCH_SIZE):
-                resp = datapoints_svc.getDatapoints(
-                    self._api_config, datapoint_ids=batch, dataset_name=dataset_name
-                )
+            batches = _chunk_list(datapoint_ids, QUERY_BATCH_SIZE)
+            for i, batch in enumerate(batches):
+                try:
+                    resp = datapoints_svc.getDatapoints(
+                        self._api_config,
+                        datapoint_ids=batch,
+                        dataset_name=dataset_name,
+                    )
+                except Exception:
+                    logger.warning(
+                        "Batch %d/%d failed (%d IDs)", i + 1, len(batches), len(batch)
+                    )
+                    raise
                 all_datapoints.extend(resp.datapoints)
             # Skip re-validation — items are already validated Datapoint instances.
             return GetDatapointsResponse.model_construct(datapoints=all_datapoints)
@@ -269,11 +282,19 @@ class DatapointsAPI(BaseAPI):
         """
         # Batch if the list is large enough to risk exceeding URL length limits.
         if datapoint_ids and len(datapoint_ids) > QUERY_BATCH_SIZE:
-            all_datapoints: List[Any] = []
-            for batch in _chunk_list(datapoint_ids, QUERY_BATCH_SIZE):
-                resp = await datapoints_svc_async.getDatapoints(
-                    self._api_config, datapoint_ids=batch, dataset_name=dataset_name
+            batches = _chunk_list(datapoint_ids, QUERY_BATCH_SIZE)
+            resps = await asyncio.gather(
+                *(
+                    datapoints_svc_async.getDatapoints(
+                        self._api_config,
+                        datapoint_ids=batch,
+                        dataset_name=dataset_name,
+                    )
+                    for batch in batches
                 )
+            )
+            all_datapoints: List[Any] = []
+            for resp in resps:
                 all_datapoints.extend(resp.datapoints)
             # Skip re-validation — items are already validated Datapoint instances.
             return GetDatapointsResponse.model_construct(datapoints=all_datapoints)
@@ -1238,19 +1259,34 @@ class ExperimentsAPI(BaseAPI):
         self, *, run_ids: List[str], **kwargs: Any
     ) -> GetExperimentRunsResponse:
         """Fetch runs in batches and merge the responses."""
+        # Pagination doesn't apply when batching by IDs — each batch must
+        # return all matching runs for its chunk.
+        kwargs.pop("page", None)
+        kwargs.pop("limit", None)
+
         all_evaluations: List[Any] = []
         all_metrics: List[str] = []
         total = 0
+        total_unfiltered = 0
 
-        for batch in _chunk_list(run_ids, QUERY_BATCH_SIZE):
-            resp = experiments_svc.getRuns(
-                self._api_config, run_ids=batch, **kwargs
-            )
+        batches = _chunk_list(run_ids, QUERY_BATCH_SIZE)
+        for i, batch in enumerate(batches):
+            try:
+                resp = experiments_svc.getRuns(
+                    self._api_config, run_ids=batch, **kwargs
+                )
+            except Exception:
+                logger.warning(
+                    "Batch %d/%d failed (%d run IDs)",
+                    i + 1,
+                    len(batches),
+                    len(batch),
+                )
+                raise
             all_evaluations.extend(resp.evaluations)
             all_metrics.extend(resp.metrics)
             total += resp.pagination.total
-
-        from honeyhive._generated.models.Pagination import Pagination
+            total_unfiltered += resp.pagination.total_unfiltered
 
         return GetExperimentRunsResponse.model_construct(
             evaluations=all_evaluations,
@@ -1259,7 +1295,7 @@ class ExperimentsAPI(BaseAPI):
                 page=1,
                 limit=total,
                 total=total,
-                total_unfiltered=total,
+                total_unfiltered=total_unfiltered,
                 total_pages=1,
                 has_next=False,
                 has_prev=False,
@@ -1360,20 +1396,30 @@ class ExperimentsAPI(BaseAPI):
     async def _batched_list_runs_async(
         self, *, run_ids: List[str], **kwargs: Any
     ) -> GetExperimentRunsResponse:
-        """Fetch runs in batches (async) and merge the responses."""
+        """Fetch runs in batches (async, parallel) and merge the responses."""
+        # Strip pagination params — each batch fetches its full slice.
+        kwargs.pop("page", None)
+        kwargs.pop("limit", None)
+
+        batches = _chunk_list(run_ids, QUERY_BATCH_SIZE)
+        resps = await asyncio.gather(
+            *(
+                experiments_svc_async.getRuns(
+                    self._api_config, run_ids=batch, **kwargs
+                )
+                for batch in batches
+            )
+        )
+
         all_evaluations: List[Any] = []
         all_metrics: List[str] = []
         total = 0
-
-        for batch in _chunk_list(run_ids, QUERY_BATCH_SIZE):
-            resp = await experiments_svc_async.getRuns(
-                self._api_config, run_ids=batch, **kwargs
-            )
+        total_unfiltered = 0
+        for resp in resps:
             all_evaluations.extend(resp.evaluations)
             all_metrics.extend(resp.metrics)
             total += resp.pagination.total
-
-        from honeyhive._generated.models.Pagination import Pagination
+            total_unfiltered += resp.pagination.total_unfiltered
 
         return GetExperimentRunsResponse.model_construct(
             evaluations=all_evaluations,
@@ -1382,7 +1428,7 @@ class ExperimentsAPI(BaseAPI):
                 page=1,
                 limit=total,
                 total=total,
-                total_unfiltered=total,
+                total_unfiltered=total_unfiltered,
                 total_pages=1,
                 has_next=False,
                 has_prev=False,

--- a/src/honeyhive/api/client.py
+++ b/src/honeyhive/api/client.py
@@ -105,6 +105,16 @@ from ._base import BaseAPI
 
 logger = logging.getLogger(__name__)
 
+# Maximum number of array items to send in a single query string request.
+# Real-world URL length limits (8-16 KB) cap practical array sizes at ~170-340
+# items for typical 26-char IDs. Batching at 100 keeps us safely within bounds.
+QUERY_BATCH_SIZE = 100
+
+
+def _chunk_list(items: List[str], size: int) -> List[List[str]]:
+    """Split a list into chunks of the given size."""
+    return [items[i : i + size] for i in range(0, len(items), size)]
+
 
 class ConfigurationsAPI(BaseAPI):
     """Configurations API."""
@@ -202,10 +212,24 @@ class DatapointsAPI(BaseAPI):
     ) -> GetDatapointsResponse:
         """List datapoints.
 
+        When datapoint_ids exceeds QUERY_BATCH_SIZE, requests are automatically
+        batched to stay within URL length limits and the results are merged.
+
         Args:
             datapoint_ids: Optional list of datapoint IDs to fetch.
             dataset_name: Optional dataset name to filter by.
         """
+        # Batch if the list is large enough to risk exceeding URL length limits.
+        if datapoint_ids and len(datapoint_ids) > QUERY_BATCH_SIZE:
+            all_datapoints: List[Any] = []
+            for batch in _chunk_list(datapoint_ids, QUERY_BATCH_SIZE):
+                resp = datapoints_svc.getDatapoints(
+                    self._api_config, datapoint_ids=batch, dataset_name=dataset_name
+                )
+                all_datapoints.extend(resp.datapoints)
+            # Skip re-validation — items are already validated Datapoint instances.
+            return GetDatapointsResponse.model_construct(datapoints=all_datapoints)
+
         return datapoints_svc.getDatapoints(
             self._api_config, datapoint_ids=datapoint_ids, dataset_name=dataset_name
         )
@@ -236,10 +260,24 @@ class DatapointsAPI(BaseAPI):
     ) -> GetDatapointsResponse:
         """List datapoints asynchronously.
 
+        When datapoint_ids exceeds QUERY_BATCH_SIZE, requests are automatically
+        batched to stay within URL length limits and the results are merged.
+
         Args:
             datapoint_ids: Optional list of datapoint IDs to fetch.
             dataset_name: Optional dataset name to filter by.
         """
+        # Batch if the list is large enough to risk exceeding URL length limits.
+        if datapoint_ids and len(datapoint_ids) > QUERY_BATCH_SIZE:
+            all_datapoints: List[Any] = []
+            for batch in _chunk_list(datapoint_ids, QUERY_BATCH_SIZE):
+                resp = await datapoints_svc_async.getDatapoints(
+                    self._api_config, datapoint_ids=batch, dataset_name=dataset_name
+                )
+                all_datapoints.extend(resp.datapoints)
+            # Skip re-validation — items are already validated Datapoint instances.
+            return GetDatapointsResponse.model_construct(datapoints=all_datapoints)
+
         return await datapoints_svc_async.getDatapoints(
             self._api_config, datapoint_ids=datapoint_ids, dataset_name=dataset_name
         )
@@ -1155,6 +1193,9 @@ class ExperimentsAPI(BaseAPI):
     ) -> GetExperimentRunsResponse:
         """List experiment runs.
 
+        When run_ids exceeds QUERY_BATCH_SIZE, requests are automatically
+        batched to stay within URL length limits and the results are merged.
+
         Args:
             dataset_id: Filter by dataset ID.
             page: Page number for pagination.
@@ -1166,6 +1207,20 @@ class ExperimentsAPI(BaseAPI):
             sort_by: Sort by field.
             sort_order: Sort order (asc/desc).
         """
+        # Batch if the list is large enough to risk exceeding URL length limits.
+        if run_ids and len(run_ids) > QUERY_BATCH_SIZE:
+            return self._batched_list_runs(
+                dataset_id=dataset_id,
+                page=page,
+                limit=limit,
+                run_ids=run_ids,
+                name=name,
+                status=status,
+                dateRange=dateRange,
+                sort_by=sort_by,
+                sort_order=sort_order,
+            )
+
         return experiments_svc.getRuns(
             self._api_config,
             dataset_id=dataset_id,
@@ -1177,6 +1232,38 @@ class ExperimentsAPI(BaseAPI):
             dateRange=dateRange,
             sort_by=sort_by,
             sort_order=sort_order,
+        )
+
+    def _batched_list_runs(
+        self, *, run_ids: List[str], **kwargs: Any
+    ) -> GetExperimentRunsResponse:
+        """Fetch runs in batches and merge the responses."""
+        all_evaluations: List[Any] = []
+        all_metrics: List[str] = []
+        total = 0
+
+        for batch in _chunk_list(run_ids, QUERY_BATCH_SIZE):
+            resp = experiments_svc.getRuns(
+                self._api_config, run_ids=batch, **kwargs
+            )
+            all_evaluations.extend(resp.evaluations)
+            all_metrics.extend(resp.metrics)
+            total += resp.pagination.total
+
+        from honeyhive._generated.models.Pagination import Pagination
+
+        return GetExperimentRunsResponse.model_construct(
+            evaluations=all_evaluations,
+            metrics=list(dict.fromkeys(all_metrics)),  # deduplicate, preserve order
+            pagination=Pagination(
+                page=1,
+                limit=total,
+                total=total,
+                total_unfiltered=total,
+                total_pages=1,
+                has_next=False,
+                has_prev=False,
+            ),
         )
 
     def get_run(self, run_id: str) -> GetExperimentRunResponse:
@@ -1229,6 +1316,9 @@ class ExperimentsAPI(BaseAPI):
     ) -> GetExperimentRunsResponse:
         """List experiment runs asynchronously.
 
+        When run_ids exceeds QUERY_BATCH_SIZE, requests are automatically
+        batched to stay within URL length limits and the results are merged.
+
         Args:
             dataset_id: Filter by dataset ID.
             page: Page number for pagination.
@@ -1240,6 +1330,20 @@ class ExperimentsAPI(BaseAPI):
             sort_by: Sort by field.
             sort_order: Sort order (asc/desc).
         """
+        # Batch if the list is large enough to risk exceeding URL length limits.
+        if run_ids and len(run_ids) > QUERY_BATCH_SIZE:
+            return await self._batched_list_runs_async(
+                dataset_id=dataset_id,
+                page=page,
+                limit=limit,
+                run_ids=run_ids,
+                name=name,
+                status=status,
+                dateRange=dateRange,
+                sort_by=sort_by,
+                sort_order=sort_order,
+            )
+
         return await experiments_svc_async.getRuns(
             self._api_config,
             dataset_id=dataset_id,
@@ -1251,6 +1355,38 @@ class ExperimentsAPI(BaseAPI):
             dateRange=dateRange,
             sort_by=sort_by,
             sort_order=sort_order,
+        )
+
+    async def _batched_list_runs_async(
+        self, *, run_ids: List[str], **kwargs: Any
+    ) -> GetExperimentRunsResponse:
+        """Fetch runs in batches (async) and merge the responses."""
+        all_evaluations: List[Any] = []
+        all_metrics: List[str] = []
+        total = 0
+
+        for batch in _chunk_list(run_ids, QUERY_BATCH_SIZE):
+            resp = await experiments_svc_async.getRuns(
+                self._api_config, run_ids=batch, **kwargs
+            )
+            all_evaluations.extend(resp.evaluations)
+            all_metrics.extend(resp.metrics)
+            total += resp.pagination.total
+
+        from honeyhive._generated.models.Pagination import Pagination
+
+        return GetExperimentRunsResponse.model_construct(
+            evaluations=all_evaluations,
+            metrics=list(dict.fromkeys(all_metrics)),  # deduplicate, preserve order
+            pagination=Pagination(
+                page=1,
+                limit=total,
+                total=total,
+                total_unfiltered=total,
+                total_pages=1,
+                has_next=False,
+                has_prev=False,
+            ),
         )
 
     async def get_run_async(self, run_id: str) -> GetExperimentRunResponse:

--- a/src/honeyhive/api/client.py
+++ b/src/honeyhive/api/client.py
@@ -54,8 +54,8 @@ from honeyhive._generated.models import (
     GetExperimentRunsResponse,
     GetExperimentRunsSchemaResponse,
     GetMetricsResponse,
-    Pagination,
     GetSessionResponse,
+    Pagination,
     PostEventRequest,
     PostEventResponse,
     PostExperimentRunRequest,
@@ -114,6 +114,7 @@ QUERY_BATCH_SIZE = 100
 
 
 T = TypeVar("T")
+
 
 def _chunk_list(items: List[T], size: int) -> List[List[T]]:
     """Split a list into chunks of the given size."""
@@ -1404,9 +1405,7 @@ class ExperimentsAPI(BaseAPI):
         batches = _chunk_list(run_ids, QUERY_BATCH_SIZE)
         resps = await asyncio.gather(
             *(
-                experiments_svc_async.getRuns(
-                    self._api_config, run_ids=batch, **kwargs
-                )
+                experiments_svc_async.getRuns(self._api_config, run_ids=batch, **kwargs)
                 for batch in batches
             )
         )

--- a/tests/unit/test_api_query_batching.py
+++ b/tests/unit/test_api_query_batching.py
@@ -10,14 +10,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from honeyhive._generated.models.Pagination import Pagination
 from honeyhive.api.client import (
     QUERY_BATCH_SIZE,
     DatapointsAPI,
     ExperimentsAPI,
     _chunk_list,
 )
-from honeyhive._generated.models.Pagination import Pagination
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -142,9 +141,7 @@ class TestDatapointsListBatching:
         assert result is expected
 
     @patch("honeyhive.api.client.datapoints_svc")
-    def test_dataset_name_forwarded_to_each_batch(
-        self, mock_svc: MagicMock
-    ) -> None:
+    def test_dataset_name_forwarded_to_each_batch(self, mock_svc: MagicMock) -> None:
         """dataset_name should be forwarded to every batch request."""
         total = QUERY_BATCH_SIZE + 10
         all_ids = [f"id_{i}" for i in range(total)]

--- a/tests/unit/test_api_query_batching.py
+++ b/tests/unit/test_api_query_batching.py
@@ -1,0 +1,265 @@
+"""Unit tests for query string array batching in the API client.
+
+When list params (datapoint_ids, run_ids) exceed QUERY_BATCH_SIZE the client
+should transparently split requests into batches and merge the results.
+"""
+
+import asyncio
+from typing import Any, List
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from honeyhive.api.client import (
+    QUERY_BATCH_SIZE,
+    DatapointsAPI,
+    ExperimentsAPI,
+    _chunk_list,
+)
+from honeyhive._generated.models.Pagination import Pagination
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_datapoints_response(ids: List[str]) -> MagicMock:
+    """Build a mock GetDatapointsResponse with a .datapoints list."""
+    resp = MagicMock()
+    resp.datapoints = [{"id": dp_id} for dp_id in ids]
+    return resp
+
+
+def _make_runs_response(
+    run_ids: List[str], metrics: List[str] | None = None
+) -> MagicMock:
+    """Build a mock GetExperimentRunsResponse."""
+    resp = MagicMock()
+    resp.evaluations = [{"run_id": rid} for rid in run_ids]
+    resp.metrics = metrics or ["accuracy"]
+    resp.pagination = Pagination(
+        page=1,
+        limit=len(run_ids),
+        total=len(run_ids),
+        total_unfiltered=len(run_ids),
+        total_pages=1,
+        has_next=False,
+        has_prev=False,
+    )
+    return resp
+
+
+def _make_api(cls: type) -> Any:
+    """Instantiate a DatapointsAPI or ExperimentsAPI with a mock config."""
+    mock_config = MagicMock()
+    mock_config.base_path = "https://api.test"
+    mock_config.get_access_token.return_value = "tok"
+    mock_config.verify = True
+    return cls(mock_config)
+
+
+# ---------------------------------------------------------------------------
+# _chunk_list
+# ---------------------------------------------------------------------------
+
+
+class TestChunkList:
+    def test_empty(self) -> None:
+        assert _chunk_list([], 100) == []
+
+    def test_under_size(self) -> None:
+        assert _chunk_list(["a", "b"], 100) == [["a", "b"]]
+
+    def test_exact_multiple(self) -> None:
+        items = list(range(6))
+        assert _chunk_list(items, 3) == [[0, 1, 2], [3, 4, 5]]
+
+    def test_remainder(self) -> None:
+        items = list(range(7))
+        assert _chunk_list(items, 3) == [[0, 1, 2], [3, 4, 5], [6]]
+
+
+# ---------------------------------------------------------------------------
+# DatapointsAPI.list
+# ---------------------------------------------------------------------------
+
+
+class TestDatapointsListBatching:
+    @patch("honeyhive.api.client.datapoints_svc")
+    def test_small_list_makes_single_call(self, mock_svc: MagicMock) -> None:
+        """Lists <= QUERY_BATCH_SIZE should pass through directly."""
+        ids = [f"id_{i}" for i in range(50)]
+        expected = _make_datapoints_response(ids)
+        mock_svc.getDatapoints.return_value = expected
+
+        api = _make_api(DatapointsAPI)
+        result = api.list(datapoint_ids=ids)
+
+        mock_svc.getDatapoints.assert_called_once()
+        assert result is expected
+
+    @patch("honeyhive.api.client.datapoints_svc")
+    def test_none_passes_through(self, mock_svc: MagicMock) -> None:
+        """None datapoint_ids should pass through without batching."""
+        expected = _make_datapoints_response([])
+        mock_svc.getDatapoints.return_value = expected
+
+        api = _make_api(DatapointsAPI)
+        result = api.list(datapoint_ids=None)
+
+        mock_svc.getDatapoints.assert_called_once()
+        assert result is expected
+
+    @patch("honeyhive.api.client.datapoints_svc")
+    def test_large_list_batches_and_merges(self, mock_svc: MagicMock) -> None:
+        """Lists > QUERY_BATCH_SIZE should be split into batches."""
+        total = QUERY_BATCH_SIZE + 50
+        all_ids = [f"id_{i}" for i in range(total)]
+
+        mock_svc.getDatapoints.side_effect = [
+            _make_datapoints_response(all_ids[:QUERY_BATCH_SIZE]),
+            _make_datapoints_response(all_ids[QUERY_BATCH_SIZE:]),
+        ]
+
+        api = _make_api(DatapointsAPI)
+        result = api.list(datapoint_ids=all_ids)
+
+        assert mock_svc.getDatapoints.call_count == 2
+        assert len(result.datapoints) == total
+
+    @patch("honeyhive.api.client.datapoints_svc")
+    def test_exact_boundary_no_batch(self, mock_svc: MagicMock) -> None:
+        """Exactly QUERY_BATCH_SIZE items should NOT trigger batching."""
+        ids = [f"id_{i}" for i in range(QUERY_BATCH_SIZE)]
+        expected = _make_datapoints_response(ids)
+        mock_svc.getDatapoints.return_value = expected
+
+        api = _make_api(DatapointsAPI)
+        result = api.list(datapoint_ids=ids)
+
+        mock_svc.getDatapoints.assert_called_once()
+        assert result is expected
+
+    @patch("honeyhive.api.client.datapoints_svc")
+    def test_dataset_name_forwarded_to_each_batch(
+        self, mock_svc: MagicMock
+    ) -> None:
+        """dataset_name should be forwarded to every batch request."""
+        total = QUERY_BATCH_SIZE + 10
+        all_ids = [f"id_{i}" for i in range(total)]
+
+        mock_svc.getDatapoints.side_effect = [
+            _make_datapoints_response(all_ids[:QUERY_BATCH_SIZE]),
+            _make_datapoints_response(all_ids[QUERY_BATCH_SIZE:]),
+        ]
+
+        api = _make_api(DatapointsAPI)
+        api.list(datapoint_ids=all_ids, dataset_name="my-dataset")
+
+        for c in mock_svc.getDatapoints.call_args_list:
+            assert c.kwargs["dataset_name"] == "my-dataset"
+
+
+# ---------------------------------------------------------------------------
+# DatapointsAPI.list_async
+# ---------------------------------------------------------------------------
+
+
+class TestDatapointsListAsyncBatching:
+    @patch("honeyhive.api.client.datapoints_svc_async")
+    def test_large_list_batches_async(self, mock_svc: MagicMock) -> None:
+        """Async: lists > QUERY_BATCH_SIZE should batch and merge."""
+        total = QUERY_BATCH_SIZE + 30
+        all_ids = [f"id_{i}" for i in range(total)]
+
+        mock_svc.getDatapoints = AsyncMock(
+            side_effect=[
+                _make_datapoints_response(all_ids[:QUERY_BATCH_SIZE]),
+                _make_datapoints_response(all_ids[QUERY_BATCH_SIZE:]),
+            ]
+        )
+
+        api = _make_api(DatapointsAPI)
+        result = asyncio.get_event_loop().run_until_complete(
+            api.list_async(datapoint_ids=all_ids)
+        )
+
+        assert mock_svc.getDatapoints.call_count == 2
+        assert len(result.datapoints) == total
+
+
+# ---------------------------------------------------------------------------
+# ExperimentsAPI.list_runs
+# ---------------------------------------------------------------------------
+
+
+class TestExperimentsListRunsBatching:
+    @patch("honeyhive.api.client.experiments_svc")
+    def test_small_list_makes_single_call(self, mock_svc: MagicMock) -> None:
+        ids = [f"run_{i}" for i in range(50)]
+        expected = _make_runs_response(ids)
+        mock_svc.getRuns.return_value = expected
+
+        api = _make_api(ExperimentsAPI)
+        result = api.list_runs(run_ids=ids)
+
+        mock_svc.getRuns.assert_called_once()
+        assert result is expected
+
+    @patch("honeyhive.api.client.experiments_svc")
+    def test_large_list_batches_and_merges(self, mock_svc: MagicMock) -> None:
+        total = QUERY_BATCH_SIZE + 20
+        all_ids = [f"run_{i}" for i in range(total)]
+
+        mock_svc.getRuns.side_effect = [
+            _make_runs_response(all_ids[:QUERY_BATCH_SIZE], metrics=["accuracy", "f1"]),
+            _make_runs_response(all_ids[QUERY_BATCH_SIZE:], metrics=["f1", "latency"]),
+        ]
+
+        api = _make_api(ExperimentsAPI)
+        result = api.list_runs(run_ids=all_ids)
+
+        assert mock_svc.getRuns.call_count == 2
+        assert len(result.evaluations) == total
+        # Metrics should be deduplicated and order-preserved.
+        assert result.metrics == ["accuracy", "f1", "latency"]
+        assert result.pagination.total == total
+
+    @patch("honeyhive.api.client.experiments_svc")
+    def test_none_run_ids_passes_through(self, mock_svc: MagicMock) -> None:
+        expected = _make_runs_response([])
+        mock_svc.getRuns.return_value = expected
+
+        api = _make_api(ExperimentsAPI)
+        result = api.list_runs(run_ids=None)
+
+        mock_svc.getRuns.assert_called_once()
+        assert result is expected
+
+
+# ---------------------------------------------------------------------------
+# ExperimentsAPI.list_runs_async
+# ---------------------------------------------------------------------------
+
+
+class TestExperimentsListRunsAsyncBatching:
+    @patch("honeyhive.api.client.experiments_svc_async")
+    def test_large_list_batches_async(self, mock_svc: MagicMock) -> None:
+        total = QUERY_BATCH_SIZE + 10
+        all_ids = [f"run_{i}" for i in range(total)]
+
+        mock_svc.getRuns = AsyncMock(
+            side_effect=[
+                _make_runs_response(all_ids[:QUERY_BATCH_SIZE]),
+                _make_runs_response(all_ids[QUERY_BATCH_SIZE:]),
+            ]
+        )
+
+        api = _make_api(ExperimentsAPI)
+        result = asyncio.get_event_loop().run_until_complete(
+            api.list_runs_async(run_ids=all_ids)
+        )
+
+        assert mock_svc.getRuns.call_count == 2
+        assert len(result.evaluations) == total

--- a/tests/unit/test_api_query_batching.py
+++ b/tests/unit/test_api_query_batching.py
@@ -225,6 +225,27 @@ class TestExperimentsListRunsBatching:
         # Metrics should be deduplicated and order-preserved.
         assert result.metrics == ["accuracy", "f1", "latency"]
         assert result.pagination.total == total
+        # total_unfiltered should be the sum of each batch's total_unfiltered.
+        assert result.pagination.total_unfiltered == total
+
+    @patch("honeyhive.api.client.experiments_svc")
+    def test_page_and_limit_stripped_from_batches(self, mock_svc: MagicMock) -> None:
+        """page/limit params should not be forwarded to batch requests."""
+        total = QUERY_BATCH_SIZE + 10
+        all_ids = [f"run_{i}" for i in range(total)]
+
+        mock_svc.getRuns.side_effect = [
+            _make_runs_response(all_ids[:QUERY_BATCH_SIZE]),
+            _make_runs_response(all_ids[QUERY_BATCH_SIZE:]),
+        ]
+
+        api = _make_api(ExperimentsAPI)
+        api.list_runs(run_ids=all_ids, page=3, limit=25)
+
+        # Neither batch call should include page or limit.
+        for call in mock_svc.getRuns.call_args_list:
+            assert "page" not in call.kwargs
+            assert "limit" not in call.kwargs
 
     @patch("honeyhive.api.client.experiments_svc")
     def test_none_run_ids_passes_through(self, mock_svc: MagicMock) -> None:


### PR DESCRIPTION
## Summary

- When list parameters (`datapoint_ids`, `run_ids`) exceed 100 items, the client now transparently splits requests into batches and merges results
- Prevents hitting URL length limits (8-16 KB) and the backend's `qs` `arrayLimit` of 1000
- Batching is invisible to callers — the API surface is unchanged

## Changes

- `src/honeyhive/api/client.py` — added `QUERY_BATCH_SIZE`, `_chunk_list()` helper, and batching logic in `DatapointsAPI.list()`/`list_async()` and `ExperimentsAPI.list_runs()`/`list_runs_async()`
- `tests/unit/test_api_query_batching.py` — 14 unit tests covering chunk logic, passthrough for small lists, batching + merge for large lists, metric deduplication, and async variants

## Test plan

- [x] `pytest tests/unit/test_api_query_batching.py` — 14/14 pass
- [x] Existing unit tests unaffected (`test_api_events_fixes.py` — 20/20 pass)

🔗 Related backend PR: https://github.com/honeyhiveai/hive-kube/pull/2430

✨ Created with Claude Code