### PR TITLE
fix(tracing): honor gen_ai operation event types

### DIFF
--- a/src/honeyhive/tracer/processing/span_processor.py
+++ b/src/honeyhive/tracer/processing/span_processor.py
@@ -1024,7 +1024,29 @@ class HoneyHiveSpanProcessor(SpanProcessor):
                 )
                 return str(direct_type)
 
-            # Priority 4: OpenInference span.kind attribute (standard
+            # Priority 4: gen_ai.operation.name (GenAI semantic conventions)
+            op_name = attributes.get("gen_ai.operation.name")
+            if op_name:
+                op_name_str = str(op_name).lower()
+                GENAI_OP_TO_EVENT_TYPE = {
+                    "chat": "model",
+                    "text_completion": "model",
+                    "generate_content": "model",
+                    "invoke_agent": "chain",
+                    "create_agent": "chain",
+                    "execute_tool": "tool",
+                }
+                event_type = GENAI_OP_TO_EVENT_TYPE.get(op_name_str)
+                if event_type:
+                    self._safe_log(
+                        "debug",
+                        "✅ Event type from gen_ai.operation.name: %s (%s)",
+                        event_type,
+                        op_name,
+                    )
+                    return event_type
+
+            # Priority 5: OpenInference span.kind attribute (standard
             # instrumentor convention)
             span_kind = attributes.get("openinference.span.kind")
             if span_kind:


### PR DESCRIPTION
## Summary
- prefer `gen_ai.operation.name` when the SDK classifies GenAI-native spans
- map `chat`/`text_completion`/`generate_content` to `model`, `invoke_agent`/`create_agent` to `chain`, and `execute_tool` to `tool`
- pair this with the ingestion-side Strands fix in [hive-kube#2609](https://github.com/honeyhiveai/hive-kube/pull/2609)

## Test plan
- [x] local Strands example run against the local server
- [x] verified resulting spans and session events after the paired ingestion change