### PR TITLE
feat: span name filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Added
+
+- **Tracer: `span_name_filters` parameter on `HoneyHiveTracer.init()`** — include/exclude spans by name prefix to filter noisy framework internals
+
 ## [1.0.0rc19] - 2026-03-06
 
 ### Added

--- a/docs/reference/api/tracer.rst
+++ b/docs/reference/api/tracer.rst
@@ -138,7 +138,10 @@ init()
    
    :param verbose: Enable verbose debug logging throughout tracer initialization. Defaults to False.
    :type verbose: bool
-   
+
+   :param span_name_filters: Filter spans by name to control which spans are exported to HoneyHive. Accepts a dictionary with ``exclude`` and/or ``include`` keys, each containing a list of filter entries. Each filter entry is a dict with ``type`` (currently only ``"prefix"``) and ``value`` (the prefix to match against span names). When ``include`` is specified, only spans matching at least one include prefix are kept. When ``exclude`` is specified, spans matching any exclude prefix are dropped. When both are specified, a span must match an include prefix and not match any exclude prefix. Filtered spans are dropped before enrichment or export. Example: ``{"exclude": [{"type": "prefix", "value": "a2a.client.transports"}]}``.
+   :type span_name_filters: Optional[Dict[str, List[Dict[str, str]]]]
+
    **Evaluation Parameters (Backwards Compatibility):**
    
    :param inputs: Session initialization inputs for backwards compatibility with main branch.

--- a/docs/reference/api/tracer.rst
+++ b/docs/reference/api/tracer.rst
@@ -139,8 +139,8 @@ init()
    :param verbose: Enable verbose debug logging throughout tracer initialization. Defaults to False.
    :type verbose: bool
 
-   :param span_name_filters: Filter spans by name to control which spans are exported to HoneyHive. Accepts a dictionary with ``exclude`` and/or ``include`` keys, each containing a list of filter entries. Each filter entry is a dict with ``type`` (currently only ``"prefix"``) and ``value`` (the prefix to match against span names). When ``include`` is specified, only spans matching at least one include prefix are kept. When ``exclude`` is specified, spans matching any exclude prefix are dropped. When both are specified, a span must match an include prefix and not match any exclude prefix. Filtered spans are dropped before enrichment or export. Example: ``{"exclude": [{"type": "prefix", "value": "a2a.client.transports"}]}``.
-   :type span_name_filters: Optional[Dict[str, List[Dict[str, str]]]]
+   :param span_name_filters: Filter spans by name to control which spans are exported to HoneyHive. Accepts a ``SpanNameFilters`` object (or equivalent dict) with ``exclude`` and/or ``include`` keys, each containing a list of ``SpanNameFilter`` entries. Each entry has a ``type`` (must be ``"prefix"``) and ``value`` (the prefix to match against span names). When ``include`` is specified, only spans matching at least one include prefix are kept. When ``exclude`` is specified, spans matching any exclude prefix are dropped. When both are specified, a span must match an include prefix and not match any exclude prefix. Filtered spans are dropped before enrichment or export. Example: ``{"exclude": [{"type": "prefix", "value": "a2a.client.transports"}]}``.
+   :type span_name_filters: Optional[SpanNameFilters]
 
    **Evaluation Parameters (Backwards Compatibility):**
    

--- a/src/honeyhive/config/models/__init__.py
+++ b/src/honeyhive/config/models/__init__.py
@@ -52,7 +52,13 @@ from .http_client import HTTPClientConfig
 from .otlp import OTLPConfig
 
 # Tracer configurations
-from .tracer import EvaluationConfig, SessionConfig, TracerConfig
+from .tracer import (
+    EvaluationConfig,
+    SessionConfig,
+    SpanNameFilter,
+    SpanNameFilters,
+    TracerConfig,
+)
 
 # Note: TracingConfig merged into TracerConfig to eliminate duplication
 
@@ -63,6 +69,8 @@ __all__ = [
     "TracerConfig",
     "SessionConfig",
     "EvaluationConfig",
+    "SpanNameFilter",
+    "SpanNameFilters",
     # API client domain
     "APIClientConfig",
     # HTTP client domain

--- a/src/honeyhive/config/models/tracer.py
+++ b/src/honeyhive/config/models/tracer.py
@@ -24,9 +24,9 @@ the host application.
 
 import logging
 import uuid
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import AliasChoices, Field, field_validator
+from pydantic import AliasChoices, BaseModel, Field, field_validator
 from pydantic_settings import SettingsConfigDict
 
 from .base import BaseHoneyHiveConfig, _safe_validate_string, _safe_validate_url
@@ -35,32 +35,33 @@ from .base import BaseHoneyHiveConfig, _safe_validate_string, _safe_validate_url
 logger = logging.getLogger(__name__)
 
 
-class SpanNameFilter(BaseHoneyHiveConfig):
+class SpanNameFilter(BaseModel):
     """A single span name filter entry.
+
+    Uses BaseModel (not BaseSettings) since these are nested data models
+    that should not read from environment variables.
 
     Attributes:
         type: The filter matching strategy. Only "prefix" is currently supported.
         value: The value to match against span names.
     """
 
-    type: str = Field(
+    type: Literal["prefix"] = Field(
         description='Filter matching strategy. Only "prefix" is currently supported.',
-        examples=["prefix"],
     )
     value: str = Field(
         description="The value to match against span names.",
         examples=["a2a.client.transports.jsonrpc"],
     )
 
-    model_config = SettingsConfigDict(
-        validate_assignment=True,
-        extra="forbid",
-        case_sensitive=False,
-    )
+    model_config = {"validate_assignment": True, "extra": "forbid"}
 
 
-class SpanNameFilters(BaseHoneyHiveConfig):
+class SpanNameFilters(BaseModel):
     """Configuration for filtering spans by name.
+
+    Uses BaseModel (not BaseSettings) since these are nested data models
+    that should not read from environment variables.
 
     Supports both include (allow-list) and exclude (block-list) filters.
     If include is specified, only spans matching at least one include filter are kept.
@@ -82,11 +83,7 @@ class SpanNameFilters(BaseHoneyHiveConfig):
         description="Block-list: drop spans matching any filter.",
     )
 
-    model_config = SettingsConfigDict(
-        validate_assignment=True,
-        extra="forbid",
-        case_sensitive=False,
-    )
+    model_config = {"validate_assignment": True, "extra": "forbid"}
 
 
 class TracerConfig(BaseHoneyHiveConfig):
@@ -175,11 +172,7 @@ class TracerConfig(BaseHoneyHiveConfig):
             "Excluded spans are dropped before enrichment and export."
         ),
         examples=[
-            {
-                "exclude": [
-                    {"type": "prefix", "value": "a2a.client.transports.jsonrpc"}
-                ]
-            }
+            {"exclude": [{"type": "prefix", "value": "a2a.client.transports.jsonrpc"}]}
         ],
     )
 

--- a/src/honeyhive/config/models/tracer.py
+++ b/src/honeyhive/config/models/tracer.py
@@ -24,7 +24,7 @@ the host application.
 
 import logging
 import uuid
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import SettingsConfigDict
@@ -33,6 +33,60 @@ from .base import BaseHoneyHiveConfig, _safe_validate_string, _safe_validate_url
 
 # Module logger for graceful degradation warnings
 logger = logging.getLogger(__name__)
+
+
+class SpanNameFilter(BaseHoneyHiveConfig):
+    """A single span name filter entry.
+
+    Attributes:
+        type: The filter matching strategy. Only "prefix" is currently supported.
+        value: The value to match against span names.
+    """
+
+    type: str = Field(
+        description='Filter matching strategy. Only "prefix" is currently supported.',
+        examples=["prefix"],
+    )
+    value: str = Field(
+        description="The value to match against span names.",
+        examples=["a2a.client.transports.jsonrpc"],
+    )
+
+    model_config = SettingsConfigDict(
+        validate_assignment=True,
+        extra="forbid",
+        case_sensitive=False,
+    )
+
+
+class SpanNameFilters(BaseHoneyHiveConfig):
+    """Configuration for filtering spans by name.
+
+    Supports both include (allow-list) and exclude (block-list) filters.
+    If include is specified, only spans matching at least one include filter are kept.
+    If exclude is specified, spans matching any exclude filter are dropped.
+    If both are specified, a span must match include AND not match exclude.
+
+    Example:
+        >>> filters = SpanNameFilters(
+        ...     exclude=[SpanNameFilter(type="prefix", value="a2a.client.transports")]
+        ... )
+    """
+
+    include: Optional[List[SpanNameFilter]] = Field(
+        default=None,
+        description="Allow-list: only keep spans matching at least one filter.",
+    )
+    exclude: Optional[List[SpanNameFilter]] = Field(
+        default=None,
+        description="Block-list: drop spans matching any filter.",
+    )
+
+    model_config = SettingsConfigDict(
+        validate_assignment=True,
+        extra="forbid",
+        case_sensitive=False,
+    )
 
 
 class TracerConfig(BaseHoneyHiveConfig):
@@ -111,6 +165,22 @@ class TracerConfig(BaseHoneyHiveConfig):
         default=False,
         description="Disable all tracing functionality",
         validation_alias=AliasChoices("HH_DISABLE_TRACING", "disable_tracing"),
+    )
+
+    span_name_filters: Optional[SpanNameFilters] = Field(
+        default=None,
+        description=(
+            "Filter spans by name using include/exclude lists. "
+            "Each filter entry specifies a type ('prefix') and value to match. "
+            "Excluded spans are dropped before enrichment and export."
+        ),
+        examples=[
+            {
+                "exclude": [
+                    {"type": "prefix", "value": "a2a.client.transports.jsonrpc"}
+                ]
+            }
+        ],
     )
 
     # OpenTelemetry Span Limits Configuration

--- a/src/honeyhive/tracer/processing/span_processor.py
+++ b/src/honeyhive/tracer/processing/span_processor.py
@@ -12,7 +12,7 @@
 
 import json
 import warnings
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 from opentelemetry import baggage, context
 from opentelemetry.context import Context
@@ -93,8 +93,8 @@ class HoneyHiveSpanProcessor(SpanProcessor):
         )
 
         # Parse span name filters from tracer config (cached for hot-path performance)
-        self._span_name_include_prefixes: list[str] = []
-        self._span_name_exclude_prefixes: list[str] = []
+        self._span_name_include_prefixes: List[str] = []
+        self._span_name_exclude_prefixes: List[str] = []
         self._parse_span_name_filters()
 
     def _parse_span_name_filters(self) -> None:
@@ -114,7 +114,20 @@ class HoneyHiveSpanProcessor(SpanProcessor):
         if not filters:
             return
 
-        def _get(obj, key, default=None):
+        try:
+            self._do_parse_span_name_filters(filters)
+        except Exception:
+            self._safe_log(
+                "warning",
+                "Failed to parse span_name_filters config, filters disabled",
+            )
+            self._span_name_include_prefixes = []
+            self._span_name_exclude_prefixes = []
+
+    def _do_parse_span_name_filters(self, filters: Any) -> None:
+        """Inner parsing logic for span_name_filters, separated for graceful degradation."""
+
+        def _get(obj: Any, key: str, default: Any = None) -> Any:
             """Get value from dict or object with attributes."""
             if isinstance(obj, dict):
                 return obj.get(key, default)
@@ -174,17 +187,13 @@ class HoneyHiveSpanProcessor(SpanProcessor):
         # Check include filters: span must match at least one
         if self._span_name_include_prefixes:
             if not any(
-                span_name.startswith(p)
-                for p in self._span_name_include_prefixes
+                span_name.startswith(p) for p in self._span_name_include_prefixes
             ):
                 return True  # Drop: doesn't match any include prefix
 
         # Check exclude filters: span must NOT match any
         if self._span_name_exclude_prefixes:
-            if any(
-                span_name.startswith(p)
-                for p in self._span_name_exclude_prefixes
-            ):
+            if any(span_name.startswith(p) for p in self._span_name_exclude_prefixes):
                 return True  # Drop: matches an exclude prefix
 
         return False

--- a/src/honeyhive/tracer/processing/span_processor.py
+++ b/src/honeyhive/tracer/processing/span_processor.py
@@ -92,6 +92,103 @@ class HoneyHiveSpanProcessor(SpanProcessor):
             disable_batch,
         )
 
+        # Parse span name filters from tracer config (cached for hot-path performance)
+        self._span_name_include_prefixes: list[str] = []
+        self._span_name_exclude_prefixes: list[str] = []
+        self._parse_span_name_filters()
+
+    def _parse_span_name_filters(self) -> None:
+        """Parse and cache span_name_filters from tracer config.
+
+        Reads span_name_filters from the tracer instance config and caches
+        the prefix values as flat lists for fast matching in on_start/on_end.
+        """
+        if not self.tracer_instance:
+            return
+
+        config = getattr(self.tracer_instance, "config", None)
+        if not config:
+            return
+
+        filters = config.get("span_name_filters")
+        if not filters:
+            return
+
+        def _get(obj, key, default=None):
+            """Get value from dict or object with attributes."""
+            if isinstance(obj, dict):
+                return obj.get(key, default)
+            return getattr(obj, key, default)
+
+        # Extract include/exclude filter lists from either Pydantic model or dict
+        for raw_list, target, label in [
+            (_get(filters, "include"), self._span_name_include_prefixes, "include"),
+            (_get(filters, "exclude"), self._span_name_exclude_prefixes, "exclude"),
+        ]:
+            if not raw_list:
+                continue
+            for entry in raw_list:
+                filter_type = _get(entry, "type")
+                filter_value = _get(entry, "value")
+                if filter_type == "prefix" and filter_value:
+                    target.append(filter_value)
+                elif filter_type:
+                    self._safe_log(
+                        "warning",
+                        "Unsupported span_name_filter type: %s "
+                        "(only 'prefix' is supported)",
+                        filter_type,
+                    )
+
+        if self._span_name_include_prefixes or self._span_name_exclude_prefixes:
+            self._safe_log(
+                "debug",
+                "Span name filters configured: %d include prefixes, "
+                "%d exclude prefixes",
+                len(self._span_name_include_prefixes),
+                len(self._span_name_exclude_prefixes),
+            )
+
+    def _is_span_excluded(self, span_name: str) -> bool:
+        """Check if a span should be excluded (dropped) based on span_name_filters.
+
+        Returns True if the span should be DROPPED.
+
+        Logic:
+        - If include filters exist, span must match at least one include prefix.
+        - If exclude filters exist, span must NOT match any exclude prefix.
+        - If both, span must match include AND not match exclude.
+
+        :param span_name: The name of the span to check
+        :type span_name: str
+        :return: True if the span should be excluded
+        :rtype: bool
+        """
+        # No filters configured - keep all spans (fast path)
+        if (
+            not self._span_name_include_prefixes
+            and not self._span_name_exclude_prefixes
+        ):
+            return False
+
+        # Check include filters: span must match at least one
+        if self._span_name_include_prefixes:
+            if not any(
+                span_name.startswith(p)
+                for p in self._span_name_include_prefixes
+            ):
+                return True  # Drop: doesn't match any include prefix
+
+        # Check exclude filters: span must NOT match any
+        if self._span_name_exclude_prefixes:
+            if any(
+                span_name.startswith(p)
+                for p in self._span_name_exclude_prefixes
+            ):
+                return True  # Drop: matches an exclude prefix
+
+        return False
+
     def _safe_log(self, level: str, message: str, *args: Any, **kwargs: Any) -> None:
         """Safely log using the centralized safe_log utility."""
         # pylint: disable=import-outside-toplevel  # Avoids circular
@@ -573,6 +670,15 @@ class HoneyHiveSpanProcessor(SpanProcessor):
         )
 
         try:
+            # Check span name filters — skip enrichment for excluded spans
+            if self._is_span_excluded(span.name):
+                self._safe_log(
+                    "debug",
+                    "Dropping span from on_start (excluded by span_name_filters): %s",
+                    span.name,
+                )
+                return
+
             ctx = self._get_context(parent_context)
             if ctx is None:
                 self._safe_log(
@@ -722,6 +828,15 @@ class HoneyHiveSpanProcessor(SpanProcessor):
         """
         try:
             self._safe_log("debug", f"🟦 ON_END CALLED for span: {span.name}")
+
+            # Check span name filters — skip export for excluded spans
+            if self._is_span_excluded(span.name):
+                self._safe_log(
+                    "debug",
+                    "Dropping span from on_end (excluded by span_name_filters): %s",
+                    span.name,
+                )
+                return
 
             # Get span duration for performance metrics
             span_context = span.get_span_context()

--- a/src/honeyhive/tracer/processing/span_processor.py
+++ b/src/honeyhive/tracer/processing/span_processor.py
@@ -103,18 +103,18 @@ class HoneyHiveSpanProcessor(SpanProcessor):
         Reads span_name_filters from the tracer instance config and caches
         the prefix values as flat lists for fast matching in on_start/on_end.
         """
-        if not self.tracer_instance:
-            return
-
-        config = getattr(self.tracer_instance, "config", None)
-        if not config:
-            return
-
-        filters = config.get("span_name_filters")
-        if not filters:
-            return
-
         try:
+            if not self.tracer_instance:
+                return
+
+            config = getattr(self.tracer_instance, "config", None)
+            if not config:
+                return
+
+            filters = config.get("span_name_filters")
+            if not filters:
+                return
+
             self._do_parse_span_name_filters(filters)
         except Exception:
             self._safe_log(

--- a/src/honeyhive/tracer/processing/span_processor.py
+++ b/src/honeyhive/tracer/processing/span_processor.py
@@ -134,7 +134,7 @@ class HoneyHiveSpanProcessor(SpanProcessor):
             return getattr(obj, key, default)
 
         # Extract include/exclude filter lists from either Pydantic model or dict
-        for raw_list, target, label in [
+        for raw_list, target, _label in [
             (_get(filters, "include"), self._span_name_include_prefixes, "include"),
             (_get(filters, "exclude"), self._span_name_exclude_prefixes, "exclude"),
         ]:

--- a/tests/unit/test_span_name_filters.py
+++ b/tests/unit/test_span_name_filters.py
@@ -1,0 +1,343 @@
+"""Unit tests for span_name_filters feature (HHAI-4085).
+
+Tests cover:
+- SpanNameFilter and SpanNameFilters Pydantic models
+- _parse_span_name_filters config parsing (dict and object access)
+- _is_span_excluded filtering logic (include, exclude, both)
+- on_start/on_end early return for excluded spans
+"""
+
+# pylint: disable=protected-access
+
+from unittest.mock import Mock, patch
+
+import pytest
+from opentelemetry.sdk.trace import Span
+
+from honeyhive.config.models.tracer import SpanNameFilter, SpanNameFilters, TracerConfig
+from honeyhive.tracer.processing.span_processor import HoneyHiveSpanProcessor
+from honeyhive.utils.dotdict import DotDict
+
+
+# -- Pydantic model tests --
+
+
+class TestSpanNameFilterModels:
+    """Test SpanNameFilter and SpanNameFilters Pydantic models."""
+
+    def test_span_name_filter_valid(self) -> None:
+        """Test creating a valid SpanNameFilter."""
+        f = SpanNameFilter(type="prefix", value="a2a.client.transports")
+        assert f.type == "prefix"
+        assert f.value == "a2a.client.transports"
+
+    def test_span_name_filter_rejects_extra_fields(self) -> None:
+        """Test that extra fields are rejected."""
+        with pytest.raises(Exception):
+            SpanNameFilter(type="prefix", value="foo", unknown="bar")
+
+    def test_span_name_filters_exclude_only(self) -> None:
+        """Test SpanNameFilters with exclude list only."""
+        filters = SpanNameFilters(
+            exclude=[SpanNameFilter(type="prefix", value="a2a.client")]
+        )
+        assert filters.include is None
+        assert len(filters.exclude) == 1
+        assert filters.exclude[0].value == "a2a.client"
+
+    def test_span_name_filters_include_only(self) -> None:
+        """Test SpanNameFilters with include list only."""
+        filters = SpanNameFilters(
+            include=[SpanNameFilter(type="prefix", value="pydantic-ai")]
+        )
+        assert filters.exclude is None
+        assert len(filters.include) == 1
+
+    def test_span_name_filters_both(self) -> None:
+        """Test SpanNameFilters with both include and exclude."""
+        filters = SpanNameFilters(
+            include=[SpanNameFilter(type="prefix", value="pydantic-ai")],
+            exclude=[SpanNameFilter(type="prefix", value="pydantic-ai.internal")],
+        )
+        assert len(filters.include) == 1
+        assert len(filters.exclude) == 1
+
+    def test_span_name_filters_empty(self) -> None:
+        """Test SpanNameFilters with no filters."""
+        filters = SpanNameFilters()
+        assert filters.include is None
+        assert filters.exclude is None
+
+    def test_tracer_config_accepts_span_name_filters(self) -> None:
+        """Test that TracerConfig accepts span_name_filters field."""
+        config = TracerConfig(
+            api_key="test",
+            project="test",
+            span_name_filters=SpanNameFilters(
+                exclude=[SpanNameFilter(type="prefix", value="a2a")]
+            ),
+        )
+        assert config.span_name_filters is not None
+        assert len(config.span_name_filters.exclude) == 1
+
+    def test_tracer_config_default_no_filters(self) -> None:
+        """Test that TracerConfig defaults to no span_name_filters."""
+        config = TracerConfig(api_key="test", project="test")
+        assert config.span_name_filters is None
+
+
+# -- _is_span_excluded logic tests --
+
+
+class TestIsSpanExcluded:
+    """Test _is_span_excluded filtering logic."""
+
+    def _make_processor(
+        self, include_prefixes: list[str] | None = None, exclude_prefixes: list[str] | None = None
+    ) -> HoneyHiveSpanProcessor:
+        """Helper to create a processor with pre-set filter lists."""
+        processor = HoneyHiveSpanProcessor()
+        processor._span_name_include_prefixes = include_prefixes or []
+        processor._span_name_exclude_prefixes = exclude_prefixes or []
+        return processor
+
+    def test_no_filters_keeps_all(self) -> None:
+        """No filters configured — all spans kept."""
+        p = self._make_processor()
+        assert p._is_span_excluded("anything") is False
+        assert p._is_span_excluded("a2a.client.transports.foo") is False
+
+    def test_exclude_drops_matching(self) -> None:
+        """Exclude filter drops spans matching the prefix."""
+        p = self._make_processor(exclude_prefixes=["a2a.client.transports"])
+        assert p._is_span_excluded("a2a.client.transports.jsonrpc.send") is True
+        assert p._is_span_excluded("a2a.client.transports") is True
+
+    def test_exclude_keeps_non_matching(self) -> None:
+        """Exclude filter keeps spans that don't match."""
+        p = self._make_processor(exclude_prefixes=["a2a.client.transports"])
+        assert p._is_span_excluded("pydantic-ai.agent_run") is False
+        assert p._is_span_excluded("chat gpt-4o-mini") is False
+        assert p._is_span_excluded("a2a.client.legacy") is False
+
+    def test_include_keeps_matching(self) -> None:
+        """Include filter keeps spans matching the prefix."""
+        p = self._make_processor(include_prefixes=["pydantic-ai", "chat"])
+        assert p._is_span_excluded("pydantic-ai.agent_run") is False
+        assert p._is_span_excluded("chat gpt-4o-mini") is False
+
+    def test_include_drops_non_matching(self) -> None:
+        """Include filter drops spans that don't match any prefix."""
+        p = self._make_processor(include_prefixes=["pydantic-ai"])
+        assert p._is_span_excluded("a2a.client.transports.foo") is True
+        assert p._is_span_excluded("random_span") is True
+
+    def test_include_and_exclude_combined(self) -> None:
+        """Both include and exclude: must match include AND not match exclude."""
+        p = self._make_processor(
+            include_prefixes=["pydantic-ai"],
+            exclude_prefixes=["pydantic-ai.internal"],
+        )
+        # Matches include, not excluded
+        assert p._is_span_excluded("pydantic-ai.agent_run") is False
+        # Matches include, but also excluded
+        assert p._is_span_excluded("pydantic-ai.internal.debug") is True
+        # Doesn't match include at all
+        assert p._is_span_excluded("a2a.client.foo") is True
+
+    def test_multiple_exclude_prefixes(self) -> None:
+        """Multiple exclude prefixes — any match causes exclusion."""
+        p = self._make_processor(
+            exclude_prefixes=["a2a.client", "fasta2a.worker"]
+        )
+        assert p._is_span_excluded("a2a.client.transports.send") is True
+        assert p._is_span_excluded("fasta2a.worker.run_task") is True
+        assert p._is_span_excluded("pydantic-ai.agent_run") is False
+
+    def test_empty_span_name(self) -> None:
+        """Empty span name doesn't match any prefix."""
+        p = self._make_processor(exclude_prefixes=["a2a"])
+        assert p._is_span_excluded("") is False
+
+    def test_exact_prefix_match(self) -> None:
+        """Prefix that exactly equals the span name still matches."""
+        p = self._make_processor(exclude_prefixes=["run task"])
+        assert p._is_span_excluded("run task") is True
+
+
+# -- _parse_span_name_filters tests --
+
+
+class TestParseSpanNameFilters:
+    """Test _parse_span_name_filters config parsing."""
+
+    def test_no_tracer_instance(self) -> None:
+        """No tracer instance — no filters parsed."""
+        p = HoneyHiveSpanProcessor()
+        assert p._span_name_include_prefixes == []
+        assert p._span_name_exclude_prefixes == []
+
+    def test_parse_from_dict_config(self) -> None:
+        """Parse filters from a plain dict config (DotDict path)."""
+        mock_tracer = Mock()
+        mock_tracer.config = DotDict(
+            {
+                "span_name_filters": {
+                    "exclude": [
+                        {"type": "prefix", "value": "a2a.client.transports"},
+                        {"type": "prefix", "value": "fasta2a.worker"},
+                    ],
+                }
+            }
+        )
+        mock_tracer.verbose = False
+        p = HoneyHiveSpanProcessor(tracer_instance=mock_tracer)
+        assert p._span_name_exclude_prefixes == [
+            "a2a.client.transports",
+            "fasta2a.worker",
+        ]
+        assert p._span_name_include_prefixes == []
+
+    def test_parse_include_from_dict(self) -> None:
+        """Parse include filters from dict config."""
+        mock_tracer = Mock()
+        mock_tracer.config = DotDict(
+            {
+                "span_name_filters": {
+                    "include": [{"type": "prefix", "value": "pydantic-ai"}],
+                }
+            }
+        )
+        mock_tracer.verbose = False
+        p = HoneyHiveSpanProcessor(tracer_instance=mock_tracer)
+        assert p._span_name_include_prefixes == ["pydantic-ai"]
+        assert p._span_name_exclude_prefixes == []
+
+    def test_parse_from_pydantic_model(self) -> None:
+        """Parse filters from Pydantic SpanNameFilters model."""
+        mock_tracer = Mock()
+        filters_model = SpanNameFilters(
+            exclude=[SpanNameFilter(type="prefix", value="a2a.client")]
+        )
+        mock_tracer.config = DotDict({"span_name_filters": filters_model})
+        mock_tracer.verbose = False
+        p = HoneyHiveSpanProcessor(tracer_instance=mock_tracer)
+        assert p._span_name_exclude_prefixes == ["a2a.client"]
+
+    def test_unsupported_filter_type_logged(self) -> None:
+        """Unsupported filter type is logged as warning, not added."""
+        mock_tracer = Mock()
+        mock_tracer.config = DotDict(
+            {
+                "span_name_filters": {
+                    "exclude": [{"type": "regex", "value": "a2a.*"}],
+                }
+            }
+        )
+        mock_tracer.verbose = True
+        p = HoneyHiveSpanProcessor(tracer_instance=mock_tracer)
+        assert p._span_name_exclude_prefixes == []
+
+    def test_no_span_name_filters_in_config(self) -> None:
+        """Config exists but no span_name_filters key — no filters."""
+        mock_tracer = Mock()
+        mock_tracer.config = DotDict({"api_key": "test"})
+        mock_tracer.verbose = False
+        p = HoneyHiveSpanProcessor(tracer_instance=mock_tracer)
+        assert p._span_name_include_prefixes == []
+        assert p._span_name_exclude_prefixes == []
+
+    def test_none_span_name_filters(self) -> None:
+        """span_name_filters is explicitly None — no filters."""
+        mock_tracer = Mock()
+        mock_tracer.config = DotDict({"span_name_filters": None})
+        mock_tracer.verbose = False
+        p = HoneyHiveSpanProcessor(tracer_instance=mock_tracer)
+        assert p._span_name_include_prefixes == []
+        assert p._span_name_exclude_prefixes == []
+
+
+# -- on_start / on_end integration tests --
+
+
+class TestSpanFilterIntegration:
+    """Test that on_start and on_end respect span name filters."""
+
+    def _make_filtered_processor(self) -> HoneyHiveSpanProcessor:
+        """Create a processor with an exclude filter for a2a transport spans."""
+        mock_tracer = Mock()
+        mock_tracer.config = DotDict(
+            {
+                "span_name_filters": {
+                    "exclude": [
+                        {"type": "prefix", "value": "a2a.client.transports"},
+                    ],
+                }
+            }
+        )
+        mock_tracer.verbose = False
+        mock_exporter = Mock()
+        return HoneyHiveSpanProcessor(
+            tracer_instance=mock_tracer, otlp_exporter=mock_exporter
+        )
+
+    def _make_mock_span(self, name: str) -> Mock:
+        """Create a mock Span with a given name."""
+        span = Mock(spec=Span)
+        span.name = name
+        span_context = Mock()
+        span_context.span_id = 12345
+        span_context.trace_id = 67890
+        span.get_span_context.return_value = span_context
+        span.attributes = {}
+        return span
+
+    def _make_mock_readable_span(self, name: str) -> Mock:
+        """Create a mock ReadableSpan with a given name and session_id."""
+        span = Mock()
+        span.name = name
+        span_context = Mock()
+        span_context.span_id = 12345
+        span_context.trace_id = 67890
+        span.get_span_context.return_value = span_context
+        span.attributes = {"honeyhive.session_id": "test-session"}
+        return span
+
+    def test_on_start_skips_excluded_span(self) -> None:
+        """on_start returns early for excluded spans — no enrichment."""
+        p = self._make_filtered_processor()
+        span = self._make_mock_span(
+            "a2a.client.transports.jsonrpc.JsonRpcTransport.send_message"
+        )
+        # Should not raise and should not call set_attribute
+        p.on_start(span)
+        span.set_attribute.assert_not_called()
+
+    def test_on_start_processes_non_excluded_span(self) -> None:
+        """on_start processes non-excluded spans normally."""
+        p = self._make_filtered_processor()
+        span = self._make_mock_span("pydantic-ai.agent_run")
+        # Should proceed to enrichment (may or may not set attributes,
+        # but should not return early)
+        p.on_start(span)
+        # The span processor will attempt to get context and enrich —
+        # we just verify it didn't skip. set_attribute may or may not
+        # be called depending on session_id availability.
+
+    def test_on_end_skips_excluded_span(self) -> None:
+        """on_end returns early for excluded spans — no export."""
+        p = self._make_filtered_processor()
+        span = self._make_mock_readable_span(
+            "a2a.client.transports.jsonrpc.JsonRpcTransport._send_request"
+        )
+        p.on_end(span)
+        # The OTLP exporter should NOT be called for excluded spans
+        p.otlp_exporter.export.assert_not_called()
+
+    def test_on_end_exports_non_excluded_span(self) -> None:
+        """on_end exports non-excluded spans normally."""
+        p = self._make_filtered_processor()
+        span = self._make_mock_readable_span("chat gpt-4o-mini")
+        p.on_end(span)
+        # The OTLP exporter should be called for non-excluded spans
+        p.otlp_exporter.export.assert_called_once()

--- a/tests/unit/test_span_name_filters.py
+++ b/tests/unit/test_span_name_filters.py
@@ -9,6 +9,7 @@ Tests cover:
 
 # pylint: disable=protected-access
 
+from typing import List, Optional
 from unittest.mock import Mock, patch
 
 import pytest
@@ -17,7 +18,6 @@ from opentelemetry.sdk.trace import Span
 from honeyhive.config.models.tracer import SpanNameFilter, SpanNameFilters, TracerConfig
 from honeyhive.tracer.processing.span_processor import HoneyHiveSpanProcessor
 from honeyhive.utils.dotdict import DotDict
-
 
 # -- Pydantic model tests --
 
@@ -35,6 +35,11 @@ class TestSpanNameFilterModels:
         """Test that extra fields are rejected."""
         with pytest.raises(Exception):
             SpanNameFilter(type="prefix", value="foo", unknown="bar")
+
+    def test_span_name_filter_rejects_unsupported_type(self) -> None:
+        """Test that non-'prefix' filter types are rejected by Pydantic."""
+        with pytest.raises(Exception):
+            SpanNameFilter(type="regex", value="a2a.*")
 
     def test_span_name_filters_exclude_only(self) -> None:
         """Test SpanNameFilters with exclude list only."""
@@ -93,7 +98,9 @@ class TestIsSpanExcluded:
     """Test _is_span_excluded filtering logic."""
 
     def _make_processor(
-        self, include_prefixes: list[str] | None = None, exclude_prefixes: list[str] | None = None
+        self,
+        include_prefixes: Optional[List[str]] = None,
+        exclude_prefixes: Optional[List[str]] = None,
     ) -> HoneyHiveSpanProcessor:
         """Helper to create a processor with pre-set filter lists."""
         processor = HoneyHiveSpanProcessor()
@@ -147,9 +154,7 @@ class TestIsSpanExcluded:
 
     def test_multiple_exclude_prefixes(self) -> None:
         """Multiple exclude prefixes — any match causes exclusion."""
-        p = self._make_processor(
-            exclude_prefixes=["a2a.client", "fasta2a.worker"]
-        )
+        p = self._make_processor(exclude_prefixes=["a2a.client", "fasta2a.worker"])
         assert p._is_span_excluded("a2a.client.transports.send") is True
         assert p._is_span_excluded("fasta2a.worker.run_task") is True
         assert p._is_span_excluded("pydantic-ai.agent_run") is False
@@ -242,6 +247,16 @@ class TestParseSpanNameFilters:
         """Config exists but no span_name_filters key — no filters."""
         mock_tracer = Mock()
         mock_tracer.config = DotDict({"api_key": "test"})
+        mock_tracer.verbose = False
+        p = HoneyHiveSpanProcessor(tracer_instance=mock_tracer)
+        assert p._span_name_include_prefixes == []
+        assert p._span_name_exclude_prefixes == []
+
+    def test_malformed_config_degrades_gracefully(self) -> None:
+        """Malformed span_name_filters config doesn't crash — filters disabled."""
+        mock_tracer = Mock()
+        # exclude should be a list, not a string
+        mock_tracer.config = DotDict({"span_name_filters": {"exclude": "not-a-list"}})
         mock_tracer.verbose = False
         p = HoneyHiveSpanProcessor(tracer_instance=mock_tracer)
         assert p._span_name_include_prefixes == []


### PR DESCRIPTION
When using third-party frameworks that emit their own OpenTelemetry spans (e.g., Google A2A, PydanticAI internals, LangChain sub-components), those spans can clutter your traces with low-level transport or framework details that aren't useful for debugging your application.

The `span_name_filters` parameter on `HoneyHiveTracer.init()` lets you control which spans are sent to HoneyHive. Filtered spans are dropped before any enrichment or export, so they have zero overhead.

HHAI-4144