### PR TITLE
feat(examples): rewrite Semantic Kernel integration with customer support domain

### DIFF
--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -33,7 +33,7 @@ Comprehensive examples for popular AI agent frameworks:
 - **[`semantic_kernel_integration.py`](semantic_kernel_integration.py)** - Microsoft Semantic Kernel with OpenAI instrumentor (✅ agents, plugins, function calling, streaming)
 - **[`strands_integration.py`](strands_integration.py)** - AWS Strands with TracerProvider pattern (✅ Bedrock models, streaming, tools)
 - **[`bedrock_integration.py`](bedrock_integration.py)** - AWS Bedrock direct with Bedrock instrumentor (✅ Nova, Titan, Claude, Converse API, streaming)
-- **[`crewai_integration.py`](crewai_integration.py)** - CrewAI crews with OpenInference instrumentors (✅ sequential crew, hierarchical crew with tools)
+- **[`crewai_example.py`](crewai_example.py)** - CrewAI crews with OpenInference instrumentors (✅ sequential crew with tools, hierarchical crew with delegation)
 - **[`langchain_integration.py`](langchain_integration.py)** - LangChain agents with LangChain instrumentor (✅ single-agent+tools, multi-agent routing, session enrichment)
 - **[`langgraph_integration.py`](langgraph_integration.py)** - LangGraph workflows with LangChain instrumentor (✅ state graphs, conditional routing, agent graphs)
 - **[`strands_agents_integration.py`](strands_agents_integration.py)** - Strands Agents SDK with HoneyHive tracing (✅ agent with tools, multi-agent orchestration)
@@ -166,13 +166,14 @@ pip install honeyhive crewai openinference-instrumentation-crewai openinference-
 export OPENAI_API_KEY=sk-...
 export HH_API_KEY=your-honeyhive-key
 export HH_PROJECT=your-project
-python integrations/crewai_integration.py
+python integrations/crewai_example.py
 ```
 
 **Features demonstrated:**
-- ✅ Sequential crew (researcher + writer)
-- ✅ Hierarchical crew with manager and tool-equipped specialists
-- ✅ CrewAI + LiteLLM instrumentors for full trace capture
+- ✅ Sequential crew with tool calls (order investigator + response drafter)
+- ✅ Hierarchical crew with delegation (manager + order/policy specialists)
+- ✅ Session continuity across multiple kickoff turns
+- ✅ CrewAI + LiteLLM instrumentors for trace capture
 
 #### LangGraph
 ```bash

--- a/examples/integrations/semantic_kernel_integration.py
+++ b/examples/integrations/semantic_kernel_integration.py
@@ -1,620 +1,233 @@
+#!/usr/bin/env python3
 """
-Microsoft Semantic Kernel Integration Example
+Microsoft Semantic Kernel + HoneyHive integration example.
 
-This example demonstrates HoneyHive integration with Microsoft's Semantic Kernel
-using the OpenInference instrumentor for OpenAI (since SK uses OpenAI internally).
+Demonstrates three Semantic Kernel patterns with HoneyHive tracing:
 
-Setup:
-This example uses the .env file in the repo root. Make sure it contains:
-- HH_API_KEY (already configured)
-- OPENAI_API_KEY (your OpenAI API key)
+1) Single agent with tool calls and multi-turn session continuity
+2) Multi-agent handoff orchestration (triage -> order/policy specialists)
+3) Streaming agent response
 
-Installation:
-pip install semantic-kernel openinference-instrumentation-openai
+Install:
+    uv pip install honeyhive semantic-kernel openinference-instrumentation-openai
 
-What Gets Traced:
-- Kernel function invocations
-- Plugin executions
-- AI service calls (OpenAI, Azure, etc.)
-- Planning and orchestration
-- Token usage and costs
-- Function arguments and results
-- Complete execution flow
+Run:
+    uv run python examples/integrations/semantic_kernel_integration.py
+
+Environment:
+    HH_API_KEY
+    HH_PROJECT
+    OPENAI_API_KEY
+    HH_SOURCE (optional, defaults to "python_sdk_example")
 """
 
 import asyncio
 import os
-from pathlib import Path
 from typing import Annotated
 
-from capture_spans import setup_span_capture
-from dotenv import load_dotenv
 from openinference.instrumentation.openai import OpenAIInstrumentor
-from pydantic import BaseModel
-
-# Semantic Kernel imports
 from semantic_kernel.agents import (
     ChatCompletionAgent,
-    GroupChatOrchestration,
-    RoundRobinGroupChatManager,
+    ChatHistoryAgentThread,
+    HandoffOrchestration,
+    OrchestrationHandoffs,
 )
 from semantic_kernel.agents.runtime import InProcessRuntime
-from semantic_kernel.connectors.ai.open_ai import (
-    OpenAIChatCompletion,
-    OpenAIChatPromptExecutionSettings,
-)
-from semantic_kernel.contents import ChatHistory
-from semantic_kernel.functions import KernelArguments, kernel_function
+from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
+from semantic_kernel.functions import kernel_function
 
-from honeyhive import HoneyHiveTracer, trace
+from honeyhive import HoneyHiveTracer
 
-# Load environment variables from repo root .env
-root_dir = Path(__file__).parent.parent.parent
-load_dotenv(root_dir / ".env")
+MODEL = "gpt-4o-mini"
 
-# Initialize HoneyHive tracer
-tracer = HoneyHiveTracer.init(
-    api_key=os.getenv("HH_API_KEY"),
-    project=os.getenv("HH_PROJECT", "semantic-kernel-demo"),
-    session_name=Path(__file__).stem,  # Use filename as session name
-    test_mode=False,
+os.environ["SEMANTICKERNEL_EXPERIMENTAL_GENAI_ENABLE_OTEL_DIAGNOSTICS"] = "true"
+os.environ["SEMANTICKERNEL_EXPERIMENTAL_GENAI_ENABLE_OTEL_DIAGNOSTICS_SENSITIVE"] = (
+    "true"
 )
 
-# Setup span capture
-span_processor = setup_span_capture("semantic_kernel", tracer)
 
-# Initialize OpenAI instrumentor to capture OpenAI API calls
-# (Semantic Kernel uses OpenAI under the hood)
-openai_instrumentor = OpenAIInstrumentor()
-openai_instrumentor.instrument(tracer_provider=tracer.provider)
-print("✓ OpenAI instrumentor initialized for Semantic Kernel")
+# -- Mock tools (customer support domain) --
 
 
-# ============================================================================
-# Models for structured data
-# ============================================================================
+class OrderPlugin:
+    """Plugin for order status lookups."""
+
+    @kernel_function(description="Look up an order's shipping status by order ID")
+    def lookup_order_status(
+        self, order_id: Annotated[str, "The order ID, e.g. ORD-1001"]
+    ) -> Annotated[str, "Order status information"]:
+        statuses = {
+            "ORD-1001": {"state": "shipped", "eta_days": 2},
+            "ORD-1002": {"state": "processing", "eta_days": 5},
+            "ORD-1003": {"state": "delayed", "eta_days": 8},
+        }
+        status = statuses.get(order_id.upper())
+        if status:
+            return f"Order {order_id.upper()}: {status['state']}, ETA {status['eta_days']} days"
+        return f"Order {order_id.upper()}: not found"
 
 
-class WeatherInfo(BaseModel):
-    """Weather information model."""
-
-    location: str
-    temperature: float
-    conditions: str
-    humidity: int
-
-
-class TaskAnalysis(BaseModel):
-    """Task analysis result."""
-
-    complexity: str
-    estimated_time: str
-    required_skills: list[str]
-
-
-# ============================================================================
-# Plugin Definitions (Functions)
-# ============================================================================
-
-
-class MathPlugin:
-    """Plugin for mathematical operations."""
-
-    @kernel_function(description="Add two numbers together")
-    def add(
-        self,
-        a: Annotated[float, "The first number"],
-        b: Annotated[float, "The second number"],
-    ) -> Annotated[float, "The sum of the two numbers"]:
-        """Add two numbers and return the result."""
-        return a + b
-
-    @kernel_function(description="Multiply two numbers together")
-    def multiply(
-        self,
-        a: Annotated[float, "The first number"],
-        b: Annotated[float, "The second number"],
-    ) -> Annotated[float, "The product of the two numbers"]:
-        """Multiply two numbers and return the result."""
-        return a * b
+class PolicyPlugin:
+    """Plugin for support policy lookups."""
 
     @kernel_function(
-        description="Calculate what percentage of total a value represents"
+        description="Look up support policy by topic (refund, cancellation, shipping)"
     )
-    def calculate_percentage(
-        self, value: Annotated[float, "The value"], total: Annotated[float, "The total"]
-    ) -> Annotated[float, "The percentage as a decimal"]:
-        """Calculate percentage and return as a decimal."""
-        if total == 0:
-            return 0
-        return (value / total) * 100
-
-
-class DataPlugin:
-    """Plugin for data operations."""
-
-    @kernel_function(description="Get weather information for a location")
-    def get_weather(
-        self, location: Annotated[str, "The city name"]
-    ) -> Annotated[str, "Weather information including temperature and conditions"]:
-        """Get mock weather data for a location."""
-        mock_data = {
-            "san francisco": {"temp": 18.5, "conditions": "Foggy", "humidity": 75},
-            "new york": {"temp": 22.0, "conditions": "Sunny", "humidity": 60},
-            "london": {"temp": 15.0, "conditions": "Rainy", "humidity": 85},
-            "tokyo": {"temp": 25.0, "conditions": "Clear", "humidity": 55},
+    def lookup_policy(
+        self, topic: Annotated[str, "The policy topic"]
+    ) -> Annotated[str, "Policy summary"]:
+        policies = {
+            "refund": "Refunds available within 30 days for undelivered or damaged items.",
+            "cancellation": "Cancellation allowed before shipment. Delayed orders can request assisted cancellation.",
+            "shipping": "Standard shipping 3-5 business days. Delays trigger proactive outreach.",
         }
+        summary = policies.get(topic.lower().strip())
+        if summary:
+            return f"Policy ({topic}): {summary}"
+        return f"No policy found for topic: {topic}"
 
-        location_lower = location.lower()
-        data = mock_data.get(
-            location_lower, {"temp": 20.0, "conditions": "Unknown", "humidity": 50}
+
+# -- Scenarios --
+
+
+async def run_single_agent_tool_scenario() -> None:
+    """Scenario 1: single agent with tools and multi-turn session continuity."""
+    agent = ChatCompletionAgent(
+        service=OpenAIChatCompletion(ai_model_id=MODEL),
+        name="support_generalist",
+        instructions=(
+            "You are a customer support agent. Use the available tools "
+            "to look up order status and policies. Address the customer "
+            "by name when possible. Keep responses concise."
+        ),
+        plugins=[OrderPlugin(), PolicyPlugin()],
+    )
+
+    thread: ChatHistoryAgentThread | None = None
+    prompts = [
+        "Hi, I'm Alex Kim. Can you check on my order ORD-1002?",
+        "It's been processing for a while. What's the shipping policy for delays?",
+    ]
+
+    for prompt in prompts:
+        response = await agent.get_response(messages=prompt, thread=thread)
+        thread = response.thread
+
+    if thread:
+        await thread.delete()
+
+
+async def run_handoff_scenario() -> None:
+    """Scenario 2: triage agent hands off to order/policy specialists."""
+    order_agent = ChatCompletionAgent(
+        service=OpenAIChatCompletion(ai_model_id=MODEL),
+        name="order_specialist",
+        description="Handles order status and delivery questions.",
+        instructions=(
+            "You are an order specialist. Use lookup_order_status to answer "
+            "questions about order status and delivery. Be concise."
+        ),
+        plugins=[OrderPlugin()],
+    )
+
+    policy_agent = ChatCompletionAgent(
+        service=OpenAIChatCompletion(ai_model_id=MODEL),
+        name="policy_specialist",
+        description="Handles refund, cancellation, and shipping policy questions.",
+        instructions=(
+            "You are a policy specialist. Use lookup_policy to answer "
+            "questions about refund, cancellation, and shipping policies. Be concise."
+        ),
+        plugins=[PolicyPlugin()],
+    )
+
+    triage_agent = ChatCompletionAgent(
+        service=OpenAIChatCompletion(ai_model_id=MODEL),
+        name="triage_agent",
+        description="Routes support requests to the right specialist.",
+        instructions=(
+            "You are a triage agent. Route order-related questions to "
+            "order_specialist and policy questions to policy_specialist."
+        ),
+    )
+
+    handoffs = (
+        OrchestrationHandoffs()
+        .add_many(
+            source_agent=triage_agent.name,
+            target_agents={
+                order_agent.name: "Transfer for order status questions",
+                policy_agent.name: "Transfer for policy questions",
+            },
         )
-
-        return f"Weather in {location}: {data['temp']}°C, {data['conditions']}, {data['humidity']}% humidity"
-
-    @kernel_function(description="Search through documents for information")
-    def search_documents(
-        self, query: Annotated[str, "The search query"]
-    ) -> Annotated[str, "Search results from the document database"]:
-        """Mock document search."""
-        results = {
-            "python": "Python is a high-level programming language known for its simplicity and readability.",
-            "ai": "Artificial Intelligence refers to the simulation of human intelligence in machines.",
-            "machine learning": "Machine learning is a subset of AI that enables systems to learn from data.",
-        }
-
-        # Simple keyword matching
-        for key, value in results.items():
-            if key in query.lower():
-                return f"Found: {value}"
-
-        return "No relevant documents found."
-
-
-# ============================================================================
-# Test Functions
-# ============================================================================
-
-
-@trace(event_type="chain", event_name="test_basic_completion", tracer=tracer)
-async def test_basic_completion():
-    """Test 1: Basic agent invocation."""
-    print("\n" + "=" * 60)
-    print("Test 1: Basic Agent Invocation")
-    print("=" * 60)
-
-    # Create agent
-    agent = ChatCompletionAgent(
-        service=OpenAIChatCompletion(
-            service_id="openai",
-            ai_model_id="gpt-3.5-turbo",
-            api_key=os.getenv("OPENAI_API_KEY"),
-        ),
-        name="BasicAgent",
-        instructions="You are a helpful assistant that gives brief, direct answers.",
+        .add(
+            source_agent=order_agent.name,
+            target_agent=triage_agent.name,
+            description="Transfer back when order question is resolved",
+        )
+        .add(
+            source_agent=policy_agent.name,
+            target_agent=triage_agent.name,
+            description="Transfer back when policy question is resolved",
+        )
     )
 
-    # Get response
-    response = await agent.get_response("What is 2+2?")
-
-    print(f"✅ Result: {response.content}")
-    print("\n📊 Expected in HoneyHive:")
-    print("   - Span: agent.get_response")
-    print("   - Span: OpenAI chat completion")
-    print("   - Attributes: agent name, model, tokens, latency")
-
-
-@trace(event_type="chain", event_name="test_plugins_and_functions", tracer=tracer)
-async def test_plugins_and_functions():
-    """Test 2: Agent with plugins (automatic function calling)."""
-    print("\n" + "=" * 60)
-    print("Test 2: Agent with Plugins")
-    print("=" * 60)
-
-    # Create agent with plugins
-    agent = ChatCompletionAgent(
-        service=OpenAIChatCompletion(
-            service_id="openai",
-            ai_model_id="gpt-4o-mini",  # Better for function calling
-            api_key=os.getenv("OPENAI_API_KEY"),
-        ),
-        name="MathAgent",
-        instructions="You are a helpful math assistant. Use the available tools to solve problems accurately.",
-        plugins=[MathPlugin(), DataPlugin()],
+    orchestration = HandoffOrchestration(
+        members=[triage_agent, order_agent, policy_agent],
+        handoffs=handoffs,
     )
 
-    # Test math plugin usage
-    response = await agent.get_response("What is 15 plus 27?")
-    print(f"✅ Math result: {response.content}")
-
-    # Test weather plugin usage
-    weather_response = await agent.get_response("What's the weather in San Francisco?")
-    print(f"✅ Weather result: {weather_response.content}")
-
-    print("\n📊 Expected in HoneyHive:")
-    print("   - Agent invocation spans")
-    print("   - Automatic function call spans")
-    print("   - Function names and arguments captured")
-    print("   - Return values in traces")
-
-
-@trace(event_type="chain", event_name="test_structured_output", tracer=tracer)
-async def test_structured_output():
-    """Test 3: Structured output with Pydantic models."""
-    print("\n" + "=" * 60)
-    print("Test 3: Structured Output")
-    print("=" * 60)
-
-    # Define structured output model
-    class PriceInfo(BaseModel):
-        item_name: str
-        price: float
-        currency: str
-
-    # Create agent with structured output
-    settings = OpenAIChatPromptExecutionSettings()
-    settings.response_format = PriceInfo
-
-    agent = ChatCompletionAgent(
-        service=OpenAIChatCompletion(
-            service_id="openai",
-            ai_model_id="gpt-4o-mini",
-            api_key=os.getenv("OPENAI_API_KEY"),
-        ),
-        name="PricingAgent",
-        instructions="You provide pricing information in structured format.",
-        plugins=[DataPlugin()],
-        arguments=KernelArguments(settings=settings),
-    )
-
-    response = await agent.get_response("What is the weather in Tokyo?")
-    print(f"✅ Structured response: {response.content}")
-
-    print("\n📊 Expected in HoneyHive:")
-    print("   - Span showing structured output configuration")
-    print("   - Response format attributes")
-    print("   - Parsed structured data")
-
-
-@trace(event_type="chain", event_name="test_chat_with_history", tracer=tracer)
-async def test_chat_with_history():
-    """Test 4: Multi-turn conversation with history."""
-    print("\n" + "=" * 60)
-    print("Test 4: Chat with History")
-    print("=" * 60)
-
-    # Create agent
-    agent = ChatCompletionAgent(
-        service=OpenAIChatCompletion(
-            service_id="openai",
-            ai_model_id="gpt-3.5-turbo",
-            api_key=os.getenv("OPENAI_API_KEY"),
-        ),
-        name="ContextAgent",
-        instructions="You are a helpful assistant that remembers context from the conversation.",
-    )
-
-    # First message
-    response1 = await agent.get_response("My name is Alice and I love pizza.")
-    print(f"✅ Response 1: {response1.content}")
-
-    # Follow-up using conversation history
-    response2 = await agent.get_response("What's my name and what do I love?")
-    print(f"✅ Response 2: {response2.content}")
-
-    print("\n📊 Expected in HoneyHive:")
-    print("   - Multiple agent invocation spans")
-    print("   - Conversation history maintained")
-    print("   - Context awareness demonstrated")
-
-
-@trace(event_type="chain", event_name="test_multi_turn_with_tools", tracer=tracer)
-async def test_multi_turn_with_tools():
-    """Test 5: Multi-turn conversation with tool usage."""
-    print("\n" + "=" * 60)
-    print("Test 5: Multi-Turn with Tools")
-    print("=" * 60)
-
-    # Create agent with both plugins
-    agent = ChatCompletionAgent(
-        service=OpenAIChatCompletion(
-            service_id="openai",
-            ai_model_id="gpt-4o-mini",
-            api_key=os.getenv("OPENAI_API_KEY"),
-        ),
-        name="AssistantAgent",
-        instructions="You are a helpful assistant. Use the available tools to provide accurate information.",
-        plugins=[MathPlugin(), DataPlugin()],
-    )
-
-    # Multi-step conversation requiring multiple tool calls
-    response = await agent.get_response(
-        "What's the weather in Tokyo? Also calculate what 25 times 1.8 is, then add 32."
-    )
-    print(f"✅ Result: {response.content}")
-
-    print("\n📊 Expected in HoneyHive:")
-    print("   - Agent invocation span")
-    print("   - Multiple function call spans")
-    print("   - Function arguments and results")
-    print("   - Token usage for all calls")
-
-
-@trace(event_type="chain", event_name="test_different_models", tracer=tracer)
-async def test_different_models():
-    """Test 6: Different agents with different models."""
-    print("\n" + "=" * 60)
-    print("Test 6: Multiple Models")
-    print("=" * 60)
-
-    # Create two agents with different models
-    agent_35 = ChatCompletionAgent(
-        service=OpenAIChatCompletion(
-            service_id="gpt-3.5",
-            ai_model_id="gpt-3.5-turbo",
-            api_key=os.getenv("OPENAI_API_KEY"),
-        ),
-        name="FastAgent",
-        instructions="You are a quick assistant.",
-    )
-
-    agent_4 = ChatCompletionAgent(
-        service=OpenAIChatCompletion(
-            service_id="gpt-4",
-            ai_model_id="gpt-4o-mini",
-            api_key=os.getenv("OPENAI_API_KEY"),
-        ),
-        name="SmartAgent",
-        instructions="You are an intelligent assistant.",
-    )
-
-    # Compare responses
-    prompt = "Explain AI in one sentence."
-    response_35 = await agent_35.get_response(prompt)
-    response_4 = await agent_4.get_response(prompt)
-
-    print(f"✅ GPT-3.5: {response_35.content}")
-    print(f"✅ GPT-4: {response_4.content}")
-
-    print("\n📊 Expected in HoneyHive:")
-    print("   - Two agent spans with different models")
-    print("   - Different agent names")
-    print("   - Model comparison metrics")
-
-
-@trace(event_type="chain", event_name="test_streaming", tracer=tracer)
-async def test_streaming():
-    """Test 7: Streaming responses using the underlying service."""
-    print("\n" + "=" * 60)
-    print("Test 7: Streaming Mode")
-    print("=" * 60)
-
-    # Create chat service for streaming
-    chat_service = OpenAIChatCompletion(
-        service_id="openai",
-        ai_model_id="gpt-3.5-turbo",
-        api_key=os.getenv("OPENAI_API_KEY"),
-    )
-
-    # Create chat history
-    history = ChatHistory()
-    history.add_system_message("You are a creative storyteller.")
-    history.add_user_message("Tell me a very short 2-sentence story about a robot.")
-
-    # Stream response
-    print("📖 Streaming output: ", end="", flush=True)
-
-    full_response = ""
-    async for message_chunks in chat_service.get_streaming_chat_message_content(
-        chat_history=history,
-        settings=chat_service.get_prompt_execution_settings_class()(
-            max_tokens=100, temperature=0.8
-        ),
-    ):
-        # message_chunks is a list of StreamingChatMessageContent objects
-        if message_chunks:
-            for chunk in message_chunks:
-                if hasattr(chunk, "content") and chunk.content:
-                    print(chunk.content, end="", flush=True)
-                    full_response += str(chunk.content)
-                elif isinstance(chunk, str):
-                    # Sometimes it might be a string directly
-                    print(chunk, end="", flush=True)
-                    full_response += chunk
-
-    print("\n✅ Streaming complete")
-    if full_response:
-        print(f"📝 Full response length: {len(full_response)} characters")
-
-    print("\n📊 Expected in HoneyHive:")
-    print("   - Streaming span with TTFT metrics")
-    print("   - Complete response captured")
-    print("   - Chunk-level details if available")
-
-
-@trace(event_type="chain", event_name="test_complex_workflow", tracer=tracer)
-async def test_complex_workflow():
-    """Test 8: Complex workflow with multiple agents."""
-    print("\n" + "=" * 60)
-    print("Test 8: Complex Multi-Agent Workflow")
-    print("=" * 60)
-
-    # Create specialized agents
-    research_agent = ChatCompletionAgent(
-        service=OpenAIChatCompletion(
-            service_id="openai",
-            ai_model_id="gpt-3.5-turbo",
-            api_key=os.getenv("OPENAI_API_KEY"),
-        ),
-        name="ResearchAgent",
-        instructions="You gather information and facts.",
-        plugins=[DataPlugin()],
-    )
-
-    math_agent = ChatCompletionAgent(
-        service=OpenAIChatCompletion(
-            service_id="openai",
-            ai_model_id="gpt-4o-mini",
-            api_key=os.getenv("OPENAI_API_KEY"),
-        ),
-        name="MathAgent",
-        instructions="You perform calculations and mathematical analysis.",
-        plugins=[MathPlugin()],
-    )
-
-    # Sequential workflow
-    weather_response = await research_agent.get_response(
-        "What's the weather in New York?"
-    )
-    print(f"✅ Research: {weather_response.content}")
-
-    calc_response = await math_agent.get_response("Calculate 25% of 80")
-    print(f"✅ Calculation: {calc_response.content}")
-
-    print("\n📊 Expected in HoneyHive:")
-    print("   - Multiple agent invocation spans")
-    print("   - Different agent names and roles")
-    print("   - Plugin usage by different agents")
-    print("   - Complete workflow trace")
-
-
-@trace(event_type="chain", event_name="test_group_chat_orchestration", tracer=tracer)
-async def test_group_chat_orchestration():
-    """Test 9: Group chat orchestration with multiple agents collaborating."""
-    print("\n" + "=" * 60)
-    print("Test 9: Group Chat Orchestration")
-    print("=" * 60)
-
-    # Create collaborative agents
-    writer_agent = ChatCompletionAgent(
-        service=OpenAIChatCompletion(
-            service_id="openai",
-            ai_model_id="gpt-4o-mini",
-            api_key=os.getenv("OPENAI_API_KEY"),
-        ),
-        name="Writer",
-        description="A creative content writer that generates and refines slogans",
-        instructions="You are a creative content writer. Generate and refine slogans based on feedback. Be concise.",
-    )
-
-    reviewer_agent = ChatCompletionAgent(
-        service=OpenAIChatCompletion(
-            service_id="openai",
-            ai_model_id="gpt-4o-mini",
-            api_key=os.getenv("OPENAI_API_KEY"),
-        ),
-        name="Reviewer",
-        description="A critical reviewer that provides constructive feedback on slogans",
-        instructions="You are a critical reviewer. Provide brief, constructive feedback on proposed slogans.",
-    )
-
-    # Create group chat with round-robin orchestration
-    group_chat = GroupChatOrchestration(
-        members=[writer_agent, reviewer_agent],
-        manager=RoundRobinGroupChatManager(max_rounds=3),  # Limit rounds for demo
-    )
-
-    # Create runtime
     runtime = InProcessRuntime()
     runtime.start()
 
-    print("🔄 Starting group chat collaboration...")
-
     try:
-        # Invoke group chat with a collaborative task
-        result = await group_chat.invoke(
-            task="Create a catchy slogan for a new AI-powered coding assistant that helps developers write better code faster.",
+        result = await orchestration.invoke(
+            task="Order ORD-1003 is delayed. Can I cancel and get a refund?",
             runtime=runtime,
         )
-
-        # Get final result
-        final_value = await result.get()
-        print(f"\n✅ Final Slogan: {final_value}")
-
+        await result.get()
     finally:
-        # Stop runtime
         await runtime.stop_when_idle()
 
-    print("\n📊 Expected in HoneyHive:")
-    print("   - Group chat orchestration span")
-    print("   - Multiple agent turns (Writer → Reviewer → Writer)")
-    print("   - Round-robin manager coordination")
-    print("   - Collaborative refinement process")
-    print("   - Final consensus result")
+
+async def run_streaming_scenario() -> None:
+    """Scenario 3: streaming response via invoke()."""
+    agent = ChatCompletionAgent(
+        service=OpenAIChatCompletion(ai_model_id=MODEL),
+        name="response_drafter",
+        instructions="Draft concise customer support responses. Use bullet points.",
+        plugins=[OrderPlugin()],
+    )
+
+    thread: ChatHistoryAgentThread | None = None
+    async for response in agent.invoke(
+        messages="Draft a response for a customer whose order ORD-1003 is delayed and wants cancellation options.",
+        thread=thread,
+    ):
+        thread = response.thread
 
 
-# ============================================================================
-# Main Execution
-# ============================================================================
+# -- Main --
 
 
-async def main():
-    """Run all integration tests."""
-    print("🚀 Microsoft Semantic Kernel + HoneyHive Integration Test Suite")
-    print(f"   Session ID: {tracer.session_id}")
-    print(f"   Project: {tracer.project}")
+async def main() -> None:
+    tracer = HoneyHiveTracer.init(
+        api_key=os.getenv("HH_API_KEY"),
+        project=os.getenv("HH_PROJECT"),
+        session_name="semantic_kernel_integration",
+        source=os.getenv("HH_SOURCE", "python_sdk_example"),
+    )
 
-    if not os.getenv("OPENAI_API_KEY"):
-        print("\n❌ Error: OPENAI_API_KEY environment variable not set")
-        print("   Please add it to your .env file")
-        return
+    instrumentor = OpenAIInstrumentor()
+    instrumentor.instrument(tracer_provider=tracer.provider)
 
-    # Run all tests
     try:
-        await test_basic_completion()
-        await test_plugins_and_functions()
-        await test_structured_output()
-        await test_chat_with_history()
-        await test_multi_turn_with_tools()
-        await test_different_models()
-        await test_streaming()
-        await test_complex_workflow()
-        await test_group_chat_orchestration()
-
-        print("\n" + "=" * 60)
-        print("🎉 All tests completed successfully!")
-        print("=" * 60)
-        print("\n📊 Check your HoneyHive dashboard:")
-        print(f"   Session ID: {tracer.session_id}")
-        print(f"   Project: {tracer.project}")
-        print("\nYou should see:")
-        print("   ✓ 9 root spans (one per test)")
-        print("   ✓ Agent invocations with names")
-        print("   ✓ Plugin executions with arguments")
-        print("   ✓ AI service calls (OpenAI)")
-        print("   ✓ Automatic function calling spans")
-        print("   ✓ Token usage metrics")
-        print("   ✓ Streaming responses with TTFT")
-        print("   ✓ Multi-agent workflow traces")
-        print("   ✓ Group chat orchestration with turn-taking")
-        print("\n💡 Key Attributes to look for:")
-        print("   • Agent names (BasicAgent, MathAgent, Writer, Reviewer, etc.)")
-        print("   • Plugin function calls")
-        print("   • AI service_id and model names")
-        print("   • Function arguments and return values")
-        print("   • Conversation history")
-        print("   • Group chat turns and collaboration")
-        print("   • Token usage and costs")
-
-    except Exception as e:
-        print(f"\n❌ Test failed: {e}")
-        print("\nCommon issues:")
-        print("   • Verify OPENAI_API_KEY is valid")
-        print("   • Ensure you have 'semantic-kernel' package installed")
-        print("   • Ensure you have 'openinference-instrumentation-openai' installed")
-        print("   • Check HoneyHive API key is valid")
-        print(f"\n📊 Traces may still be in HoneyHive: Session {tracer.session_id}")
-        import traceback
-
-        traceback.print_exc()
-
+        await run_single_agent_tool_scenario()
+        await run_handoff_scenario()
+        await run_streaming_scenario()
     finally:
-        # Cleanup
-        print("\n📤 Cleaning up...")
-        if span_processor:
-            span_processor.force_flush()
-        openai_instrumentor.uninstrument()
-        print("✓ Cleanup completed")
+        tracer.force_flush()
+        instrumentor.uninstrument()
 
 
 if __name__ == "__main__":

--- a/examples/integrations/semantic_kernel_integration.py
+++ b/examples/integrations/semantic_kernel_integration.py
@@ -6,7 +6,7 @@ Demonstrates three Semantic Kernel patterns with HoneyHive tracing:
 
 1) Single agent with tool calls and multi-turn session continuity
 2) Multi-agent handoff orchestration (triage -> order/policy specialists)
-3) Streaming agent response
+3) Token-level streaming via invoke_stream()
 
 Install:
     uv pip install honeyhive semantic-kernel openinference-instrumentation-openai
@@ -191,7 +191,7 @@ async def run_handoff_scenario() -> None:
 
 
 async def run_streaming_scenario() -> None:
-    """Scenario 3: streaming response via invoke()."""
+    """Scenario 3: token-level streaming via invoke_stream()."""
     agent = ChatCompletionAgent(
         service=OpenAIChatCompletion(ai_model_id=MODEL),
         name="response_drafter",
@@ -200,11 +200,14 @@ async def run_streaming_scenario() -> None:
     )
 
     thread: ChatHistoryAgentThread | None = None
-    async for response in agent.invoke(
+    async for response in agent.invoke_stream(
         messages="Draft a response for a customer whose order ORD-1003 is delayed and wants cancellation options.",
         thread=thread,
     ):
         thread = response.thread
+
+    if thread:
+        await thread.delete()
 
 
 # -- Main --


### PR DESCRIPTION
## Example Update: semantic-kernel

**File:** python-sdk/examples/integrations/semantic_kernel_integration.py
**Framework version:** 1.36.0 (latest stable: 1.39.4)
**Status:** Updated

### Summary
- Rewrote the Semantic Kernel example to match the style of other integration examples (ADK, PydanticAI)
- Uses the shared customer support domain with order status / policy lookup mock tools (ORD-1001 through ORD-1003)
- Replaced test-style structure (9 test functions with `@trace` decorators) with 3 clean scenario functions

### Patterns Covered
- Agent names/hierarchy: yes (support_generalist, triage_agent, order_specialist, policy_specialist, response_drafter)
- System instructions: yes
- User input/model output: yes
- Tool calls (args + results): yes (OrderPlugin, PolicyPlugin with `@kernel_function`)
- Session continuity: yes (multi-turn via `AgentThread` in Scenario 1)
- Multi-agent handoff orchestration: yes (`HandoffOrchestration` with `OrchestrationHandoffs` in Scenario 2)
- Streaming: yes (via `agent.invoke()` in Scenario 3)

### Changes Made
- Replaced weather/math/data themes with customer support domain
- Updated from `gpt-3.5-turbo` to `gpt-4o-mini`
- Replaced `GroupChatOrchestration` with `HandoffOrchestration` (more representative multi-agent pattern)
- Added native SK OTel diagnostics env vars alongside OpenInference OpenAI instrumentor
- Removed `@trace` decorators, `setup_span_capture`, `dotenv`, `pydantic` imports
- Removed verbose print statements and emoji output noise
- Code reduced from 622 lines to 233 lines

### Tracing Issues Found
- None found. 46 events ingested correctly (9 model + 36 tool + 1 session). All model events have token counts, system prompts, and conversation history. Handoff transfers visible as tool executions.

### Test plan
- [x] Smoke run passes (exit 0, no errors)
- [x] 45 raw spans captured in span dump
- [x] 46 events retrieved from HoneyHive session API
- [x] Model events have clean inputs (chat_history) and outputs
- [x] Session continuity confirmed (turn 2 shows full conversation history)
- [x] Handoff events visible (transfer_to_order_specialist, transfer_to_policy_specialist)
- [x] `make format` passes

### Links
- UI trace: https://fe.testing-cp.honeyhive.ai/datastore/sessions/86e50066-1eb9-4b68-9a53-b66ed15abebb/peQ9-_5k2zXezKJ_cwO20KYx