### PR TITLE
fix: resolve UnboundLocalError for results in evaluator

### DIFF
--- a/src/honeyhive/experiments/evaluators.py
+++ b/src/honeyhive/experiments/evaluators.py
@@ -1003,7 +1003,7 @@ class evaluator(metaclass=EvaluatorMeta):  # pylint: disable=invalid-name
             results = tuple(results)
             scores = tuple(scores)
         else:
-            _, scores = single_evaluation()
+            results, scores = single_evaluation()
 
         # apply aggregation
         aggregate_result, aggregate_score = self.sync_apply_aggregation(


### PR DESCRIPTION
## Summary
- Fix `UnboundLocalError` on `results` variable in `experiments/evaluators.py:1006`
- When `repeat` is not set, `single_evaluation()` return was assigned to `_` instead of `results`, leaving `results` unbound when `sync_apply_aggregation` referenced it on line 1010
- Changed `_` to `results` in the non-repeat code path

## Test plan
- [ ] Run evaluator without `repeat` setting and confirm no `UnboundLocalError`
- [ ] Run evaluator with `repeat` setting and confirm existing behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/honeyhiveai/python-sdk/pull/341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
