### PR TITLE
fix(ci): dispatch docs changelog sync after publish

### DIFF
--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: write  # For creating GitHub releases
+  actions: write  # For dispatching follow-up workflows
   id-token: write  # For trusted publishing to PyPI
 
 env:
@@ -396,3 +397,14 @@ jobs:
           echo "- ✅ Installation test passed" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ Published to PyPI" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ GitHub release created" >> $GITHUB_STEP_SUMMARY
+
+      - name: Trigger docs changelog sync
+        if: steps.check_pypi.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SYNC_REF: ${{ github.event.inputs.branch || github.ref_name }}
+          VERSION: v${{ steps.get_version.outputs.version }}
+        run: |
+          echo "🚀 Dispatching docs changelog sync for $VERSION on $SYNC_REF..."
+          gh workflow run sync-changelog-to-docs.yml --ref "$SYNC_REF" -f version="$VERSION"
+          echo "✅ Docs changelog sync dispatched"

--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -400,6 +400,7 @@ jobs:
 
       - name: Trigger docs changelog sync
         if: steps.check_pypi.outputs.exists == 'false'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SYNC_REF: ${{ github.event.inputs.branch || github.ref_name }}


### PR DESCRIPTION
## Summary
- trigger `sync-changelog-to-docs.yml` explicitly from `sdk-publish.yml` after a new release is published
- add `actions: write` so the publish workflow can dispatch the follow-up workflow with the released version
- avoid relying on `release` event fan-out, which does not run when the release is created by `github-actions[bot]` via `GITHUB_TOKEN`

## Test plan
- [x] Run `uv sync --extra dev --extra docs`
- [x] Run `make generate && make format`
- [ ] Trigger `Publish to PyPI` in GitHub Actions and confirm it dispatches `Sync SDK Release to Docs`