### PR TITLE
feat(integrations): add LiteLLM OTEL example (HHAI-4265)

### DIFF
--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -12,6 +12,7 @@ Lightweight, community-driven instrumentors following OpenTelemetry standards:
 - **[`openinference_google_ai_example.py`](openinference_google_ai_example.py)** - Google AI integration
 - **[`openinference_google_adk_example.py`](openinference_google_adk_example.py)** - Google Agent Development Kit
 - **[`openinference_bedrock_example.py`](openinference_bedrock_example.py)** - AWS Bedrock integration
+- **[`openinference_litellm_example.py`](openinference_litellm_example.py)** - LiteLLM integration (multi-provider routing)
 - **[`openinference_mcp_example.py`](openinference_mcp_example.py)** - MCP (Model Context Protocol) integration
 
 ### **Traceloop Instrumentors**
@@ -263,6 +264,7 @@ For detailed integration guides, see:
 - [Google AI Integration](../../docs/how-to/integrations/google-ai.rst)
 - [Google ADK Integration](../../docs/how-to/integrations/google-adk.rst)
 - [AWS Bedrock Integration](../../docs/how-to/integrations/bedrock.rst)
+- [LiteLLM Integration](../../docs/how-to/integrations/litellm.rst)
 - [Azure OpenAI Integration](../../docs/how-to/integrations/azure-openai.rst)
 - [MCP Integration](../../docs/how-to/integrations/mcp.rst)
 - [Multi-Provider Guide](../../docs/how-to/integrations/multi-provider.rst)

--- a/examples/integrations/openinference_litellm_example.py
+++ b/examples/integrations/openinference_litellm_example.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""
+LiteLLM + HoneyHive integration example.
+
+Demonstrates LiteLLM completions across multiple providers with HoneyHive tracing.
+All LiteLLM calls are automatically traced via the OpenInference instrumentor.
+
+IMPORTANT: Use `litellm.completion()` (module-level), not `from litellm import completion`.
+The instrumentor patches module attributes, so direct imports bypass instrumentation.
+
+If you also have openinference-instrumentation-openai or similar provider instrumentors,
+disable them when using LiteLLM to avoid duplicate spans.
+
+Install:
+    pip install honeyhive openinference-instrumentation-litellm litellm
+
+Run:
+    python examples/integrations/openinference_litellm_example.py
+
+Environment:
+    HH_API_KEY
+    HH_PROJECT
+    OPENAI_API_KEY       (for openai/ models)
+    ANTHROPIC_API_KEY    (for anthropic/ models)
+"""
+
+import os
+
+import litellm
+from openinference.instrumentation.litellm import LiteLLMInstrumentor
+
+from honeyhive import HoneyHiveTracer
+
+
+def main() -> None:
+    """Run LiteLLM completions across providers with HoneyHive tracing."""
+    # 1. Initialize HoneyHive tracer
+    tracer = HoneyHiveTracer.init(
+        api_key=os.getenv("HH_API_KEY"),
+        project=os.getenv("HH_PROJECT"),
+        session_name="openinference_litellm_example",
+        source=os.getenv("HH_SOURCE", "python_sdk_example"),
+    )
+
+    # 2. Instrument LiteLLM
+    instrumentor = LiteLLMInstrumentor()
+    instrumentor.instrument(tracer_provider=tracer.provider)
+
+    # 3. Use litellm.completion() as usual - all calls are traced automatically
+    try:
+        # OpenAI via LiteLLM
+        response = litellm.completion(
+            model="openai/gpt-4o-mini",
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "What is the capital of France?"},
+            ],
+            max_tokens=50,
+        )
+        print(f"OpenAI response: {response.choices[0].message.content}")
+
+        # Anthropic via LiteLLM
+        response2 = litellm.completion(
+            model="anthropic/claude-3-haiku-20240307",
+            messages=[
+                {"role": "user", "content": "Tell me a fun fact about Paris."},
+            ],
+            max_tokens=100,
+        )
+        print(f"Anthropic response: {response2.choices[0].message.content}")
+    finally:
+        tracer.force_flush()
+        instrumentor.uninstrument()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,12 @@ openinference-mcp = [
     "openinference-instrumentation-mcp>=1.3.0",
 ]
 
+# LiteLLM (openinference-litellm)
+openinference-litellm = [
+    "openinference-instrumentation-litellm>=0.1.0",
+    "litellm>=1.0.0",
+]
+
 # OpenLLMetry (Traceloop) Alternative Integrations
 # Each integration group includes individual Traceloop instrumentor and commonly used provider SDK
 # Note: Packages are named "opentelemetry-instrumentation-*" but are published by Traceloop
@@ -164,11 +170,13 @@ all-openinference = [
     "openinference-instrumentation-google-genai>=0.1.0",
     "openinference-instrumentation-google-adk>=0.1.0",
     "openinference-instrumentation-bedrock>=0.1.0",
+    "openinference-instrumentation-litellm>=0.1.0",
     "openinference-instrumentation-mcp>=1.3.0",
     "openai>=1.0.0",
     "anthropic>=0.18.0",
     "google-genai>=0.3.0",
     "google-adk>=0.1.0",
+    "litellm>=1.0.0",
     "boto3>=1.26.0",
     "azure-identity>=1.12.0",
 ]
@@ -179,9 +187,11 @@ openinference-llm-providers = [
     "openinference-instrumentation-anthropic>=0.1.0",
     "openinference-instrumentation-google-genai>=0.1.0",
     "openinference-instrumentation-bedrock>=0.1.0",
+    "openinference-instrumentation-litellm>=0.1.0",
     "openai>=1.0.0",
     "anthropic>=0.18.0",
     "google-genai>=0.3.0",
+    "litellm>=1.0.0",
     "boto3>=1.26.0",
 ]
 


### PR DESCRIPTION
## Summary

- Add `openinference-litellm` optional dependency group in `pyproject.toml` (`openinference-instrumentation-litellm` + `litellm`) and include it in the `all-openinference` and `openinference-llm-providers` convenience groups.
- Add `examples/integrations/openinference_litellm_example.p`y following the model provider pattern (init tracer, instrument, make completions, flush/uninstrument).
- Add LiteLLM entry to the integrations README catalog.

## Notes
- LiteLLM is a model provider integration (not an agent framework), so the example is intentionally simple: two completions across different providers.
- Uses `openinference-instrumentation-litellm` (Arize, production-stable, ~330K monthly PyPI downloads) which patches `litellm.completion` / `acompletion` / `embedding` etc. and accepts `tracer_provider=tracer.provider`. Same BYOI pattern as all other OpenInference examples.
- Users must call `litellm.completion()` (module-level), not `from litellm import completion`, for instrumentation to work.

## Test plan

Smoke-tested example locally and against staging. Traces land correctly as model events with inputs, outputs, token counts, and model name.

Multi-turn, tool calling, and multimodal paths validated via separate test scripts (not included in PR).

`uv run python -m py_compile examples/integrations/openinference_litellm_example.py` passes.