### PR TITLE
ci: retarget workflows from federated-sdk-release-candidate to main

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -5,8 +5,6 @@ on:
   pull_request:
     branches:
       - main
-      - complete-refactor
-      - federated-sdk-release-candidate
     paths:
       - 'src/**'
       - 'tests/**'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -73,7 +73,7 @@ jobs:
         if: steps.check-workflow.outputs.skip != 'true'
         uses: actions/checkout@v6
         with:
-          ref: federated-sdk-release-candidate
+          ref: main
           fetch-depth: 1
 
       - name: Run Claude Code Review
@@ -109,7 +109,7 @@ jobs:
               `examples/` need corresponding updates. Include a "Documentation" section in the
               top-level PR comment listing any suggested doc updates.
 
-            NOTE: the default branch of this repository is `federated-sdk-release-candidate`.
+            NOTE: the default branch of this repository is `main`.
 
             ## How to post feedback
 

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -14,7 +14,7 @@ name: Deploy Documentation to GitHub Pages
 
 on:
   push:
-    branches: [federated-sdk-release-candidate]
+    branches: [main]
     paths:
       - 'docs/**'
       - 'src/honeyhive/**'

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout python-sdk
         uses: actions/checkout@v6
         with:
-          ref: federated-sdk-release-candidate  # Pinned: this is the current default/release branch for federated SDK releases
+          ref: main
           fetch-depth: 0  # Fetch full history for commit analysis
           
       - name: Claude Code - Generate Changelog

--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Branch to publish from (e.g., federated-sdk-release-candidate for RC testing)'
+        description: 'Branch to publish from'
         required: false
-        default: 'federated-sdk-release-candidate'
+        default: 'main'
 
 permissions:
   contents: write  # For creating GitHub releases


### PR DESCRIPTION
# Summary

Retargets all GitHub Actions workflows from `federated-sdk-release-candidate` to `main` in preparation for promoting `main` back to the default branch. Pure CI-config change — no source changes, no behavior change until the default branch flips.

# Details

- `docs-deploy.yml`: push trigger switched from `federated-sdk-release-candidate` to `main`
- `generate-changelog.yml`: pinned checkout ref switched to `main`
- `sdk-publish.yml`: dispatch input default switched to `main`; description tidied
- `changelog-check.yml`: dropped `federated-sdk-release-candidate` and `complete-refactor` from the PR-base allow-list, leaving `main`
- `claude-code-review.yml`: hardcoded checkout ref + prompt docstring switched to `main` (workflow itself is currently disabled via `if: false`, but kept consistent)