### PR TITLE
docs: add Cursor Cloud dev setup agent skill

### DIFF
--- a/.agents/skills/cursor-cloud-dev-setup/SKILL.md
+++ b/.agents/skills/cursor-cloud-dev-setup/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: cursor-cloud-dev-setup
+description: >
+  Use this skill when setting up, building, testing, or running the HoneyHive Python SDK
+  in a Cursor Cloud (or similar containerized) development environment. Covers environment
+  bootstrap, dependency installation, test/lint/build commands, and known gotchas.
+---
+
+# Cursor Cloud Dev Setup — HoneyHive Python SDK
+
+This is a **client-side Python library** for LLM observability, evaluation, and tracing.
+There are no databases or backend services to run locally.
+
+## Quick reference
+
+| Task | Command |
+|------|---------|
+| Unit tests | `tox -e unit` |
+| Lint (pylint + mypy) | `tox -e lint` |
+| Format check (black + isort) | `tox -e format` |
+| Build package | `python -m build` |
+| All quality checks | `make check` |
+| See all commands | `make help` |
+
+Per project convention (see `.claude/CLAUDE.md`), **always use `tox` for testing** — do not invoke `pytest` directly.
+
+## Environment setup
+
+- Python 3.12 is the primary development version (`requires-python = ">=3.11"`).
+- The virtual environment lives at `.venv/` and is created with `uv venv .venv --python 3.12`.
+- Dependencies: `uv pip install -e ".[dev,docs]"` (user preference: use `uv` instead of `pip`).
+- Activate with `source .venv/bin/activate` (also `source $HOME/.local/bin/env` for `uv` on PATH).
+
+## Gotchas
+
+- **`tox -e lint` fails at 9.51/10** (threshold 9.99) due to pre-existing cyclic-import warnings and duplicate-code issues. This is a known state, not a regression.
+- **8 unit tests in `test_tracer_infra_environment.py` fail** in container/VM environments because cloud environment detection tests (GCP, Azure, AWS EC2) detect unexpected environment variables. These are pre-existing and environment-specific.
+- **OTLP warnings** (`No valid export method: OTLP exporter is False`) appear when running with `HH_OTLP_ENABLED=false`; this is expected in test mode.
+- `tox` creates its own virtualenvs under `.tox/` and installs dependencies there, so `.venv` is primarily for IDE support and direct `make` commands (e.g., `make format`, `make typecheck`).
+- Integration tests (`tox -e integration`) require a real `HH_API_KEY` and optional LLM provider API keys; unit tests (`tox -e unit`) run fully offline with mocked credentials.

--- a/.agents/skills/cursor-cloud-dev-setup/SKILL.md
+++ b/.agents/skills/cursor-cloud-dev-setup/SKILL.md
@@ -31,10 +31,36 @@ Per project convention (see `.claude/CLAUDE.md`), **always use `tox` for testing
 - Dependencies: `uv pip install -e ".[dev,docs]"` (user preference: use `uv` instead of `pip`).
 - Activate with `source .venv/bin/activate` (also `source $HOME/.local/bin/env` for `uv` on PATH).
 
-## Gotchas
+## Known failures and workarounds
 
-- **`tox -e lint` fails (pylint scores 9.51/10, threshold is 9.99).** Tox stops at the first failing command, so **mypy never runs**. To run mypy independently: `python -m mypy src/honeyhive --config-file=pyproject.toml`. The pylint violations are a mix of cyclic-import (R0401), duplicate-code (R0801), and other issues; disabling R0401+R0801 only raises the score to ~9.59.
-- **8 unit tests in `test_tracer_infra_environment.py` fail inside Docker** due to a test isolation bug: `/.dockerenv` exists in the container, so `detect_primary_environment_type()` returns `"docker"` before ever checking cloud-provider env vars. The tests mock env vars (e.g., `GOOGLE_CLOUD_PROJECT`) but don't mock `os.path.exists("/.dockerenv")`. These tests pass on bare-metal CI runners.
-- **OTLP warnings** (`No valid export method: OTLP exporter is False`) appear when running with `HH_OTLP_ENABLED=false`; this is expected in test mode.
-- `tox` creates its own virtualenvs under `.tox/` and installs dependencies there, so `.venv` is primarily for IDE support and direct `make` commands (e.g., `make format`, `make typecheck`).
-- Integration tests (`tox -e integration`) require a real `HH_API_KEY` and optional LLM provider API keys; unit tests (`tox -e unit`) run fully offline with mocked credentials.
+Neither `tox -e lint` nor `tox -e unit` exits cleanly in this environment. **You cannot rely on exit codes alone**; compare output against the baselines below to detect regressions.
+
+### `tox -e lint` — always fails (pylint 9.51/10, threshold 9.99)
+
+Pylint scores ~9.51 due to cyclic-import (R0401), duplicate-code (R0801), and other violations. Because tox stops at the first failing command, **mypy never runs** (it has 274 pre-existing errors across 28 files).
+
+**Workaround**: run mypy independently to check type safety:
+
+```
+python -m mypy src/honeyhive --config-file=pyproject.toml
+```
+
+When making changes, compare pylint score and mypy error count against these baselines to catch regressions.
+
+### `tox -e unit` — always has 8 failures
+
+**Baseline**: 2256 passed, 8 failed, 249 skipped (numbers will shift as tests are added).
+
+All 8 failures are in `tests/unit/test_tracer_infra_environment.py` — a test isolation bug where `/.dockerenv` exists in the container, so `detect_primary_environment_type()` returns `"docker"` before checking cloud-provider env vars. The tests mock env vars but not `os.path.exists("/.dockerenv")`. These pass on bare-metal CI runners.
+
+**Workaround**: after running `tox -e unit`, verify that the only failures are the 8 known environment-detection tests. Any new failures indicate a real regression.
+
+### Running pytest directly (not via tox)
+
+Avoid this (project convention is `tox`). If you do, expect 5 additional config-test failures because `HH_API_URL` and `HH_PROJECT` secrets in the environment override the expected defaults. Tox isolates these via its `setenv`/`passenv` configuration.
+
+### Minor
+
+- **OTLP warnings** (`No valid export method: OTLP exporter is False`) appear with `HH_OTLP_ENABLED=false`; expected in test mode.
+- `tox` creates its own virtualenvs under `.tox/`, so `.venv` is for IDE support and direct `make` commands.
+- Integration tests (`tox -e integration`) require a real `HH_API_KEY` and optional LLM provider API keys; unit tests run fully offline with mocked credentials.

--- a/.agents/skills/cursor-cloud-dev-setup/SKILL.md
+++ b/.agents/skills/cursor-cloud-dev-setup/SKILL.md
@@ -33,8 +33,8 @@ Per project convention (see `.claude/CLAUDE.md`), **always use `tox` for testing
 
 ## Gotchas
 
-- **`tox -e lint` fails at 9.51/10** (threshold 9.99) due to pre-existing cyclic-import warnings and duplicate-code issues. This is a known state, not a regression.
-- **8 unit tests in `test_tracer_infra_environment.py` fail** in container/VM environments because cloud environment detection tests (GCP, Azure, AWS EC2) detect unexpected environment variables. These are pre-existing and environment-specific.
+- **`tox -e lint` fails (pylint scores 9.51/10, threshold is 9.99).** Tox stops at the first failing command, so **mypy never runs**. To run mypy independently: `python -m mypy src/honeyhive --config-file=pyproject.toml`. The pylint violations are a mix of cyclic-import (R0401), duplicate-code (R0801), and other issues; disabling R0401+R0801 only raises the score to ~9.59.
+- **8 unit tests in `test_tracer_infra_environment.py` fail inside Docker** due to a test isolation bug: `/.dockerenv` exists in the container, so `detect_primary_environment_type()` returns `"docker"` before ever checking cloud-provider env vars. The tests mock env vars (e.g., `GOOGLE_CLOUD_PROJECT`) but don't mock `os.path.exists("/.dockerenv")`. These tests pass on bare-metal CI runners.
 - **OTLP warnings** (`No valid export method: OTLP exporter is False`) appear when running with `HH_OTLP_ENABLED=false`; this is expected in test mode.
 - `tox` creates its own virtualenvs under `.tox/` and installs dependencies there, so `.venv` is primarily for IDE support and direct `make` commands (e.g., `make format`, `make typecheck`).
 - Integration tests (`tox -e integration`) require a real `HH_API_KEY` and optional LLM provider API keys; unit tests (`tox -e unit`) run fully offline with mocked credentials.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is the **HoneyHive Python SDK** — a client-side Python library for LLM observability, evaluation, and tracing. It is **not** a server application; there are no databases or backend services to run locally.
+
+### Quick reference
+
+| Task | Command |
+|------|---------|
+| Unit tests | `tox -e unit` |
+| Lint (pylint + mypy) | `tox -e lint` |
+| Format check (black + isort) | `tox -e format` |
+| Build package | `python -m build` |
+| All quality checks | `make check` |
+| See all commands | `make help` |
+
+Per project convention (see `.claude/CLAUDE.md`), **always use `tox` for testing** — do not invoke `pytest` directly.
+
+### Environment setup
+
+- Python 3.12 is the primary development version (`requires-python = ">=3.11"`).
+- The virtual environment lives at `.venv/` and is created with `uv venv .venv --python 3.12`.
+- Dependencies: `uv pip install -e ".[dev,docs]"` (user preference: use `uv` instead of `pip`).
+- Activate with `source .venv/bin/activate` (also `source $HOME/.local/bin/env` for `uv` on PATH).
+
+### Gotchas discovered during setup
+
+- **`tox -e lint` fails at 9.51/10** (threshold 9.99) due to pre-existing cyclic-import warnings and duplicate-code issues in the codebase. This is a known state, not a regression.
+- **8 unit tests in `test_tracer_infra_environment.py` fail** in container/VM environments because cloud environment detection tests (GCP, Azure, AWS EC2) detect unexpected environment variables. These are pre-existing and environment-specific.
+- **OTLP warnings** (`No valid export method: OTLP exporter is False`) appear when running with `HH_OTLP_ENABLED=false`; this is expected in test mode.
+- `tox` creates its own virtualenvs under `.tox/` and installs dependencies there, so the `.venv` is primarily for IDE support and direct `make` commands (e.g., `make format`, `make typecheck`).
+- Integration tests (`tox -e integration`) require real `HH_API_KEY` and optional LLM provider API keys; unit tests (`tox -e unit`) run fully offline with mocked credentials.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,32 +2,4 @@
 
 ## Cursor Cloud specific instructions
 
-This is the **HoneyHive Python SDK** — a client-side Python library for LLM observability, evaluation, and tracing. It is **not** a server application; there are no databases or backend services to run locally.
-
-### Quick reference
-
-| Task | Command |
-|------|---------|
-| Unit tests | `tox -e unit` |
-| Lint (pylint + mypy) | `tox -e lint` |
-| Format check (black + isort) | `tox -e format` |
-| Build package | `python -m build` |
-| All quality checks | `make check` |
-| See all commands | `make help` |
-
-Per project convention (see `.claude/CLAUDE.md`), **always use `tox` for testing** — do not invoke `pytest` directly.
-
-### Environment setup
-
-- Python 3.12 is the primary development version (`requires-python = ">=3.11"`).
-- The virtual environment lives at `.venv/` and is created with `uv venv .venv --python 3.12`.
-- Dependencies: `uv pip install -e ".[dev,docs]"` (user preference: use `uv` instead of `pip`).
-- Activate with `source .venv/bin/activate` (also `source $HOME/.local/bin/env` for `uv` on PATH).
-
-### Gotchas discovered during setup
-
-- **`tox -e lint` fails at 9.51/10** (threshold 9.99) due to pre-existing cyclic-import warnings and duplicate-code issues in the codebase. This is a known state, not a regression.
-- **8 unit tests in `test_tracer_infra_environment.py` fail** in container/VM environments because cloud environment detection tests (GCP, Azure, AWS EC2) detect unexpected environment variables. These are pre-existing and environment-specific.
-- **OTLP warnings** (`No valid export method: OTLP exporter is False`) appear when running with `HH_OTLP_ENABLED=false`; this is expected in test mode.
-- `tox` creates its own virtualenvs under `.tox/` and installs dependencies there, so the `.venv` is primarily for IDE support and direct `make` commands (e.g., `make format`, `make typecheck`).
-- Integration tests (`tox -e integration`) require real `HH_API_KEY` and optional LLM provider API keys; unit tests (`tox -e unit`) run fully offline with mocked credentials.
+See the agent skill at `.agents/skills/cursor-cloud-dev-setup/SKILL.md` for full development environment setup, commands, and known gotchas.


### PR DESCRIPTION
Create an `agentskills.io` skill for Cursor Cloud dev setup and update `AGENTS.md` to reference it.

---
<p><a href="https://cursor.com/agents/bc-73aee4d2-9dab-4e8c-b06e-8ae3b1e6ec27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73aee4d2-9dab-4e8c-b06e-8ae3b1e6ec27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/honeyhiveai/python-sdk/pull/295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
